### PR TITLE
Sustained inactivity daylight saving

### DIFF
--- a/R/g.part4.R
+++ b/R/g.part4.R
@@ -159,6 +159,8 @@ g.part4 = function(datadir=c(),metadatadir=c(),f0=f0,f1=f1,idloc=1,loglocation =
       # load milestone 3 data (RData files), check whether there is data, identify id numbers...
       load(paste(meta.sleep.folder,"/",fnames[i],sep=""))
       if (nrow(sib.cla.sum) != 0) { #there needs to be some information
+        sib.cla.sum$sib.onset.time = iso8601chartime2POSIX(sib.cla.sum$sib.onset.time, tz = desiredtz)
+        sib.cla.sum$sib.end.time = iso8601chartime2POSIX(sib.cla.sum$sib.end.time, tz = desiredtz)
         #------------------------------------------------------
         # extract the identifier from accelerometer data
         if (idloc == 2) { #idloc is an argument to specify where the participant identifier can be found

--- a/R/g.part5.R
+++ b/R/g.part5.R
@@ -175,11 +175,10 @@ g.part5 = function(datadir=c(),metadatadir=c(),f0=c(),f1=c(),strategy=1,maxdur=7
               pr1 = pr0 + ((60/ws3)*1440*6)
               if (pr1 > pr2) pr1 = pr2
               if (pr0 > pr1) pr0 = pr1
-              s0 = which(time[pr0:pr1] == gik.ons[g])[1]
-              s1 = which(time[pr0:pr1] == gik.end[g])[1]
-              timebb = as.character(time[pr0:pr1]) 
-              if(length(unlist(strsplit(timebb[1],"[+]"))) > 1) { # only do this for ISO8601 format
-                timebb = iso8601chartime2POSIX(timebb,tz=desiredtz)
+              #Coerce time into iso8601 format, so it is sensitive to daylight saving times when hours can be potentially repeated
+              timebb = as.character(time[pr0:pr1])
+              if(length(unlist(strsplit(timebb[1],"[+]"))) < 2) { # only do this for ISO8601 format
+                timebb = POSIXtime2iso8601(timebb,tz=desiredtz)
               }
               s0 = which(timebb == gik.ons[g])[1]
               s1 = which(timebb == gik.end[g])[1]

--- a/R/g.plot5.R
+++ b/R/g.plot5.R
@@ -240,6 +240,8 @@ g.plot5 = function(metadatadir=c(),dofirstpage=FALSE, viewingwindow = 1,f0=c(),f
         }
         detection = rep(NA,length(time))
         S = sib.cla.sum #SLES$output
+        S$sib.onset.time = iso8601chartime2POSIX(S$sib.onset.time, tz = desiredtz)
+        S$sib.end.time = iso8601chartime2POSIX(S$sib.end.time, tz = desiredtz)
         def = unique(S$definition)[1]
         S = S[which(S$definition==def),] # simplify to one definition
         for (j in 1:length(unique(S$night))) { #nights

--- a/R/g.sib.sum.R
+++ b/R/g.sib.sum.R
@@ -8,10 +8,12 @@ g.sib.sum = function(SLE,M,ignorenonwear=FALSE,desiredtz="Europe/London") {
   }
   space = ifelse(length(unlist(strsplit(as.character(A$time[1])," "))) > 1,TRUE,FALSE)
   temptime = as.character(unlist(A$time))
+  #time stored as iso8601 what makes it sensitive to daylight saving days.
   if (space == FALSE) {
-    time = as.POSIXlt(temptime,tz=desiredtz,format="%Y-%m-%dT%H:%M:%S%z")
+    time = temptime
   } else {
-    time = as.POSIXlt(temptime,tz=desiredtz)
+    time = as.POSIXlt(temptime, tz = desiredtz)
+    time = POSIXtime2iso8601(time, tz = desiredtz)
   }
   # time = as.POSIXlt(A$time,tz=desiredtz,format="%Y-%m-%dT%H:%M:%S%z")
   night = A$night


### PR DESCRIPTION
Hi again Vincent,

Here a proposal to fix the problem I got to detect sleep in daylight saving days. Briefly, in one of my files I found dur_night_sleep_min to be higher than 0 only in the first day, and then there were 0's in the database for the rest of the days. However, when looking at the visual reports and databases from g.part4, it did detect sleep time higher than 0 for all of the recorded days (I can send you this file if you want to replicate this).

The sib.cla.sum database stored in the meta data from g.part3 stores the onset and end times for every sustained inactivity period detected in POSIX format. In g.part5, those times happening between 2am - 3am were confused by GGIR (this is just when it's happening the change in the time).

To solve this, I changed the format in what sustained inactivity times are stored in the metadata from g.part3, now they are stored in ISO8601. The ending would tell us if the time has already changed or not (e.g., ...+0200 vs ...+0100). Then, the rest of the changes are only intended to change the format of the times when needed so that GGIR keeps working as usual.

I got consistent results between plots and databases from part4 and part5 using this code.

Let me know if you find any problem in it.

Best,
Jairo