### PR TITLE
tidyup of g.readaccfile

### DIFF
--- a/R/g.calibrate.R
+++ b/R/g.calibrate.R
@@ -65,7 +65,7 @@ g.calibrate = function(datafile,use.temp=TRUE,spherecrit=0.3,minloadcrit=72,prin
     accread = g.readaccfile(filename=datafile,blocksize=blocksize,blocknumber=i,
                             selectdaysfile = selectdaysfile,filequality=filequality,
                             decn=decn,dayborder=dayborder,ws=ws,desiredtz=desiredtz,
-                            PreviousEndPage=PreviousEndPage)
+                            PreviousEndPage=PreviousEndPage,inspectfileobject=INFI)
     P = accread$P
     filequality = accread$filequality
     filetooshort = filequality$filetooshort

--- a/R/g.calibrate.R
+++ b/R/g.calibrate.R
@@ -54,13 +54,12 @@ g.calibrate = function(datafile,use.temp=TRUE,spherecrit=0.3,minloadcrit=72,prin
   while (LD > 1) {
     P = c()
     if (i  == 1) {
-      cat(paste("\nLoading block: ",i,sep=""))
+      cat(paste("\nLoading block: ",i," ",sep=""))
     } else {
       cat(paste(" ",i,sep=""))
     }
     #try to read data blocks based on monitor type and data format
     options(warn=-1) #turn off warnings (code complains about unequal rowlengths
-    
     accread = g.readaccfile(filename=datafile,blocksize=blocksize,blocknumber=i,
                             selectdaysfile = selectdaysfile,filequality=filequality,
                             decn=decn,dayborder=dayborder,ws=ws,desiredtz=desiredtz,
@@ -243,7 +242,7 @@ g.calibrate = function(datafile,use.temp=TRUE,spherecrit=0.3,minloadcrit=72,prin
           QC = "recalibration not done because not enough points on all sides of the sphere"
         }
       } else {
-        cat("\nno non-movement found\n")
+        cat("\nNo non-movement found\n")
         QC = "recalibration not done because no non-movement data available"
         meta_temp = c()
       }
@@ -357,27 +356,20 @@ g.calibrate = function(datafile,use.temp=TRUE,spherecrit=0.3,minloadcrit=72,prin
   }
   QCmessage = QC
   if (printsummary == TRUE) {
-    cat("\n----------------------------------------\n")
-    cat("Summary of autocalibration procedure:\n")
-    cat("\nStatus:\n")
-    print(QCmessage)
-    cat("\nCalibration error (g) before:\n")
-    print(cal.error.start)
-    cat("\nCallibration error (g) after:\n")
-    print(cal.error.end)
-    cat("\nOffset correction:\n")
-    print(offset)
-    cat("\nScale correction:\n")
-    print(scale)
-    cat("\nNumber of hours used:\n")
-    print(nhoursused)
-    cat("\nNumber of 10 second windows around the sphere:\n")
-    print(npoints)
-    cat("\nTemperature used (if available):\n")
-    print(use.temp)
-    cat("\nTemperature offset (if temperature is available):\n")
-    print(tempoffset)
-    cat("\n----------------------------------------\n")
+    # cat(paste0(rep('_ ',options()$width),collapse=''))
+    cat("\nSummary of autocalibration procedure:")
+    cat("\n")
+    cat(paste0("\nStatus: ",QCmessage))
+    cat(paste0("\nCalibration error (g) before: ",cal.error.start))
+    cat(paste0("\nCallibration error (g) after: ",cal.error.end))
+    cat(paste0("\nOffset correction ",c("x","y","z"),": ",offset))
+    cat(paste0("\nScale correction ",c("x","y","z"),": ",scale))
+    cat(paste0("\nNumber of hours used: ",nhoursused))
+    cat(paste0("\nNumber of 10 second windows around the sphere: ",npoints))
+    cat(paste0("\nTemperature used (if available): ",use.temp))
+    cat(paste0("\nTemperature offset (if temperature is available) ",c("x","y","z"),": ",tempoffset))
+    cat("\n")
+    # cat(paste0(rep('_',options()$width),collapse=''))
   }
   if (use.temp==TRUE) {
     if (length(spheredata) > 0) {

--- a/R/g.calibrate.R
+++ b/R/g.calibrate.R
@@ -1,7 +1,6 @@
 g.calibrate = function(datafile,use.temp=TRUE,spherecrit=0.3,minloadcrit=72,printsummary=TRUE,
                        chunksize=c(),windowsizes=c(5,900,3600),selectdaysfile=c(),dayborder=0,
                        desiredtz = c()) {
-  
   if (length(chunksize) == 0) chunksize = 1
   if (chunksize > 1) chunksize = 1
   if (chunksize < 0.4) chunksize = 0.4
@@ -22,7 +21,7 @@ g.calibrate = function(datafile,use.temp=TRUE,spherecrit=0.3,minloadcrit=72,prin
   PreviousEndPage = c() # needed for g.readaccfile
   scale = c(1,1,1)
   offset = c(0,0,0)
-  bsc_qc = data.frame(time=c(),size=c())
+  bsc_qc = data.frame(time=c(),size=c(),stringsAsFactors = FALSE)
   #inspect file  
   options(warn=-1) #turn off warnings
   INFI = g.inspectfile(datafile, desiredtz=desiredtz)  # Check which file type and monitor brand it is

--- a/R/g.calibrate.R
+++ b/R/g.calibrate.R
@@ -54,7 +54,7 @@ g.calibrate = function(datafile,use.temp=TRUE,spherecrit=0.3,minloadcrit=72,prin
   while (LD > 1) {
     P = c()
     if (i  == 1) {
-      cat(paste("\nLoading block: ",i," ",sep=""))
+      cat(paste("\nLoading block: ",i,sep=""))
     } else {
       cat(paste(" ",i,sep=""))
     }
@@ -195,7 +195,7 @@ g.calibrate = function(datafile,use.temp=TRUE,spherecrit=0.3,minloadcrit=72,prin
       }
     } else {
       LD = 0 #once LD < 1 the analysis stops, so this is a trick to stop it
-      cat("\nstop reading because there is not enough data in this block\n")
+      # cat("\nstop reading because there is not enough data in this block\n")
     }
     spherepopulated = 0
     if (switchoffLD == 1) {

--- a/R/g.cwaread.R
+++ b/R/g.cwaread.R
@@ -266,7 +266,7 @@ g.cwaread = function(fileName, start = 0, end = 0, progressBar = FALSE, desiredt
   struc = list(0,0L)
   header = readHeader(fid, numDBlocks)
   # preprocess start and stop
-  origin = header$start
+  origin = as.numeric(header$start)
   step = 1/header$frequency
   if (is.numeric(start)) {
     if (start<0)
@@ -275,14 +275,11 @@ g.cwaread = function(fileName, start = 0, end = 0, progressBar = FALSE, desiredt
   }
   if (is.numeric(end)) {
     end = end * pageLength
-    if (end > numDBlocks * 120) {
-      end = numDBlocks * 120
+    if (end > numDBlocks * 150) {
+      end = numDBlocks * 150
     }
     end = origin + end * step
   }
-  # to prevent creation of too big arrays we can use this estimation
-  if (end > origin + numDBlocks * 150 * step)
-    end = origin + numDBlocks * 150 * step
   # If data is not necessary then stop work
   if (end <= start) {
     close(fid)

--- a/R/g.cwaread.R
+++ b/R/g.cwaread.R
@@ -376,7 +376,7 @@ g.cwaread = function(fileName, start = 0, end = 0, progressBar = FALSE, desiredt
   #############################################################################
   # Process the last block of data if necessary
   if (pos <= nr) { # & ignorelastblock == FALSE){ #ignorelastblock == FALSE added by VvH on 22-4-2017
-    print("last block of data")
+    # print("last block of data")
     # Calculate pseudo time for the "next" block
     newTimes = (prevRaw$start - prevStart) / prevLength * prevRaw$length + prevRaw$start
     prevLength = prevRaw$length

--- a/R/g.cwaread.R
+++ b/R/g.cwaread.R
@@ -249,7 +249,6 @@ g.cwaread = function(fileName, start = 0, end = 0, progressBar = FALSE, desiredt
   ################################################################################################
   # Main function
 
-
   # Parse input arguments
   nargin = nargs()
   if (nargin < 1) {
@@ -350,16 +349,20 @@ g.cwaread = function(fileName, start = 0, end = 0, progressBar = FALSE, desiredt
     tmp = resample(rawAccel, rawTime, timeRes[pos:last], rawLast)
     # put result to specified position
     last = nrow(tmp) + pos - 1
-    accelRes[pos:last,] = tmp
+    if (last>=pos) {
+      accelRes[pos:last,] = tmp
+    }
 
     # Remove all rawdata exclude the last
     rawTime[1] = rawTime[rawLast]
     rawAccel[1,] = rawAccel[rawLast,]
     rawPos = 2
     # Fill light, temp and battery
-    light[pos:last] = prevRaw$light
-    temp[pos:last] = prevRaw$temperature
-    battery[pos:last] = prevRaw$battery
+    if (last>=pos) {
+      light[pos:last] = prevRaw$light
+      temp[pos:last] = prevRaw$temperature
+      battery[pos:last] = prevRaw$battery
+    }
     # Now current become previous
     prevRaw = raw
     pos = last + 1
@@ -400,14 +403,13 @@ g.cwaread = function(fileName, start = 0, end = 0, progressBar = FALSE, desiredt
     tmp = resample(rawAccel, rawTime, timeRes[pos:last], rawLast)
     # put result to specified position
     last = nrow(tmp) + pos - 1
-    accelRes[pos:last,] = tmp
-    # Fill light, temp and battery
-    light[pos:last] = prevRaw$light
-    temp[pos:last] = prevRaw$temperature
-    battery[pos:last] = prevRaw$battery
-    # Now current become previous
-    prevRaw = raw
-    pos = last +1
+    if (last>=pos){
+      accelRes[pos:last,] = tmp
+      # Fill light, temp and battery
+      light[pos:last] = prevRaw$light
+      temp[pos:last] = prevRaw$temperature
+      battery[pos:last] = prevRaw$battery
+    }
   }
   close(fid)
   #===============================================================================
@@ -435,6 +437,6 @@ g.cwaread = function(fileName, start = 0, end = 0, progressBar = FALSE, desiredt
   # Form outcome
   return(invisible(list(
     header = header,
-    data = as.data.frame(cbind(time = timeRes, accelRes,temp,  battery, light))
+    data = as.data.frame(cbind(time = timeRes, accelRes, temp,  battery, light))
   )))
 }

--- a/R/g.getmeta.R
+++ b/R/g.getmeta.R
@@ -135,7 +135,8 @@ g.getmeta = function(datafile,desiredtz = c(),windowsizes = c(5,900,3600),
     if (useRDA == FALSE) {
       accread = g.readaccfile(filename=datafile,blocksize=blocksize,blocknumber=i,
                               selectdaysfile = selectdaysfile,filequality=filequality,decn=decn,
-                              dayborder=dayborder,ws=ws,desiredtz=desiredtz,PreviousEndPage=PreviousEndPage)
+                              dayborder=dayborder,ws=ws,desiredtz=desiredtz,PreviousEndPage=PreviousEndPage,
+                              inspectfileobject=INFI)
       P = accread$P
       filequality = accread$filequality
       filetooshort = filequality$filetooshort

--- a/R/g.getmeta.R
+++ b/R/g.getmeta.R
@@ -63,7 +63,7 @@ g.getmeta = function(datafile,desiredtz = c(),windowsizes = c(5,900,3600),
   count = 1 #counter to keep track of the number of seconds that have been read
   count2 = 1 #count number of blocks read with length "ws2" (15 minutes or whatever is specified above)
   LD = 2 #dummy variable used to identify end of file and to make the process stop
-  bsc_qc = data.frame(time=c(),size=c())
+  bsc_qc = data.frame(time=c(),size=c(), stringsAsFactors = FALSE)
   # inspect file
 
   if (length(unlist(strsplit(datafile,"[.]RD"))) > 1) {

--- a/R/g.part1.R
+++ b/R/g.part1.R
@@ -12,13 +12,13 @@ g.part1 = function(datadir=c(),outputdir=c(),f0=1,f1=c(),windowsizes = c(5,900,3
                    backup.cal.coef=c(),selectdaysfile=c(),dayborder=0,dynrange=c()) {
   if (length(datadir) == 0 | length(outputdir) == 0) {
     if (length(datadir) == 0) {
-      print("Variable datadir is not defined")
+      cat("\nVariable datadir is not defined")
     }
     if (length(outputdir) == 0) {
-      print("Variable outputdir is not specified")
+      cat("\nVariable outputdir is not specified")
     }
   }
-  if (f1 == 0) print("Warning: f1 = 0 is not a meaningful value")
+  if (f1 == 0) cat("\nWarning: f1 = 0 is not a meaningful value")
   filelist = isfilelist(datadir)
   #Extra code to handle raw accelerometer data in Raw data format:
   # list of all csv and bin files
@@ -33,7 +33,7 @@ g.part1 = function(datadir=c(),outputdir=c(),f0=1,f1=c(),windowsizes = c(5,900,3
   if (filelist == TRUE | useRDA == TRUE) {
     if (length(studyname) == 0) {
       studyname = "mystudy"
-      print("Error: studyname not specified in part1. Needed for analysing lists of files")
+      cat("\nError: studyname not specified in part1. Needed for analysing lists of files")
     } else {
       outputfolder = paste("/output_",studyname,sep="")
     }
@@ -100,7 +100,7 @@ g.part1 = function(datadir=c(),outputdir=c(),f0=1,f1=c(),windowsizes = c(5,900,3
   if (length(f0) ==  0) f0 = 1
   if (length(f1) ==  0) f1 = length(fnames)
   if (is.na(fnames[1]) == TRUE) {
-    print("Error: File path not clearly identified. Check path name")
+    cat("\nError: File path not clearly identified. Check path name")
   }
   if (f0 > length(fnames)) f0 = 1
   if (f1 > length(fnames)) f1 = length(fnames)
@@ -121,13 +121,13 @@ g.part1 = function(datadir=c(),outputdir=c(),f0=1,f1=c(),windowsizes = c(5,900,3
   #=================================================================
   # THE LOOP TO RUN THROUGH ALL BINARY FILES AND PROCES THEM
   if (length(fnames) == 0) {
-    print("no files to analyse")
+    cat("\nno files to analyse")
   }
   filelocationkey = matrix("",length(fnames),3)
   fnames = sort(fnames)
   for (j in f0:f1) { #f0:f1 #j is file index (starting with f0 and ending with f1)
     if (print.filename == TRUE) {
-      print(paste("File name: ",fnames[j],sep=""))
+      cat(paste0("\nFile name: ",fnames[j]))
     }
     if (filelist == TRUE) {
       datafile = as.character(fnames[j])
@@ -184,7 +184,7 @@ g.part1 = function(datadir=c(),outputdir=c(),f0=1,f1=c(),windowsizes = c(5,900,3
     options(warn=0) #turn on warnings
     if (overwrite == TRUE) skip = 0
     if (skip == 0) { #if skip = 1 then skip the analysis as you already processed this file
-      print(paste("P1 file",j,sep=""))
+      cat(paste0("\nP1 file",j))
       turn.do.cal.back.on = FALSE
       if (do.cal == TRUE & I$dformc == 3) { # do not do the auto-calibration for wav files (because already done in pre-processign)
         do.cal = FALSE
@@ -192,8 +192,8 @@ g.part1 = function(datadir=c(),outputdir=c(),f0=1,f1=c(),windowsizes = c(5,900,3
       }
       #--------------------------------------
       if (do.cal ==TRUE & useRDA == FALSE) {
-        print("---------------------------------------------")
-        print("investigate calibration of the sensors...")
+        cat("\n---------------------------------------------")
+        cat("\ninvestigate calibration of the sensors...")
         C = g.calibrate(datafile,use.temp=use.temp,spherecrit=spherecrit,
                         minloadcrit=minloadcrit,printsummary=printsummary,chunksize=chunksize,
                         windowsizes=windowsizes,selectdaysfile=selectdaysfile,dayborder=dayborder,
@@ -248,11 +248,11 @@ g.part1 = function(datadir=c(),outputdir=c(),f0=1,f1=c(),windowsizes = c(5,900,3
           C$offset = as.numeric(bcc.data[bcc.i[1],bcc.offseti])
           C$tempoffset=  as.numeric(bcc.data[bcc.i[1],bcc.temp.offseti])
           cat("\nNew offset correction:\n")
-          print(C$offset)
+          cat(paste0("\n",C$offset))
           cat("\nNew scale correction:\n")
-          print(C$scale)
+          cat(paste0("\n",C$scale))
           cat("\nNew tempoffset correction:\n")
-          print(C$tempoffset)
+          cat(paste0("\n",C$tempoffset))
           cat("\n----------------------------------------\n")
         } else {
           cat("\nNo matching filename found in backup.cal.coef\n")
@@ -260,7 +260,7 @@ g.part1 = function(datadir=c(),outputdir=c(),f0=1,f1=c(),windowsizes = c(5,900,3
         }
       }
       #------------------------------------------------
-      print("get meta data...")
+      cat("\nget meta data...")
       M = g.getmeta(datafile,                  
                     do.bfen=do.bfen,
                     do.enmo=do.enmo,
@@ -282,7 +282,7 @@ g.part1 = function(datadir=c(),outputdir=c(),f0=1,f1=c(),windowsizes = c(5,900,3
                     outputfolder=outputfolder,
                     dayborder=dayborder,dynrange=dynrange)
       #------------------------------------------------
-      print("save .RData-file with: calibration report, file inspection report and all meta data...")
+      cat("\nSave .RData-file with: calibration report, file inspection report and all meta data...")
       # remove directory in filename if present
       filename = unlist(strsplit(fnames[j],"/"))
       if (length(filename) > 0) {

--- a/R/g.part1.R
+++ b/R/g.part1.R
@@ -121,7 +121,7 @@ g.part1 = function(datadir=c(),outputdir=c(),f0=1,f1=c(),windowsizes = c(5,900,3
   #=================================================================
   # THE LOOP TO RUN THROUGH ALL BINARY FILES AND PROCES THEM
   if (length(fnames) == 0) {
-    cat("\nno files to analyse")
+    cat("\nNo files to analyse")
   }
   filelocationkey = matrix("",length(fnames),3)
   fnames = sort(fnames)
@@ -192,8 +192,9 @@ g.part1 = function(datadir=c(),outputdir=c(),f0=1,f1=c(),windowsizes = c(5,900,3
       }
       #--------------------------------------
       if (do.cal ==TRUE & useRDA == FALSE) {
-        cat("\n---------------------------------------------")
-        cat("\ninvestigate calibration of the sensors...")
+        # cat(paste0("\n",rep('-',options()$width),collapse=''))
+        cat("\n")
+        cat("\nInvestigate calibration of the sensors with function g.calibrate:\n")
         C = g.calibrate(datafile,use.temp=use.temp,spherecrit=spherecrit,
                         minloadcrit=minloadcrit,printsummary=printsummary,chunksize=chunksize,
                         windowsizes=windowsizes,selectdaysfile=selectdaysfile,dayborder=dayborder,
@@ -247,20 +248,16 @@ g.part1 = function(datadir=c(),outputdir=c(),f0=1,f1=c(),windowsizes = c(5,900,3
           C$scale = as.numeric(bcc.data[bcc.i[1],bcc.scalei])
           C$offset = as.numeric(bcc.data[bcc.i[1],bcc.offseti])
           C$tempoffset=  as.numeric(bcc.data[bcc.i[1],bcc.temp.offseti])
-          cat("\nNew offset correction:\n")
-          cat(paste0("\n",C$offset))
-          cat("\nNew scale correction:\n")
-          cat(paste0("\n",C$scale))
-          cat("\nNew tempoffset correction:\n")
-          cat(paste0("\n",C$tempoffset))
-          cat("\n----------------------------------------\n")
+          cat(paste0("\nNew offset correction ",c("x","y","z"),": ",C$offset))
+          cat(paste0("\nNew scale correction ",c("x","y","z"),": ",C$scale))
+          cat(paste0("\nNew tempoffset correction ",c("x","y","z"),": ",C$tempoffset))
         } else {
           cat("\nNo matching filename found in backup.cal.coef\n")
           cat(paste0("\nCheck that filename ",fnames[j]," exists in the csv-file\n"))
         }
       }
       #------------------------------------------------
-      cat("\nget meta data...")
+      cat("\nExtract signal features (metrics) with the g.getmeta function:\n")
       M = g.getmeta(datafile,                  
                     do.bfen=do.bfen,
                     do.enmo=do.enmo,
@@ -282,7 +279,7 @@ g.part1 = function(datadir=c(),outputdir=c(),f0=1,f1=c(),windowsizes = c(5,900,3
                     outputfolder=outputfolder,
                     dayborder=dayborder,dynrange=dynrange)
       #------------------------------------------------
-      cat("\nSave .RData-file with: calibration report, file inspection report and all meta data...")
+      cat("\nSave .RData-file with: calibration report, file inspection report and all signal features...\n")
       # remove directory in filename if present
       filename = unlist(strsplit(fnames[j],"/"))
       if (length(filename) > 0) {
@@ -298,8 +295,6 @@ g.part1 = function(datadir=c(),outputdir=c(),f0=1,f1=c(),windowsizes = c(5,900,3
       SI = sessionInfo()
       save(SI,file=paste(path3,"/results/QC/sessioninfo_part1.RData",sep=""))
       rm(M); rm(I); rm(C)
-    } else {
-      #  print("file skipped because it was analysed before")
     }
     if(length(filelocationkey) > 0) {
       filelocationkey[,3] = datadir[j]

--- a/R/g.readaccfile.R
+++ b/R/g.readaccfile.R
@@ -65,7 +65,6 @@ g.readaccfile = function(filename,blocksize,blocknumber,selectdaysfile=c(),fileq
       if (blocknumber == 1) {
         filequality$filecorrupt = TRUE
       }
-      cat("\nEnd of file reached\n")
     }
   } else if (mon == 4 & dformat == 3) { # axivity wav
     startpage = blocksize*(blocknumber-1)
@@ -85,7 +84,6 @@ g.readaccfile = function(filename,blocksize,blocknumber,selectdaysfile=c(),fileq
       if (blocknumber == 1) {
         filequality$filecorrupt = TRUE
       }
-      cat("\nEnd of file reached\n")
     }
   } else if (mon == 2 & dformat == 1 & useRDA == FALSE) { # GENEActiv binary non-RDA format
     if (length(selectdaysfile) > 0) { # code to only read fragments of the data (Millenium cohort)
@@ -119,10 +117,10 @@ g.readaccfile = function(filename,blocksize,blocknumber,selectdaysfile=c(),fileq
           if (sf != P$freq) sf = P$freq
         },silent=TRUE)
         if (length(P) <= 2) {
-          cat("\ninitial attempt to read data unsuccessful, try again with mmap turned on:\n")
+          # cat("\nInitial attempt to read data unsuccessful, try again with mmap turned on:\n")
           #try again but now with mmap.load turned on
           if (length(P) != 0) {
-            cat("\ndata read succesfully\n")
+            # cat("\nData read succesfully\n")
           } else {
             switchoffLD = 1
           }
@@ -131,12 +129,10 @@ g.readaccfile = function(filename,blocksize,blocknumber,selectdaysfile=c(),fileq
       if (length(P) > 0) {
         if (length(selectdaysfile) > 0) {
           if (tint[blocknumber,1] == "0") {
-            print("last block")
             switchoffLD = 1
           }
         } else {
           if (nrow(P$data.out) < (blocksize*300)) { #last block
-            print("last block")
             switchoffLD = 1
           }
         }
@@ -176,12 +172,12 @@ g.readaccfile = function(filename,blocksize,blocknumber,selectdaysfile=c(),fileq
       try(expr={P = GENEAread::read.bin(binfile=filename,start=startpage,
                                         end=endpage,calibrate=TRUE,do.temp=TRUE,mmap.load=FALSE)},silent=TRUE)
       if (length(P) <= 2) {
-        cat("\ninitial attempt to read data unsuccessful, try again with mmap turned on:\n")
+        # cat("\ninitial attempt to read data unsuccessful, try again with mmap turned on:\n")
         #try again but now with mmap.load turned on
         try(expr={P = GENEAread::read.bin(binfile=filename,start=startpage,
                                           end=endpage,calibrate=TRUE,do.temp=TRUE,mmap.load=TRUE)},silent=TRUE)
         if (length(P) != 0) {
-          cat("\ndata read succesfully\n")
+          # cat("\ndata read succesfully\n")
           if (sf != P$freq) sf = P$freq
         } else {
           switchoffLD = 1
@@ -190,12 +186,10 @@ g.readaccfile = function(filename,blocksize,blocknumber,selectdaysfile=c(),fileq
       if (length(P) > 0) {
         if (length(selectdaysfile) > 0) {
           if (tint[blocknumber,1] == "0") {
-            print("last block")
             switchoffLD = 1
           }
         } else {
           if (nrow(P$data.out) < (blocksize*300)) { #last block
-            print("last block")
             switchoffLD = 1
           }
         }
@@ -223,7 +217,7 @@ g.readaccfile = function(filename,blocksize,blocknumber,selectdaysfile=c(),fileq
     }
     #===============
   } else if (mon == 2 & dformat == 2) { # GENEActiv csv format
-    cat("\nGeneactiv in csv-format\n")
+    # cat("\nGeneactiv in csv-format\n")
     startpage = (100+(blocksize*300*(blocknumber-1)))
     deltapage = (blocksize*300)
     UPI = updatepageindexing(startpage=startpage,deltapage=deltapage,
@@ -239,7 +233,7 @@ g.readaccfile = function(filename,blocksize,blocknumber,selectdaysfile=c(),fileq
       }
     } else {
       P = c()
-      cat("\nEnd of file reached\n")
+      # cat("\nEnd of file reached\n")
     }
   } else if (mon == 3 & dformat == 2) { # Actigraph csv format
     headerlength = 10
@@ -279,7 +273,7 @@ g.readaccfile = function(filename,blocksize,blocknumber,selectdaysfile=c(),fileq
       }
     } else {
       P = c()
-      cat("\nEnd of file reached\n")
+      # cat("\nEnd of file reached\n")
     }
   } else if (mon == 4 & dformat == 4) { # axivity cwa
     startpage = blocksize*(blocknumber-1)
@@ -290,15 +284,11 @@ g.readaccfile = function(filename,blocksize,blocknumber,selectdaysfile=c(),fileq
     try(expr={P = g.cwaread(fileName=filename, start = startpage, # try to read block first time
                             end = endpage, progressBar = FALSE, desiredtz = desiredtz)},silent=TRUE)
     if (length(P) > 1) { # data reading succesful
-      if (length(P$data) == 0) { # too short?
+      if (length(P$data) == 0 | nrow(P$data) < ((sf*ws*2)+1)) { # too short?
         P = c() ; switchoffLD = 1
-        cat("\nWarning (1): Data in block too short for doing non-wear detection\n")
-        if (blocknumber == 1) filequality$filetooshort = TRUE
-      } else { # too short for non-wear detection
-        if (nrow(P$data) < ((sf*ws*2)+1)) {
-          P = c() ; switchoffLD = 1
-          cat("\nError: Data too short for doing non-wear detection 1\n")
-          if (blocknumber == 1) filequality$filetooshort = TRUE
+        if (blocknumber == 1) {
+          filequality$filetooshort = TRUE
+          cat("\nWarning (1): Data in block too short for doing non-wear detection\n")
         }
       }
     } else { #data reading not succesful
@@ -326,34 +316,24 @@ g.readaccfile = function(filename,blocksize,blocknumber,selectdaysfile=c(),fileq
         try(expr={P = g.cwaread(fileName=filename, start = startpage,
                                 end = endpage, progressBar = FALSE, desiredtz = desiredtz)},silent=TRUE)
         if (length(P) > 1) { # data reading succesful
-          if (length(P$data) == 0) { # if this still does not work then
+          if (length(P$data) == 0 | nrow(P$data) < ((sf*ws*2)+1)) { # if this still does not work then
             P = c() ; switchoffLD = 1
-            cat("\nWarning (3): data in block too short for doing non-wear detection\n")
-            if (blocknumber == 1) filequality$filetooshort = TRUE
-          } else {
-            if (nrow(P$data) < ((sf*ws*2)+1)) {
-              P = c() ; switchoffLD = 1
-              cat("\nError: data too short for doing non-wear detection 1\n")
-              if (blocknumber == 1) filequality$filetooshort = TRUE
-            } else {
-              filequality$NFilePagesSkipped = NFilePagesSkipped # store number of pages jumped
+            if (blocknumber == 1) {
+              cat("\nWarning (3): data in block too short for doing non-wear detection\n")
+              filequality$filetooshort = TRUE
             }
+          } else {
+            filequality$NFilePagesSkipped = NFilePagesSkipped # store number of pages jumped
           }
           # Add replications of Ptest to the beginning of P to achieve same data length as under nuormal conditions
           P$data = rbind(do.call("rbind",replicate(NFilePagesSkipped,PtestStartPage$data,simplify = FALSE)), P$data)
         } else { # Data reading still not succesful, so classify file as corrupt
           P = c()
-          if (blocknumber == 1) {
-            filequality$filecorrupt = TRUE
-          }
-          cat("\nEnd of file reached\n")
+          if (blocknumber == 1) filequality$filecorrupt = TRUE
         }
       } else {
         P = c()
-        if (blocknumber == 1) {
-          filequality$filecorrupt = TRUE
-        }
-        cat("\nEnd of file reached\n")
+        if (blocknumber == 1) filequality$filecorrupt = TRUE
       }
     }
   } else if (mon == 4 & dformat == 2) { # axivity (ax3) csv format
@@ -377,7 +357,6 @@ g.readaccfile = function(filename,blocksize,blocknumber,selectdaysfile=c(),fileq
         filequality$filetooshort = TRUE
       }
       if (nrow(P) < (deltapage)) { #last block
-        print("last block")
         switchoffLD = 1
       }
       # resample the acceleration data, because AX3 data is stored at irregular time points
@@ -402,7 +381,7 @@ g.readaccfile = function(filename,blocksize,blocknumber,selectdaysfile=c(),fileq
       P = cbind(timeRes,accelRes)
     } else {
       P = c()
-      cat("\nEnd of file reached\n")
+      # cat("\nEnd of file reached\n")
     }
   }
   invisible(list(P=P,filequality=filequality, switchoffLD = switchoffLD, endpage = endpage))

--- a/R/g.readaccfile.R
+++ b/R/g.readaccfile.R
@@ -1,6 +1,5 @@
 g.readaccfile = function(filename,blocksize,blocknumber,selectdaysfile=c(),filequality,
                          decn,dayborder,ws, desiredtz = c(), PreviousEndPage = 1,inspectfileobject=c()) {
-  options(warn=2) 
   # function wrapper to read blocks of accelerationd data from various brands
   # the code identifies which accelerometer brand and data format it is
   # blocksize = number of pages to read at once
@@ -89,11 +88,9 @@ g.readaccfile = function(filename,blocksize,blocknumber,selectdaysfile=c(),fileq
       #===================================================================
       # All of the below needed for Millenium cohort
       SDF = read.csv(selectdaysfile, stringsAsFactors = FALSE) # small change by CLS
-
       hvars = g.extractheadervars(I)
       SN = hvars$SN
       SDFi = which(basename(SDF$binFile) == basename(filename))
-
       if(length(SDFi) != 1) {
         save(SDF, SDFi, file = "debuggingFile.Rda")
         stop(paste0("CLS error: there are zero or more than one files: ",

--- a/R/updateBlocksize.R
+++ b/R/updateBlocksize.R
@@ -4,7 +4,12 @@ updateBlocksize = function(blocksize=c(), bsc_qc=data.frame(time=c(),size=c())) 
   }
   gco = gc()
   memuse = gco[2,2] #memuse in mb
-  bsc_qc = rbind(bsc_qc,c(as.character(Sys.time()),memuse))
+  bsc_qc_new_row = data.frame(time=as.character(Sys.time()),size=memuse,stringsAsFactors = FALSE)
+  if (nrow(bsc_qc) == 0) {
+    bsc_qc = bsc_qc_new_row
+  } else {
+    bsc_qc = rbind(bsc_qc,bsc_qc_new_row)
+  }
   if (memuse > 4000) {
     if (nrow(bsc_qc) < 5) {
       blocksize = round(blocksize * 0.8)

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -1,7 +1,7 @@
 \name{NEWS}
 \title{News for Package \pkg{GGIR}}
 \newcommand{\cpkg}{\href{http://CRAN.R-project.org/package=#1}{\pkg{#1}}}
-\section{Changes in version 1.8-0 (release date:06-01-2019)}{
+\section{Changes in version 1.8-0 (release date:09-01-2019)}{
 \itemize{
   \item Part4 handling of clocktime 9am corrected in addition to fix from version 1.7-1.
   \item Fixed bug for Actigraph csv header recognition when column 2 and 3 are NA (prevented processing before)
@@ -14,6 +14,7 @@
   \item Fixed bug in scenario when person is daysleeper and wakingup time occurs before noon, and 12 hours too early.
   \item Fixed bug re. storefolderstructure=TRUE causing 2 variables to drop in g.report.part4 if storefolderstructure=TRUE.
   \item g.intensitygradient enabled to handle absense of data.
+  \item tidied up some of the redundant or even confusiong information printer to the console
   }
 }
 \section{Changes in version 1.7-1 (release date:25-11-2018)}{

--- a/man/g.readaccfile.Rd
+++ b/man/g.readaccfile.Rd
@@ -11,7 +11,7 @@ then deleted. This is needed for memory management.
 \usage{
 g.readaccfile(filename,blocksize,blocknumber,
   selectdaysfile=c(),filequality, decn,dayborder,ws,desiredtz=c(),
-  PreviousEndPage=1)
+  PreviousEndPage=1,inspectfileobject=c())
 }
 \arguments{
   \item{filename}{
@@ -47,6 +47,9 @@ and  filedoesnotholdday. All with the value TRUE or FALSE
   \item{PreviousEndPage}{
    Page number on which previous block ended (automatically assigned within
    g.getmeta and g.calibrate).
+  }
+  \item{inspectfileobject}{
+  Output from the function \link{g.inspectfile}.
   }
 
 }


### PR DESCRIPTION
Thanks to critical attention and feedback from Evgeny I was able to make the following improvements:
- I moved the call to g.inspectfile outside g.readaccfile to avoid applying it with every block (=time waste).
- I did not attempt to re-use the loaded data in g.inspectfile by other functions. It only takes a few seconds and storing and then inserting later may add complexity.
- I made the pageindexing specific to accelerometer brand and data format in function 'updatepageindexing' inside g.readaccfile, because with some accelerometer brands the indexing is inclusive of the endpage, while for other brands the indexing is exclusive of the endpage.
- I revised the corrupt page handling for cwa data, because with the new pageindexing system this did not work anymore.
- Finally, I tidied up some redundant code in the function, e.g. calculations of endpage.