### PR TITLE
G.part5 and g.report.part5 updates

### DIFF
--- a/R/g.part5.R
+++ b/R/g.part5.R
@@ -459,7 +459,12 @@ g.part5 = function(datadir=c(),metadatadir=c(),f0=c(),f1=c(),strategy=1,maxdur=7
                             dsummary[di,fi] = summarysleep_tmp2$night[wi]
                             ds_names[fi] = "night number";      fi = fi + 1
                           }
-                          dsummary[di,fi] = summarysleep_tmp2$acc_onset[wi]
+                          if (timewindowi == "WW") {
+                            dsummary[di,fi] = summarysleep_tmp2$acc_onset[wi]
+                          } else {
+                            if (wi > 1) dsummary[di,fi] = summarysleep_tmp2$acc_onset[wi-1]
+                          }
+                          
                           ds_names[fi] = "acc_onset";      fi = fi + 1
                           if (timewindowi == "WW") {
                             dsummary[di,fi] = summarysleep_tmp2$acc_wake[wi]
@@ -468,9 +473,13 @@ g.part5 = function(datadir=c(),metadatadir=c(),f0=c(),f1=c(),strategy=1,maxdur=7
                           }
                           ds_names[fi] = "acc_wake";      fi = fi + 1
                           
-                          dsummary[di,fi] = summarysleep_tmp2$sleeplog_onset[wi]
-                          
+                          if (timewindowi == "WW") {
+                            dsummary[di,fi] = summarysleep_tmp2$sleeplog_onset[wi]
+                          } else {
+                            if (wi > 1) dsummary[di,fi] = summarysleep_tmp2$sleeplog_onset[wi-1]
+                          }
                           ds_names[fi] = "sleeplog_onset";      fi = fi + 1
+                          
                           if (timewindowi == "WW") {
                             dsummary[di,fi] = summarysleep_tmp2$sleeplog_wake[wi]
                           } else {
@@ -478,9 +487,13 @@ g.part5 = function(datadir=c(),metadatadir=c(),f0=c(),f1=c(),strategy=1,maxdur=7
                           }
                           ds_names[fi] = "sleeplog_wake";      fi = fi + 1
                           
-                          dsummary[di,fi] = summarysleep_tmp2$acc_onset_ts[wi]     
-                          
+                          if (timewindowi == "WW") {
+                            dsummary[di,fi] = summarysleep_tmp2$acc_onset_ts[wi]
+                          } else {
+                            if (wi > 1) dsummary[di,fi] = summarysleep_tmp2$acc_onset_ts[wi-1]
+                          }
                           ds_names[fi] = "acc_onset_ts";      fi = fi + 1
+                          
                           if (timewindowi == "WW") {
                             dsummary[di,fi] = summarysleep_tmp2$acc_wake_ts[wi]
                           } else {
@@ -488,61 +501,97 @@ g.part5 = function(datadir=c(),metadatadir=c(),f0=c(),f1=c(),strategy=1,maxdur=7
                           }
                           ds_names[fi] = "acc_wake_ts";      fi = fi + 1
                           
-                          dsummary[di,fi] = summarysleep_tmp2$sleeplog_onset_ts[wi]
-                          
+                          if (timewindowi == "WW") {
+                            dsummary[di,fi] = summarysleep_tmp2$sleeplog_onset_ts[wi]
+                          } else {
+                            if (wi > 1) dsummary[di,fi] = summarysleep_tmp2$sleeplog_onset_ts[wi-1]
+                          }
                           ds_names[fi] = "sleeplog_onset_ts";      fi = fi + 1
+                          
                           if (timewindowi == "WW") {
                             dsummary[di,fi] = summarysleep_tmp2$sleeplog_wake_ts[wi]
                           } else {
                             if (wi > 1) dsummary[di,fi] = summarysleep_tmp2$sleeplog_wake_ts[wi-1]
                           }
                           ds_names[fi] = "sleeplog_wake_ts";      fi = fi + 1
-                          dsummary[di,fi] = summarysleep_tmp2$daysleeper[wi]
+                          
+                          if (timewindowi == "WW") {
+                            dsummary[di,fi] = summarysleep_tmp2$daysleeper[wi]
+                          } else {
+                            if (wi > 1) dsummary[di,fi] = summarysleep_tmp2$daysleeper[wi-1]
+                          }
                           # if timewindowi is MM then the following variables are less informative,
                           # because they only refer to the evening and not the morning.
                           ds_names[fi] = "daysleeper";      fi = fi + 1
-                          dsummary[di,fi] = summarysleep_tmp2$cleaningcode[wi]
+                          
+                          if (timewindowi == "WW") {
+                            dsummary[di,fi] = summarysleep_tmp2$cleaningcode[wi]
+                          } else {
+                            if (wi > 1) dsummary[di,fi] = summarysleep_tmp2$cleaningcode[wi-1]
+                          }
                           ds_names[fi] = "cleaningcode";      fi = fi + 1
-                          dsummary[di,fi] = summarysleep_tmp2$sleeplog_used[wi]
+                          
+                          if (timewindowi == "WW") {
+                            dsummary[di,fi] = summarysleep_tmp2$sleeplog_used[wi]
+                          } else {
+                            if (wi > 1) dsummary[di,fi] = summarysleep_tmp2$sleeplog_used[wi-1]
+                          }
                           ds_names[fi] = "sleeplog_used";      fi = fi + 1
-                          dsummary[di,fi] = summarysleep_tmp2$acc_available[wi]
+                          
+                          if (timewindowi == "WW") {
+                            dsummary[di,fi] = summarysleep_tmp2$acc_available[wi]
+                          } else {
+                            if (wi > 1) dsummary[di,fi] = summarysleep_tmp2$acc_available[wi-1]
+                          }
                           ds_names[fi] = "acc_available";      fi = fi + 1
                         }
                         # 
                         # define time windows
                         # qqq definitions changed so we get acc_onset and acc_wake regarding to the same day of measurement in the same row.
                         # Also, it allows for the analysis of the first day for those studies in which the accelerometer is started during the morning and the first day is of interest.
-                        if (timewindowi == "MM") {
-                          if (wi==1) {
-                            # if (waketi > 0) {
-                            #   qqq1 = waketi + 1
-                            # } else {
-                            qqq1 = 1
-                            # }
-                            qqq2 = nightsi[wi]
-                          } else if (wi<=nrow(summarysleep_tmp2)) {
-                            qqq1 = nightsi[wi-1] + 1
-                            qqq2 = nightsi[wi]
-                          } else if (wi>nrow(summarysleep_tmp2)) {
-                            qqq1 = qqq2 + 1
-                            qqq2 = length(diur)
+                        #Included variables daystoskip and daystoskipnext to skip days when they have no valid nights (missing from g.part4)
+                        if(wi == 1 | (exists("daystoskipnext")==FALSE & timewindowi=="MM")){
+                          qqq1 = qqq[1]
+                          qqq2 = qqq[2]
+                        } else if (timewindowi=="MM"){
+                          if(daystoskipnext==0 ){
+                            qqq1 = qqq[1]
+                            qqq2 = qqq[2]
                           }
-                          dsummary[di, fi] = "MM"
-                        } else if (timewindowi == "WW") {
-                          if (wi==1){
-                            if (waketi > 0) qqq1 = waketi + 1
-                            else {qqq1 = 1}
-                            qqq2 = which(diff(diur) == -1)[wi] + 1
-                          } else if (wi<=nrow(summarysleep_tmp2)) {
-                            qqq1 = which(diff(diur) == -1)[wi-1] + 1
-                            qqq2 = which(diff(diur) == -1)[wi]
-                          } else if (wi>nrow(summarysleep_tmp2)) {
-                            qqq1 = qqq2 + 1
-                            qqq2 = length(diur)
+                        } else { 
+                          if (timewindowi=="MM"){
+                            if(daystoskipnext>0) daystoskip = daystoskipnext
+                            }
+                          if (timewindowi == "MM") {
+                            if (summarysleep_tmp2$night[wi]==1) {
+                              qqq1 = 1
+                              qqq2 = nightsi[wi]
+                            } else if (wi<=nrow(summarysleep_tmp2)) {
+                              qqq1 = nightsi[wi + daystoskip - 1] + 1
+                              qqq2 = nightsi[wi + daystoskip]
+                            } else if (wi>nrow(summarysleep_tmp2)) {
+                              qqq1 = qqq2 + 1
+                              qqq2 = length(diur)
+                            }
+                          } else if (timewindowi == "WW") {
+                            daystoskip = summarysleep_tmp2$night[wi] - summarysleep_tmp2$night[wi-1] - 1
+                            if (wi==1){
+                              if (waketi > 0) qqq1 = waketi + 1
+                              else {qqq1 = 1}
+                              qqq2 = which(diff(diur) == -1)[wi] + 1
+                            } else if (wi<=nrow(summarysleep_tmp2)) {
+                              qqq1 = which(diff(diur) == -1)[wi + daystoskip - 1] + 1
+                              qqq2 = which(diff(diur) == -1)[wi + daystoskip]
+                            } else if (wi>nrow(summarysleep_tmp2)) {
+                              qqq1 = qqq2 + 1
+                              qqq2 = length(diur)
+                            }
                           }
-                          dsummary[di, fi] = "WW"
                         }
-                        
+                        if(timewindowi == "MM" & wi>1) {daystoskipnext = summarysleep_tmp2$night[wi] - summarysleep_tmp2$night[wi-1] - 1}
+                        else if(timewindowi == "WW" & exists("daystoskipnext")==TRUE) {rm(daystoskipnext)}
+                        qqq = c(qqq1, qqq2)
+                        dsummary[di, fi] = timewindowi
                         ds_names[fi] = "window";      fi = fi + 1    
                         # keep track of threshold value
                         dsummary[di,fi] = TRLi
@@ -596,15 +645,18 @@ g.part5 = function(datadir=c(),metadatadir=c(),f0=c(),f1=c(),strategy=1,maxdur=7
                         zt_hrs_nonwear = (length(which(diur[qqq1:qqq2] == 0 & nonwear[qqq1:qqq2] == 1)) * ws3) / 3600 #day
                         zt_hrs_total = (length(which(diur[qqq1:qqq2] == 0)) * ws3) / 3600 #day
                         dsummary[di,fi] = (zt_hrs_nonwear/zt_hrs_total)  * 10000 / 100
-                        ds_names[fi] = "nonwear_perc_day";      fi = fi + 1
+                        dsummary[di,fi+1] = zt_hrs_total - zt_hrs_nonwear   #Wearing time per day (hours)
+                        ds_names[fi:(fi+1)] = c("nonwear_perc_day","wear_hours_day");      fi = fi + 2
                         zt_hrs_nonwear = (length(which(diur[qqq1:qqq2] == 1 & nonwear[qqq1:qqq2] == 1)) * ws3) / 3600 #night
                         zt_hrs_total = (length(which(diur[qqq1:qqq2] == 1)) * ws3) / 3600 #night
                         dsummary[di,fi] =  (zt_hrs_nonwear/zt_hrs_total)  * 10000 / 100
-                        ds_names[fi] = "nonwear_perc_night";      fi = fi + 1
+                        dsummary[di,fi+1] = zt_hrs_total - zt_hrs_nonwear   #Wearing time per night (hours)
+                        ds_names[fi:(fi+1)] = c("nonwear_perc_night","wear_hours_night");      fi = fi + 2
                         zt_hrs_nonwear = (length(which(nonwear[qqq1:qqq2] == 1)) * ws3) / 3600
                         zt_hrs_total = (length(diur[qqq1:qqq2]) * ws3) / 3600 #night and day
                         dsummary[di,fi] =  (zt_hrs_nonwear/zt_hrs_total)  * 10000 / 100
-                        ds_names[fi] = "nonwear_perc_nightandday";      fi = fi + 1
+                        dsummary[di,fi+1] = zt_hrs_total - zt_hrs_nonwear   #Wearing time per night and day (hours)
+                        ds_names[fi:(fi+1)] = c("nonwear_perc_nightandday","wear_hours_nightandday");      fi = fi + 2
                         #=============================
                         # sleep efficiency
                         dsummary[di,fi] = length(which(sibdetection[qqq1:qqq2] == 1 & diur[qqq1:qqq2] == 1)) / length(which(diur[qqq1:qqq2] == 1))

--- a/R/g.report.part5.R
+++ b/R/g.report.part5.R
@@ -30,10 +30,10 @@ g.report.part5 = function(metadatadir=c(),f0=c(),f1=c(),loglocation=c(),
       out = as.matrix(output)
     }
     outputfinal = as.data.frame(do.call(rbind,lapply(fnames.ms5[f0:f1],myfun)),stringsAsFactors=FALSE)
-    cut = which(outputfinal[1,] == "")
-    if (length(cut) > 0) {
-      outputfinal = outputfinal[,-cut]
-    }
+    #cut = which(outputfinal[1,] == "") #After the last update in g.part5, we can expect empy rows for sleep variables, but we do not want to remove these columns
+    #if (length(cut) > 0) {
+    #  outputfinal = outputfinal[,-cut]
+    #}
     cut2 = which(outputfinal[,1] == "" & outputfinal[,2] == "")
     if (length(cut2) > 0) {
       outputfinal = outputfinal[-cut2,]
@@ -268,7 +268,7 @@ g.report.part5 = function(metadatadir=c(),f0=c(),f1=c(),loglocation=c(),
                 # before processing OF3, first identify which days have enough monitor wear time
                 maxpernwnight = (1 - (includenightcrit / 24)) * 100
                 maxpernwday = (1 - (includedaycrit / 24)) * 100
-                validdaysi = which(OF3$nonwear_perc_day < maxpernwday & OF3$nonwear_perc_night < maxpernwnight)
+                validdaysi = which(as.numeric(OF3$nonwear_perc_day) < maxpernwday & as.numeric(OF3$nonwear_perc_night) < maxpernwnight)  #as.numeric function included, it was producing inconsistencies.
                 # aggregate OF3 (days) to person summaries in OF4
                 OF4 = takeweightedmean(OF3[validdaysi,],filename="filename",day="daytype")
                 


### PR DESCRIPTION
Hi Vincent,
After the last update of g.part5, I went through this function and the report generation and I found some bugs and other aspects to improve in these functions. This pull request includes:

**g.part5**
1. For "MM" windows, half of the sleep information (onset times) were stored in one row and the remaining (waking-up times and quality information) were stored in the next one. Now information of the night is all stored in the corresponding row.
2. When a night was missing (after running g.part4), the code stored information for the next night (i.e., next row in the summarysleep data frame), but still analysed the window for the day with the missing night. I have included variables "daystoskip" and "daystoskipnext" to skip windows with missing nights from g.part4 conveniently for MM and WW windows.
3. I have also included 3 variables calculation that I consider of interest: wear time in hours per specified window (i.e., day, night and nightandday).
4. I got some error messages in the calculation of M5, L5 (...) variables when the number of windows for L5M5 analyses was inferior to 1, so I have included this condition for the calculation.

**g.report.part5**
1. After the last update of g.part5, we can expect empty cells in sleep variables for certain days, so I have removed the part of the code in which empty variables were removed (cut definition in lines 34-37)
2. When identifying the valid days for the mean calculations, the variables "nonwear_perc" were considered as "character" class, so the conditional to identify these days was not working correctly, I have now included "as.numeric" function in this part of the code.

Hope everything is fine.

Best,
Jairo