### PR TITLE
added citation metadata (needs verification)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@
 *.dll
 *.RData
 *.Rd2pdf*
-.zenodo.json

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,49 @@
+{
+    "creators": [
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "van Hees, Vincent",
+            "orcid": "0000-0003-0182-9008"
+        },
+        {
+            "affiliation": "University of Granada",
+            "name": "Migueles, Jairo H.",
+            "orcid": "0000-0003-0366-6935"
+        },
+        {
+            "affiliation": "University of Leicester",
+            "name": "Mirkes, Evgeny",
+            "orcid": "0000-0003-1474-1734"
+        },
+        {
+            "affiliation": "University College London",
+            "name": "Heywood, Joe"
+        },
+        {
+            "affiliation": "MRC Epidemiology Unit",
+            "name": "Zhao, Jing Hua",
+            "orcid": "0000-0003-4930-3582"
+        },
+        {
+            "affiliation": "Inserm",
+            "name": "Sabia, Séverine",
+            "orcid": "0000-0003-3109-9720"
+        },
+        {
+            "affiliation": "Activinsights Ltd.",
+            "name": "Fang, Zhou"
+        }
+    ],
+    "description": "Converts raw data from wearables into insightful reports for researchers investigating human daily physical activity and sleep.",
+    "keywords": [
+        "activity tracker",
+        "health",
+        "fitness",
+        "sleep research",
+        "accelerometer"
+    ],
+    "license": {
+        "id": "LGPL-2.0-only"
+    },
+    "title": "GGIR"
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,53 @@
+# YAML 1.2
+---
+abstract: "Converts raw data from wearables into insightful reports for researchers investigating human daily physical activity and sleep."
+authors: 
+  -
+    affiliation: "Netherlands eScience Center"
+    family-names: Hees
+    given-names: Vincent
+    name-particle: van
+    orcid: "https://orcid.org/0000-0003-0182-9008"
+  -
+    affiliation: "University of Granada"
+    family-names: Migueles
+    given-names: "Jairo H."
+    orcid: "https://orcid.org/0000-0003-0366-6935"
+  -
+    affiliation: "University of Leicester"
+    family-names: Mirkes
+    given-names: Evgeny
+    orcid: "https://orcid.org/0000-0003-1474-1734"
+  -
+    affiliation: "University College London"
+    family-names: Heywood
+    given-names: Joe
+  -
+    affiliation: "MRC Epidemiology Unit"
+    family-names: Zhao
+    given-names: "Jing Hua"
+    orcid: "https://orcid.org/0000-0003-4930-3582"
+  -
+    affiliation: Inserm
+    family-names: Sabia
+    given-names: "Séverine"
+    orcid: "https://orcid.org/0000-0003-3109-9720"
+  -
+    affiliation: "Activinsights Ltd."
+    family-names: Fang
+    given-names: Zhou
+cff-version: "1.0.3"
+date-released: 2018-09-21
+doi: "10.5281/zenodo.1051064"
+keywords: 
+  - "activity tracker"
+  - health
+  - fitness
+  - "sleep research"
+  - accelerometer
+license: "LGPL-2.0-only"
+message: "If you use this software, please cite it using these metadata."
+repository-code: "https://github.com/wadpac/GGIR"
+title: GGIR
+version: "1.6-7"
+...


### PR DESCRIPTION
Hi Vincent,

This PR adds some citation metadata to your repo. I based the information in the ``CITATION.cff`` file on ``https://zenodo.org/record/1429701#.W6tElRRoRzg`` (with the exception of the ``doi``, for which I used GGIR's conceptDOI instead of the versioned doi, it's more robust that way). 

The author order, the author orcids and the author affiliations need checking.

I ran ``cffconvert -f zenodo -ig > .zenodo.json`` to generate the zenodo metadata file from the CITATION.cff file.

Obviously, the next time you do a release, you should adapt some of the data, like ``release-date`` and ``version`` etc.

Note: if you run ``cffconvert --validate`` on this PR's ``CITATION.cff`` it will give an error about the license:
```bash
$cffconvert --validate
validation.invalid
 --- All found errors ---
["Enum 'LGPL-2.0-only' does not exist. Path: '/license'"]
```
This is because the 1.0.3 version of the CFF schema does not include the license key ``LGPL-2.0-only``. I don't think it will be an issue anywhere else beyond making the validator stumble.

Also disabled gitignore on ``.zenodo.json`` file (not sure what the implications for releasing on CRAN are, but I'm sure you do).

Hope this helps, let me know if you experience trouble,
-Jurriaan

