### PR TITLE
Negative tz issue145

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: GGIR
 Type: Package
 Title: Raw Accelerometer Data Analysis
-Version: 1.7-1
-Date: 2018-11-25
+Version: 1.7-2
+Date: 2018-12-14
 Authors@R: c(person("Vincent T","van Hees",role=c("aut","cre"),
                   email="vincentvanhees@gmail.com"),
                   person("Zhou","Fang",role="ctb"),

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -11,7 +11,7 @@ export(g.analyse,g.calibrate,g.getmeta
         g.readaccfile,g.report.part2,g.report.part4,
        g.report.part5,g.sib.det,g.sib.plot,g.wavread,
        g.weardec,isfilelist,iso8601chartime2POSIX,is_this_a_dst_night,
-        numUnpack,POSIXtime2iso8601,resample)
+        numUnpack,POSIXtime2iso8601,resample,is.ISO8601)
 importFrom("grDevices", "colors", "dev.off", "pdf","rainbow")
 importFrom("graphics", "abline", "axis", "par", "plot", "plot.new",
       "rect","axis.POSIXct", "barplot", "box", "legend",

--- a/R/g.part5.R
+++ b/R/g.part5.R
@@ -178,7 +178,7 @@ g.part5 = function(datadir=c(),metadatadir=c(),f0=c(),f1=c(),strategy=1,maxdur=7
               if (pr0 > pr1) pr0 = pr1
               #Coerce time into iso8601 format, so it is sensitive to daylight saving times when hours can be potentially repeated
               timebb = as.character(time[pr0:pr1])
-              if(length(unlist(strsplit(timebb[1],"T"))) < 2) { # only do this for POSIX format
+              if (is.ISO8601(timebb[1]) == FALSE) { # only do this for POSIX format
                 timebb = POSIXtime2iso8601(timebb,tz=desiredtz)
               }
               s0 = which(timebb == gik.ons[g])[1]
@@ -301,7 +301,7 @@ g.part5 = function(datadir=c(),metadatadir=c(),f0=c(),f1=c(),strategy=1,maxdur=7
                 s1 = which(as.character(time) == w1c)[1]
               }
               timebb = as.character(time) 
-              if(length(unlist(strsplit(timebb[1],"T"))) > 1) { # only do this for ISO8601 format
+              if (is.ISO8601(timebb[1]) == TRUE) { # only do this for ISO8601 format
                 timebb = iso8601chartime2POSIX(timebb,tz=desiredtz)
                 s0 = which(as.character(timebb) == w0c)[1]
                 s1 = which(as.character(timebb) == w1c)[1]
@@ -706,7 +706,7 @@ g.part5 = function(datadir=c(),metadatadir=c(),f0=c(),f1=c(),strategy=1,maxdur=7
                           if (ignore == FALSE) dsummary[di,fi] = M5VALUE
                           ds_names[fi] = paste("M",wini,"VALUE",sep="");      fi = fi + 1
                           if (ignore == FALSE) {
-                            if(length(unlist(strsplit(L5HOUR,"T"))) > 1) { # only do this for ISO8601 format
+                            if (is.ISO8601(L5HOUR)) { # only do this for ISO8601 format
                               L5HOUR = as.character(iso8601chartime2POSIX(L5HOUR,tz=desiredtz))
                               M5HOUR = as.character(iso8601chartime2POSIX(M5HOUR,tz=desiredtz))
                               if (length(unlist(strsplit(L5HOUR," "))) == 1) L5HOUR = paste0(L5HOUR," 00:00:00") #added because on some OS timestamps are deleted for midnight

--- a/R/g.part5.R
+++ b/R/g.part5.R
@@ -178,7 +178,7 @@ g.part5 = function(datadir=c(),metadatadir=c(),f0=c(),f1=c(),strategy=1,maxdur=7
               if (pr0 > pr1) pr0 = pr1
               #Coerce time into iso8601 format, so it is sensitive to daylight saving times when hours can be potentially repeated
               timebb = as.character(time[pr0:pr1])
-              if(length(unlist(strsplit(timebb[1],"[+]"))) < 2) { # only do this for ISO8601 format
+              if(length(unlist(strsplit(timebb[1],"T"))) < 2) { # only do this for POSIX format
                 timebb = POSIXtime2iso8601(timebb,tz=desiredtz)
               }
               s0 = which(timebb == gik.ons[g])[1]
@@ -301,7 +301,7 @@ g.part5 = function(datadir=c(),metadatadir=c(),f0=c(),f1=c(),strategy=1,maxdur=7
                 s1 = which(as.character(time) == w1c)[1]
               }
               timebb = as.character(time) 
-              if(length(unlist(strsplit(timebb[1],"[+]"))) > 1) { # only do this for ISO8601 format
+              if(length(unlist(strsplit(timebb[1],"T"))) > 1) { # only do this for ISO8601 format
                 timebb = iso8601chartime2POSIX(timebb,tz=desiredtz)
                 s0 = which(as.character(timebb) == w0c)[1]
                 s1 = which(as.character(timebb) == w1c)[1]
@@ -706,7 +706,7 @@ g.part5 = function(datadir=c(),metadatadir=c(),f0=c(),f1=c(),strategy=1,maxdur=7
                           if (ignore == FALSE) dsummary[di,fi] = M5VALUE
                           ds_names[fi] = paste("M",wini,"VALUE",sep="");      fi = fi + 1
                           if (ignore == FALSE) {
-                            if(length(unlist(strsplit(L5HOUR,"[+]"))) > 1) { # only do this for ISO8601 format
+                            if(length(unlist(strsplit(L5HOUR,"T"))) > 1) { # only do this for ISO8601 format
                               L5HOUR = as.character(iso8601chartime2POSIX(L5HOUR,tz=desiredtz))
                               M5HOUR = as.character(iso8601chartime2POSIX(M5HOUR,tz=desiredtz))
                               if (length(unlist(strsplit(L5HOUR," "))) == 1) L5HOUR = paste0(L5HOUR," 00:00:00") #added because on some OS timestamps are deleted for midnight

--- a/R/is.ISO8601.R
+++ b/R/is.ISO8601.R
@@ -1,0 +1,11 @@
+is.ISO8601 = function(x) {
+  NNeg = length(unlist(strsplit(x,"[-]")))
+  NPos = length(unlist(strsplit(x,"[+]")))
+  is.ISO = FALSE
+  if (NPos == 2) {
+    is.ISO = TRUE
+  } else if (NNeg == 4 | NNeg == 2) {
+    is.ISO = TRUE
+  }
+  return(is.ISO)
+}

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -1,10 +1,11 @@
 \name{NEWS}
 \title{News for Package \pkg{GGIR}}
 \newcommand{\cpkg}{\href{http://CRAN.R-project.org/package=#1}{\pkg{#1}}}
-\section{Changes in version 1.7-2 (release date:25-11-2018)}{
+\section{Changes in version 1.7-2 (release date:14-12-2018)}{
 \itemize{
   \item Part4 handling of clocktime 9am corrected in addition to fix from version 1.7-1.
   \item Bug fixed for Actigraph csv header recognition when column 2 and 3 are NA (prevented processing before)
+  \item Bug fixed that caused part5 to struggle with timezones west of greenwhich time.
   }
 }
 \section{Changes in version 1.7-1 (release date:25-11-2018)}{

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -5,6 +5,7 @@
 \itemize{
   \item Part4 handling of clocktime 9am corrected in addition to fix from version 1.7-1.
   \item Bug fixed for Actigraph csv header recognition when column 2 and 3 are NA (prevented processing before)
+  \item Fixed bug in g.report.part5 in the calculation of the total number of valid days per person.
   \item Bug fixed that caused part5 to struggle with timezones west of greenwhich time.
   }
 }

--- a/man/is.ISO8601.Rd
+++ b/man/is.ISO8601.Rd
@@ -1,0 +1,19 @@
+\name{is.ISO8601}
+\alias{is.ISO8601}
+\title{
+Check whether character timestamp is in iso8601 format.
+}
+\description{
+Checks whether timestamp stored in character format is in ISO8601 format or not}
+\usage{
+is.ISO8601(x)	
+}
+\arguments{
+  \item{x}{
+Timestamps in character format either in ISO8601 or as "yyyy-mm-dd hh:mm:ss".
+}
+}
+\examples{
+x ="1980-1-1 18:00:00"
+is.ISO8601(x)
+}

--- a/tests/testthat/test_isISO8601.R
+++ b/tests/testthat/test_isISO8601.R
@@ -1,0 +1,16 @@
+library(GGIR)
+context("is.ISO8601")
+test_that("is.ISO8601 is able to detect ISO8601", {
+  # west of greenwhich with negative timezone
+  x = "2017-01-01 13:15:12"
+  expect_equal(is.ISO8601(x),FALSE)
+  tz = "America/Aruba"
+  x_converted = as.character(POSIXtime2iso8601(x,tz))
+  expect_equal(is.ISO8601(x_converted),TRUE)
+  
+  # east of greenwhich with positive timezone
+  x = "2017-01-01 13:15:12"
+  tz = "Europe/Amsterdam"
+  x_converted = as.character(POSIXtime2iso8601(x,tz))
+  expect_equal(is.ISO8601(x_converted),TRUE)
+})


### PR DESCRIPTION
Hi Jairo @jhmigueles, can you check and merge this pull request?

It relates to issue #145. In function g.part5 we currently check whether a timestamp stored as a character string is in iso8601 format or not. This check looks specifically for a "+"-sign in the character string, which does not make sense for timezones west of Greenwhich which have a "-". I have now updated this check and moved it to a separate function is.ISO8601 and wrote documentation and a test for it.
This should address issue #145.
Cheers, Vincent
