### PR TITLE
Fixes issue #66 winhr and moves IVIS calculation to separate function

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -11,7 +11,8 @@ export(g.analyse,g.calibrate,g.getmeta
         g.readaccfile,g.report.part2,g.report.part4,
        g.report.part5,g.sib.det,g.sib.plot,g.wavread,
        g.weardec,isfilelist,iso8601chartime2POSIX,is_this_a_dst_night,
-        numUnpack,POSIXtime2iso8601,resample,is.ISO8601,updateBlocksize)
+        numUnpack,POSIXtime2iso8601,resample,is.ISO8601,updateBlocksize,
+       g.IVIS)
 importFrom("grDevices", "colors", "dev.off", "pdf","rainbow")
 importFrom("graphics", "abline", "axis", "par", "plot", "plot.new",
       "rect","axis.POSIXct", "barplot", "box", "legend",

--- a/R/g.IVIS.R
+++ b/R/g.IVIS.R
@@ -1,0 +1,43 @@
+g.IVIS = function(Xi, epochsizesecondsXi = 5, IVIS_epochsize_seconds = 3600, IVIS_windowsize_minutes = 60, IVIS.activity.metric = 1) {
+  
+  if (IVIS.activity.metric == 2) { # use binary scoring
+    Xi = ifelse((Xi*1000) < 20, 0, 1) # explored on 5 June 2018 as an attempt to better mimic original ISIV construct
+    Xi = zoo::rollsum(x=Xi,k=(600/epochsizesecondsXi)) # explored on 5 June 2018 as an first attempt to better mimic original ISIV construct
+  }
+  if (length(Xi) > (IVIS_epochsize_seconds/epochsizesecondsXi) & length(Xi) >  (IVIS_windowsize_minutes*60)/epochsizesecondsXi) {
+    if (IVIS_epochsize_seconds > epochsizesecondsXi) { # downsample Xi now
+      Xicum =cumsum(Xi)
+      step = IVIS_epochsize_seconds/epochsizesecondsXi # should be 6 when epochsizesecondsXi=5 and IVIS_epochsize_seconds = 30
+      select= seq(1,length(Xicum),by=step) # adjusted 17/7/2017
+      Xi = diff(c(0,Xicum[select]))/step
+    }
+    nhr = 24*round(60/IVIS_windowsize_minutes) # Number of hours in a day (modify this variable if you want to study different resolutions)
+    Nsecondsinday = 24*3600
+    ni = (Nsecondsinday/nhr)/IVIS_epochsize_seconds # number of epochs in an hour
+    # derive average day with 1 'hour' resolution (hour => windowsize):
+    N = length(Xi)
+    hour = rep(1:ceiling(N/ni),each=ni)
+    if (length(hour) > N) hour = hour[1:N]
+    dat = data.frame(Xi=Xi,hour=hour)
+    InterdailyStability = NA
+    IntradailyVariability = NA
+    if (nrow(dat) > 1) {
+      hh = aggregate(. ~ hour,data=dat,mean)
+      hh$hour_perday = hh$hour - (floor(hh$hour/nhr)*nhr) # 24 hour in a day
+      hh$day = ceiling(hh$hour/nhr)
+      if (nrow(hh) > 1) {
+        hh2 = aggregate(. ~ hour_perday,data=hh,mean)
+        Xh = hh2$Xi
+        # average acceleration per day
+        Xm = suppressWarnings(mean(Xh,na.rm = TRUE))
+        p = length(Xh)
+        InterdailyStability = (sum((Xh - Xm)^2) * N) / (p * sum((Xi-Xm)^2)) # IS: lower is less synchronized with the 24 hour zeitgeber
+        IntradailyVariability = (sum(diff(Xi)^2) * N) / ((N-1) * sum((Xm-Xi)^2)) #IV: higher is more variability within days (fragmentation)
+      }
+    }
+  } else {
+    InterdailyStability = NA
+    IntradailyVariability = NA
+  }
+  invisible(list(InterdailyStability=InterdailyStability, IntradailyVariability=IntradailyVariability))
+}

--- a/R/g.analyse.R
+++ b/R/g.analyse.R
@@ -3,10 +3,11 @@ g.analyse =  function(I,C,M,IMP,qlevels=c(),qwindow=c(0,24),quantiletype = 7,L5M
                       mvpathreshold = c(),boutcriter=c(),mvpadur=c(1,5,10),selectdaysfile=c(),
                       window.summary.size=10,
                       dayborder=0,bout.metric = 1,closedbout=FALSE,desiredtz=c(),
-                      IVIS_windowsize_minutes = 60, IVIS_epochsize_seconds = 3600, iglevels = c()) {
+                      IVIS_windowsize_minutes = 60, IVIS_epochsize_seconds = 3600, iglevels = c(),
+                      IVIS.activity.metric=1) {
   L5M5window = c(0,24) # as of version 1.6-0 this is hardcoded because argument qwindow now
-  # specifies the window over which L5M5 analysis is done
-  # winhr = winhr[1]
+  # specifies the window over which L5M5 analysis is done. So, L5M5window is a depricated
+  # argument and this is also clarified in the documentation
   fname=I$filename
   averageday = IMP$averageday
   strategy = IMP$strategy
@@ -90,22 +91,19 @@ g.analyse =  function(I,C,M,IMP,qlevels=c(),qwindow=c(0,24),quantiletype = 7,L5M
   id2 = id
   iid2 = iid
   if (idloc == 3) { #remove hyphen in id-name for Pelotas id-numbers
-    for (j in 1:length(id)) {
-      temp = unlist(strsplit(id,"-"))
-      if (length(temp) == 2) {
-        id2[j] = as.character(temp[1])
-      } else {
-        id2[j] = as.character(id[j])
+    get_char_before_hyphen = function(x) {
+      for (j in 1:length(x)) {
+        temp = unlist(strsplit(x,"-"))
+        if (length(temp) == 2) {
+          x2[j] = as.character(temp[1])
+        } else {
+          x2[j] = as.character(x[j])
+        }
       }
+      return(x2)
     }
-    for (j in 1:length(iid)) {
-      temp = unlist(strsplit(iid,"-"))
-      if (length(temp) == 2) {
-        iid2[j] = as.character(temp[1])
-      } else {
-        iid2[j] = as.character(iid[j])
-      }
-    }
+    id2 = get_char_before_hyphen(id)
+    iid2 = get_char_before_hyphen(iid)
   }
   #---------------------
   # detect first and last midnight and all midnights
@@ -132,14 +130,7 @@ g.analyse =  function(I,C,M,IMP,qlevels=c(),qwindow=c(0,24),quantiletype = 7,L5M
     starttimei = firstmidnighti
     endtimei = lastmidnighti - 1
   }
-  # calibration error
-  if (length(which(r1==1)) > 0) {
-    CALIBRATE = mean(as.numeric(as.matrix(metalong[which(r1==1 & r2 != 1),which(colnames(M$metalong) == "EN")]))) #mean EN during non-wear time and non-clipping time
-  } else {
-    CALIBRATE = c()
-    is.na(CALIBRATE) = T
-  }
-  # get r5long
+  # get r5long - this is vector with the 5 second scores of what data needs to be imputed
   r5long = matrix(0,length(r5),(ws2/ws3))
   r5long = replace(r5long,1:length(r5long),r5)
   r5long = t(r5long)
@@ -181,7 +172,6 @@ g.analyse =  function(I,C,M,IMP,qlevels=c(),qwindow=c(0,24),quantiletype = 7,L5M
       QLN[QLNi] = paste("p",(round((qlevels[QLNi]) * 10000))/100,sep="")
     }
   }
-  
   if (doquan == TRUE) {
     QUAN = qlevels_names = c()
     ML5AD = ML5AD_names = c()
@@ -242,15 +232,14 @@ g.analyse =  function(I,C,M,IMP,qlevels=c(),qwindow=c(0,24),quantiletype = 7,L5M
           colnames(M$metashort)[(igi+1)] != "angley" &
           colnames(M$metashort)[(igi+1)] != "anglez") {
         breaks = iglevels
-        q59 = c()
+        y_ig = c()
         avday = averageday[,igi] 
         avday = c(avday[(firstmidnighti*(ws2/ws3)):length(avday)],avday[1:((firstmidnighti*(ws2/ws3))-1)])
         # we are not taking the segment of the day now (too much output)
         q60 = cut((avday*1000),breaks,right=FALSE)
         q60 = table(q60)
-        q59  = (as.numeric(q60) * ws3)/60 #converting to minutes
+        y_ig  = (as.numeric(q60) * ws3)/60 #converting to minutes
         x_ig = zoo::rollmean(iglevels,k=2)
-        y_ig = q59
         igout = g.intensitygradient(x_ig, y_ig)
         if (length(avday) > 0) {
           igfullr = c(igfullr,as.vector(unlist(igout)))
@@ -262,50 +251,15 @@ g.analyse =  function(I,C,M,IMP,qlevels=c(),qwindow=c(0,24),quantiletype = 7,L5M
       }
     }
   }
-  
-  #============================
   # IS and IV variables
-  # select data from first midnight to last midnight
-  fmn = midnightsi[1] * (ws2/ws3)
+  fmn = midnightsi[1] * (ws2/ws3) # select data from first midnight to last midnight
   lmn = midnightsi[length(midnightsi)] * (ws2/ws3)
-  Xi = IMP$metashort$ENMO[fmn:lmn] # this is already imputed, so no need to ignore segments
-  # Xi = ifelse((Xi*1000) < 20, 0, 1) # explored on 5 June 2018 as an attempt to better mimic original ISIV construct
-  # Xi = zoo::rollsum(x=Xi,k=(600/ws3)) # explored on 5 June 2018 as an first attempt to better mimic original ISIV construct
-  if (length(Xi) > (IVIS_epochsize_seconds/ws3) & length(Xi) >  (IVIS_windowsize_minutes*60)/ws3) {
-    if (IVIS_epochsize_seconds > ws3) { # downsample Xi now
-      Xicum =cumsum(Xi)
-      step = IVIS_epochsize_seconds/ws3 # should be 6 when ws3=5 and IVIS_epochsize_seconds = 30
-      select= seq(1,length(Xicum),by=step) # adjusted 17/7/2017
-      Xi = diff(c(0,Xicum[select]))/step
-    }
-    nhr = 24*round(60/IVIS_windowsize_minutes) # Number of hours in a day (modify this variable if you want to study different resolutions)
-    Nsecondsinday = 24*3600
-    ni = (Nsecondsinday/nhr)/IVIS_epochsize_seconds # number of epochs in an hour
-    # derive average day with 1 'hour' resolution (hour => windowsize):
-    N = length(Xi)
-    hour = rep(1:ceiling(N/ni),each=ni)
-    if (length(hour) > N) hour = hour[1:N]
-    dat = data.frame(Xi=Xi,hour=hour)
-    InterdailyStability = NA
-    IntradailyVariability = NA
-    if (nrow(dat) > 1) {
-      hh = aggregate(. ~ hour,data=dat,mean)
-      hh$hour_perday = hh$hour - (floor(hh$hour/nhr)*nhr) # 24 hour in a day
-      hh$day = ceiling(hh$hour/nhr)
-      if (nrow(hh) > 1) {
-        hh2 = aggregate(. ~ hour_perday,data=hh,mean)
-        Xh = hh2$Xi
-        # average acceleration per day
-        Xm = suppressWarnings(mean(Xh,na.rm = TRUE))
-        p = length(Xh)
-        InterdailyStability = (sum((Xh - Xm)^2) * N) / (p * sum((Xi-Xm)^2)) # IS: lower is less synchronized with the 24 hour zeitgeber
-        IntradailyVariability = (sum(diff(Xi)^2) * N) / ((N-1) * sum((Xm-Xi)^2)) #IV: higher is more variability within days (fragmentation)
-      }
-    }
-  } else {
-    InterdailyStability = NA
-    IntradailyVariability = NA
-  }
+  # By using the metahosrt from the IMP we do not need to ignore segments, because data imputed
+  Xi = IMP$metashort[fmn:lmn,which(colnames(IMP$metashort) %in% c("anglex","angley","anglez","timestamp") == FALSE)[1]]
+  IVISout = g.IVIS(Xi, epochsizesecondsXi = ws3, IVIS_epochsize_seconds = IVIS_epochsize_seconds, 
+                   IVIS_windowsize_minutes = IVIS_windowsize_minutes, IVIS.activity.metric=IVIS.activity.metric)
+  InterdailyStability = IVISout$InterdailyStability
+  IntradailyVariability = IVISout$IntradailyVariability
   #--------------------------------------------------------------
   # Features per day
   if (doperday == TRUE) {
@@ -765,12 +719,12 @@ g.analyse =  function(I,C,M,IMP,qlevels=c(),qwindow=c(0,24),quantiletype = 7,L5M
                         mvpa[6] = length(which(getboutout$x == 1))   / (60/ws3) #time spent MVPA in minutes
                       }
                       if (length(which(is.nan(mvpa) == TRUE)) > 0) mvpa[which(is.nan(mvpa) == TRUE)] = 0
-                      mvpanames[,mvpai] = c( paste("MVPA_E",ws3,"S_T",mvpathreshold[mvpai],sep=""),
-                                             paste("MVPA_E1M_T",mvpathreshold[mvpai],sep=""),
-                                             paste("MVPA_E5M_T",mvpathreshold[mvpai],sep=""),
-                                             paste("MVPA_E",ws3,"S_B",mvpadur[1],"M",(boutcriter * 100),"%_T",mvpathreshold[mvpai],sep=""),
-                                             paste("MVPA_E",ws3,"S_B",mvpadur[2],"M",(boutcriter * 100),"%_T",mvpathreshold[mvpai],sep=""),
-                                             paste("MVPA_E",ws3,"S_B",mvpadur[3],"M",(boutcriter * 100),"%_T",mvpathreshold[mvpai],sep=""))
+                      mvpanames[,mvpai] = c( paste0("MVPA_E",ws3,"S_T",mvpathreshold[mvpai]),
+                                             paste0("MVPA_E1M_T",mvpathreshold[mvpai]),
+                                             paste0("MVPA_E5M_T",mvpathreshold[mvpai]),
+                                             paste0("MVPA_E",ws3,"S_B",mvpadur[1],"M",(boutcriter * 100),"%_T",mvpathreshold[mvpai]),
+                                             paste0("MVPA_E",ws3,"S_B",mvpadur[2],"M",(boutcriter * 100),"%_T",mvpathreshold[mvpai]),
+                                             paste0("MVPA_E",ws3,"S_B",mvpadur[3],"M",(boutcriter * 100),"%_T",mvpathreshold[mvpai]))
                       for (fillds in 1:6) {
                         daysummary[di,fi] = mvpa[fillds]
                         ds_names[fi] = paste(mvpanames[fillds,mvpai],"_",colnames(metashort)[mi] ,anwi_nameindices[anwi_index],sep=""); fi=fi+1
@@ -798,10 +752,10 @@ g.analyse =  function(I,C,M,IMP,qlevels=c(),qwindow=c(0,24),quantiletype = 7,L5M
   LW = length(which(r5 < 1)) * (ws2/60) #length wear in minutes (for entire signal)
   LWp = length(which(r5[which(r4 == 0)] < 1)) * (ws2/60) #length wear in minutes (for protocol)
   LMp = length(which(r4 == 0)) * (ws2/60) #length protocol
-  #================================================
-  # Summary per individual, not per day:
-  #------------------------------
-  # Extract the average 24 hr
+  #====================================================================
+  # Summarise per recording (not per day)
+  #====================================================================
+  # Extract the average 24 hr but ignore angle metrics
   lookattmp = which(colnames(metashort) != "angle" &
                       colnames(metashort) != "anglex" &
                       colnames(metashort) != "angley" &
@@ -815,20 +769,20 @@ g.analyse =  function(I,C,M,IMP,qlevels=c(),qwindow=c(0,24),quantiletype = 7,L5M
       average24hc = matrix(0,n_ws3_perday,1)
       if (floor(ND) != 0) {
         for (j in 1:floor(ND)) {
-          string = as.numeric(as.matrix(metashort[(((j-1)*n_ws3_perday)+1):(j*n_ws3_perday),lookat[h]]))
-          val = which(is.na(string) == F)
-          average24h[val,1] = average24h[val,1] + string[val] #mean acceleration
+          dataOneDay = as.numeric(as.matrix(metashort[(((j-1)*n_ws3_perday)+1):(j*n_ws3_perday),lookat[h]]))
+          val = which(is.na(dataOneDay) == F)
+          average24h[val,1] = average24h[val,1] + dataOneDay[val] #mean acceleration
           average24hc[val,1] = average24hc[val,1] +1
         }
       }
       if (floor(ND) < ND) {
         if (floor(ND) == 0) {
-          string = as.numeric(as.matrix(metashort[,lookat[h]]))
+          dataOneDay = as.numeric(as.matrix(metashort[,lookat[h]]))
         } else {
-          string = as.numeric(as.matrix(metashort[((floor(ND)*n_ws3_perday)+1):nrow(metashort),lookat[h]]))
+          dataOneDay = as.numeric(as.matrix(metashort[((floor(ND)*n_ws3_perday)+1):nrow(metashort),lookat[h]]))
         }
-        val = which(is.na(string) == F)
-        average24h[val,1] = average24h[val,1] + string[val]  #mean acceleration
+        val = which(is.na(dataOneDay) == F)
+        average24h[val,1] = average24h[val,1] + dataOneDay[val]  #mean acceleration
         average24hc[val,1] = average24hc[val,1] +1
       }
       average24h = average24h / average24hc
@@ -837,12 +791,9 @@ g.analyse =  function(I,C,M,IMP,qlevels=c(),qwindow=c(0,24),quantiletype = 7,L5M
   } else {
     cat("file skipped for general average caculation because not enough data")
   }
+  # Person identification number
   id[which(id == "NA")] =iid[which(id == "NA")]
   id2[which(id2 == "NA")] =iid2[which(id2 == "NA")]
-  #check whether there was enough data in a day by looking at r5long
-  weekdays = c("Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday")
-  weekdayi = which(weekdays == wdayname)
-  #-----------------------------------
   if (idloc == 2) {
     filesummary[vi] = unlist(strsplit(fname,"_"))[1] #id
   } else if (idloc == 4) {
@@ -852,7 +803,7 @@ g.analyse =  function(I,C,M,IMP,qlevels=c(),qwindow=c(0,24),quantiletype = 7,L5M
   } else if (idloc == 3) {
     filesummary[vi] = id2
   }
-  #-----------------------------------
+  # Serial number
   if (snloc == 1) {
     filesummary[(vi+1)] = SN
   } else if (snloc == 2) {
@@ -860,35 +811,35 @@ g.analyse =  function(I,C,M,IMP,qlevels=c(),qwindow=c(0,24),quantiletype = 7,L5M
   }
   s_names[vi:(vi+1)] = c("ID","device_sn")
   vi = vi+2
-  #-----------------------------------
+  # starttime of measurement, body location, filename
   filesummary[vi] = BL
   filesummary[(vi+1)] = fname
   filesummary[(vi+2)] = startt # starttime of measurement
   s_names[vi:(vi+2)] = c("bodylocation","filename","start_time")
   vi = vi+3
-  #-----------------------------------
-  filesummary[vi] = wdayname # weekday on which measurement started
+  # weekday on which measurement started, sample frequency and device
+  filesummary[vi] = wdayname 
   filesummary[(vi+1)] = I$sf
   filesummary[(vi+2)] = I$monn
   s_names[vi:(vi+2)] = c("startday","samplefreq","device")
   vi = vi+3
-  #-----------------------------------
+  # clipsing score and measurement duration in days
   filesummary[vi] = LC2  / ((LD/1440)*96)
   filesummary[(vi+1)] = LD/1440 #measurement duration in days
-  s_names[vi:(vi+1)] = c("clipping_score", #paste("number of ",ws2/60," minute time windows with potential signal clipping (> 80% of time > 7.5 g)",sep="") divided by number of 15 minute periods
+  s_names[vi:(vi+1)] = c("clipping_score",
                          "meas_dur_dys")
   vi = vi+2
-  #-----------------------------------
+  # completeness core and measurement duration with different definitions
   filesummary[vi] = dcomplscore #completeness of the day
   filesummary[(vi+1)] = LMp/1440 #measurement duration according to protocol
   filesummary[(vi+2)] = LWp/1440 #wear duration in days (out of measurement protocol)
   s_names[vi:(vi+2)] = c("complete_24hcycle", # day (fraction of 24 hours for which data is available at all)
                          "meas_dur_def_proto_day","wear_dur_def_proto_day")
   vi = vi+3
-  #-----------------------------------
+  # calibration error after auto-calibration
   if (length(C$cal.error.end) == 0)   C$cal.error.end = c(" ")
-  filesummary[vi] = C$cal.error.end #CALIBRATE
-  filesummary[vi+1] = C$QCmessage #CALIBRATE
+  filesummary[vi] = C$cal.error.end
+  filesummary[vi+1] = C$QCmessage
   for (la in 1:length(lookat)) {
     MA[la] = 	MA[la] * 1000
   }
@@ -896,9 +847,9 @@ g.analyse =  function(I,C,M,IMP,qlevels=c(),qwindow=c(0,24),quantiletype = 7,L5M
   filesummary[(vi+2):(vi+q0)] = MA
   colnames_to_lookat = paste0(colnames_to_lookat,"_fullRecordingMean")
   s_names[vi:(vi+q0)] = c("calib_err",
-                          "calib_status",colnames_to_lookat) #colnames(metashort)[2:ncol(metashort)]
+                          "calib_status",colnames_to_lookat)
   vi = vi+q0+2
-  #---------------------------------------
+  #quantile, ML5, and intensity gradient variables
   if (doquan == TRUE) {
     q1 = length(QUAN)
     filesummary[vi:((vi-1)+q1)] = QUAN*1000
@@ -917,93 +868,90 @@ g.analyse =  function(I,C,M,IMP,qlevels=c(),qwindow=c(0,24),quantiletype = 7,L5M
     s_names[vi:((vi-1)+q1)] = paste0(igfullr_names,"_fullRecording")
     vi = vi + q1
   }
-  
-  #---------------------------------------
   if (tooshort == 0) {
-    #--------------------------------------------------------------
-    # expand with extracted values from features per day: do this for ENMO and activity levels
+    #====================================================================
+    # Summarise per recording (not per day) - additional variables if the recording is long enough
+    #====================================================================
+    # Recognise weekenddays with enough data
     wkend  = which(daysummary[,which(ds_names == "weekday")] == "Saturday" | daysummary[,which(ds_names == "weekday")] == "Sunday")
     columnWithAlwaysData = which(ds_names == "N hours")
     NVHcolumn = which(ds_names == "N valid hours") #only count in the days for which the inclusion criteria is met
     v1 = which(is.na(as.numeric(daysummary[wkend,columnWithAlwaysData])) == F &
                  as.numeric(daysummary[wkend,NVHcolumn]) >= includedaycrit)
     wkend = wkend[v1]
+    # Recognise weekdays with enough data
     wkday  = which(daysummary[,which(ds_names == "weekday")] != "Saturday" & daysummary[,which(ds_names == "weekday")] != "Sunday")
     v2 = which(is.na(as.numeric(daysummary[wkday,columnWithAlwaysData])) == F  &
                  as.numeric(daysummary[wkday,NVHcolumn]) >= includedaycrit)
     wkday = wkday[v2]
-    filesummary[vi] = length(wkend) # number of weekend days
-    if (is.na(filesummary[vi]) == TRUE) filesummary[vi] = 0
-    filesummary[(vi+1)] = length(wkday) # number of week day
-    if (is.na(filesummary[(vi+1)]) == TRUE) filesummary[(vi+1)] = 0
+    # Add number of weekend and weekdays to filesummary
+    filesummary[vi:(vi+1)] = c(length(wkend),  length(wkday)) # number of weekend days & weekdays
+    iNA = which(is.na(filesummary[vi:(vi+1)]) == TRUE)
+    if (length(iNA) > 0) filesummary[(vi:(vi+1))[iNA]] = 0
     s_names[vi:(vi+1)] = c("N valid WEdays","N valid WKdays")
     vi = vi + 2
-    filesummary[vi] = InterdailyStability
-    if (is.na(filesummary[vi]) == TRUE) filesummary[vi] = " "
-    filesummary[(vi+1)] = IntradailyVariability
-    if (is.na(filesummary[(vi+1)]) == TRUE) filesummary[(vi+1)] = " "
-    s_names[vi:(vi+1)] = c("IS_interdailystability","IV_intradailyvariability")
-    vi = vi + 2
-    filesummary[vi] = IVIS_windowsize_minutes
-    if (is.na(filesummary[vi]) == TRUE) filesummary[vi] = " "
-    filesummary[(vi+1)] = IVIS_epochsize_seconds
-    if (is.na(filesummary[(vi+1)]) == TRUE) filesummary[(vi+1)] = " "
-    s_names[vi:(vi+1)] = c("IVIS_windowsize_minutes","IVIS_epochsize_seconds")
-    vi = vi + 2
-    #############################################################
-    #metrics - summarise with stratification to weekdays and weekend days
+    # Add ISIV to filesummary
+    filesummary[vi:(vi+3)] = c(InterdailyStability, IntradailyVariability,
+                        IVIS_windowsize_minutes, IVIS_epochsize_seconds)
+    iNA = which(is.na(filesummary[vi:(vi+3)]) == TRUE)
+    if (length(iNA) > 0) filesummary[(vi:(vi+3))[iNA]] = " "
+    s_names[vi:(vi+3)] = c("IS_interdailystability","IV_intradailyvariability",
+                           "IVIS_windowsize_minutes","IVIS_epochsize_seconds")
+    vi = vi + 4
+    # Variables per metric - summarise with stratification to weekdays and weekend days
     daytoweekvar = c(5:length(ds_names))
-    
     md = which(ds_names[daytoweekvar] %in% c("measurementday", "weekday") == TRUE)
     if (length(md) > 0) daytoweekvar = daytoweekvar[-md]
     dtwtel = 0
     if (length(daytoweekvar) >= 1) {
       sp = length(daytoweekvar) + 1
       for (dtwi in daytoweekvar) {
-        #checkwhether columns is empty:
+        #check whether columns is empty:
         uncona = unique(daysummary[,dtwi])
         storevalue = !(length(uncona) == 1 & length(qwindow) > 2 & uncona[1] == "")
-        if (storevalue == TRUE) {
-          v4 = mean(suppressWarnings(as.numeric(daysummary[,dtwi])),na.rm=TRUE) #plain average of available days
+        # Only do next 15-isch linges of code if:
+        # - there is more than 1 day of data
+        # - there are multiple daysegments (qwindow)
+        # - first value is not empty
+        if (storevalue == TRUE) { 
+          # Plain average of available days
+          v4 = mean(suppressWarnings(as.numeric(daysummary[,dtwi])),na.rm=TRUE) 
           filesummary[(vi+1+(dtwtel*sp))] = v4 # #average all availabel days
-          s_names[(vi+1+(dtwtel*sp))] = paste("AD_",ds_names[dtwi],sep="")  #daytoweekvar_names[dtwtel+1]
-          #========================================================================
-          # attempt to stratify to week and weekend days
-          # Average of available days
+          s_names[(vi+1+(dtwtel*sp))] = paste("AD_",ds_names[dtwi],sep="")
+          # Average of available days per weekenddays / weekdays:
           dtw_wkend = suppressWarnings(as.numeric(daysummary[wkend,dtwi]))
           dtw_wkday = suppressWarnings(as.numeric(daysummary[wkday,dtwi]))
-          filesummary[(vi+2+(dtwtel*sp))] = suppressWarnings(mean(dtw_wkend,na.rm=TRUE)) # #weekend average
-          filesummary[(vi+3+(dtwtel*sp))] = suppressWarnings(mean(dtw_wkday,na.rm=TRUE)) # #weekday average
-          s_names[(vi+2+(dtwtel*sp))] = paste0("WE_",ds_names[dtwi]) #Weekend no weighting
-          s_names[(vi+3+(dtwtel*sp))] = paste0("WD_",ds_names[dtwi]) #weekdays no weighting
-          #==================================================
-          # Weighted average of available days
+          filesummary[(vi+2+(dtwtel*sp))] = suppressWarnings(mean(dtw_wkend,na.rm=TRUE))
+          filesummary[(vi+3+(dtwtel*sp))] = suppressWarnings(mean(dtw_wkday,na.rm=TRUE))
+          s_names[(vi+2+(dtwtel*sp))] = paste0("WE_",ds_names[dtwi]) # Weekend no weighting
+          s_names[(vi+3+(dtwtel*sp))] = paste0("WD_",ds_names[dtwi]) # Weekdays no weighting
+          # Weighted average of available days per weekenddays / weekdays:
           if (length(dtw_wkend) > 2) {
             dtw_wkend = c((dtw_wkend[1]+dtw_wkend[3])/2,dtw_wkend[2])
           }
           if (length(dtw_wkday) > 5) {
             dtw_wkday = c((dtw_wkday[1]+dtw_wkday[6])/2,dtw_wkday[2:5])
           }
-          filesummary[(vi+4+(dtwtel*sp))] = suppressWarnings(mean(dtw_wkend,na.rm=TRUE)) # #weekend average
-          filesummary[(vi+5+(dtwtel*sp))] = suppressWarnings(mean(dtw_wkday,na.rm=TRUE)) # #weekday average
-          s_names[(vi+4+(dtwtel*sp))] = paste("WWE_",ds_names[dtwi],sep="")
-          s_names[(vi+5+(dtwtel*sp))] = paste("WWD_",ds_names[dtwi],sep="")
+          filesummary[(vi+4+(dtwtel*sp))] = suppressWarnings(mean(dtw_wkend,na.rm=TRUE))
+          filesummary[(vi+5+(dtwtel*sp))] = suppressWarnings(mean(dtw_wkday,na.rm=TRUE))
+          s_names[(vi+4+(dtwtel*sp))] = paste("WWE_",ds_names[dtwi],sep="") # Weekend with weighting
+          s_names[(vi+5+(dtwtel*sp))] = paste("WWD_",ds_names[dtwi],sep="") # Weekdays with weighting
           dtwtel = dtwtel + 1
         }
-        s_names[(vi+1+(dtwtel*sp))] = paste("AD_",ds_names[dtwi],sep="")  #daytoweekvar_names[dtwtel+1]
-        #========================================================================
-        # attempt to stratify to week and weekend days
-        # Average of available days
+        # Plain average of available days
+        v4 = mean(suppressWarnings(as.numeric(daysummary[,dtwi])),na.rm=TRUE) 
+        filesummary[(vi+1+(dtwtel*sp))] = v4
+        s_names[(vi+1+(dtwtel*sp))] = paste("AD_",ds_names[dtwi],sep="")
+        # Average of available days per weekenddays / weekdays:
         dtw_wkend = suppressWarnings(as.numeric(daysummary[wkend,dtwi]))
         dtw_wkday = suppressWarnings(as.numeric(daysummary[wkday,dtwi]))
         if (storevalue == TRUE) {
-          filesummary[(vi+2+(dtwtel*sp))] = mean(dtw_wkend,na.rm=TRUE) # #weekend average
-          filesummary[(vi+3+(dtwtel*sp))] = mean(dtw_wkday,na.rm=TRUE) # #weekday average
+          filesummary[(vi+2+(dtwtel*sp))] = mean(dtw_wkend,na.rm=TRUE)
+          filesummary[(vi+3+(dtwtel*sp))] = mean(dtw_wkday,na.rm=TRUE)
         }
-        s_names[(vi+2+(dtwtel*sp))] = paste("WE_",ds_names[dtwi],sep="") #Weekend no weighting
-        s_names[(vi+3+(dtwtel*sp))] = paste("WD_",ds_names[dtwi],sep="") #weekdays no weighting
-        #==================================================
-        # Weighted average of available days
+        s_names[(vi+2+(dtwtel*sp))] = paste("WE_",ds_names[dtwi],sep="") # Weekend no weighting
+        s_names[(vi+3+(dtwtel*sp))] = paste("WD_",ds_names[dtwi],sep="") # Weekdays no weighting
+        # Weighted average of available days per weekenddays / weekdays:
         if (length(dtw_wkend) > 2) {
           dtw_wkend = c((dtw_wkend[1]+dtw_wkend[3])/2,dtw_wkend[2])
         }
@@ -1011,8 +959,8 @@ g.analyse =  function(I,C,M,IMP,qlevels=c(),qwindow=c(0,24),quantiletype = 7,L5M
           dtw_wkday = c((dtw_wkday[1]+dtw_wkday[6])/2,dtw_wkday[2:5])
         }
         if (storevalue == TRUE) {
-          filesummary[(vi+4+(dtwtel*sp))] = mean(dtw_wkend,na.rm=TRUE) # #weekend average
-          filesummary[(vi+5+(dtwtel*sp))] = mean(dtw_wkday,na.rm=TRUE) # #weekday average
+          filesummary[(vi+4+(dtwtel*sp))] = mean(dtw_wkend,na.rm=TRUE) # Weekend with weighting
+          filesummary[(vi+5+(dtwtel*sp))] = mean(dtw_wkday,na.rm=TRUE) # Weekdays with weighting
         }
         s_names[(vi+4+(dtwtel*sp))] = paste("WWE_",ds_names[dtwi],sep="")
         s_names[(vi+5+(dtwtel*sp))] = paste("WWD_",ds_names[dtwi],sep="")
@@ -1031,7 +979,9 @@ g.analyse =  function(I,C,M,IMP,qlevels=c(),qwindow=c(0,24),quantiletype = 7,L5M
     GGIRversion = SI$otherPkgs$GGIR$Version
     if (length(GGIRversion) == 0) GGIRversion = "GGIR not used"
     filesummary[(vi+5)] = GGIRversion #"2014-03-14 12:14:00 GMT"
-    s_names[vi:(vi+5)] = as.character(c("data exclusion stategy (value=1, ignore specific hours; value=2, ignore all data before the first midnight and after the last midnight)",
+    s_names[vi:(vi+5)] = as.character(c(paste("data exclusion stategy (value=1, ignore specific hours;",
+                                              " value=2, ignore all data before the first midnight and",
+                                              " after the last midnight)"),
                                         "n hours ignored at start of meas (if strategy=1)",
                                         "n hours ignored at end of meas (if strategy=1)",
                                         "n days of measurement after which all data is ignored (if strategy=1)",
@@ -1039,9 +989,8 @@ g.analyse =  function(I,C,M,IMP,qlevels=c(),qwindow=c(0,24),quantiletype = 7,L5M
                                         "GGIR version"))
     vi = vi + 5
   }
-  #---------------------------------------------------------------
   rm(metashort); rm(LD); rm(LW); rm(HN); rm(id); rm(metalong)
-  #------------------------
+  # tidy up daysummary object
   mw = which(is.na(daysummary)==T)
   if (length(mw) > 0) {
     daysummary[which(is.na(daysummary)==T)] = " "
@@ -1058,12 +1007,12 @@ g.analyse =  function(I,C,M,IMP,qlevels=c(),qwindow=c(0,24),quantiletype = 7,L5M
   }
   daysummary = data.frame(value=daysummary,stringsAsFactors=FALSE)
   names(daysummary) = ds_names
-  
   # remove double columns with 1-6am variables
   columnswith16am = grep("1-6am",x=colnames(daysummary))
   if (length(columnswith16am) > 1) {
     daysummary = daysummary[,-columnswith16am[2:length(columnswith16am)]]
   }
+  # tidy up filesummary object
   mw = which(is.na(filesummary)==T)
   if (length(mw) > 0) {
     filesummary[which(is.na(filesummary)==T)] = " "
@@ -1076,7 +1025,6 @@ g.analyse =  function(I,C,M,IMP,qlevels=c(),qwindow=c(0,24),quantiletype = 7,L5M
     s_names = s_names[-cut]
     filesummary = filesummary[-cut]
   }
-  
   filesummary = data.frame(value=t(filesummary),stringsAsFactors=FALSE) #needs to be t() because it will be a column otherwise
   names(filesummary) = s_names
   
@@ -1095,7 +1043,6 @@ g.analyse =  function(I,C,M,IMP,qlevels=c(),qwindow=c(0,24),quantiletype = 7,L5M
   selectcolumns = selectcolumns[which(selectcolumns %in% colnames(filesummary) == TRUE)]
   filesummary = filesummary[,selectcolumns]
   filesummary = filesummary[,!duplicated(filesummary)]
-  
   if (length(selectdaysfile) > 0) {
     windowsummary = data.frame(windowsummary,stringsAsFactors = FALSE) # addition for Millenium cohort
     names(windowsummary) = ws_names

--- a/R/g.part2.R
+++ b/R/g.part2.R
@@ -6,7 +6,8 @@ g.part2 = function(datadir=c(),metadatadir=c(),f0=c(),f1=c(),strategy = 1, hrs.d
                    boutcriter = 0.8,ndayswindow=7,idloc=1,do.imp=TRUE,storefolderstructure = FALSE,
                    overwrite=FALSE,epochvalues2csv=FALSE,mvpadur=c(1,5,10),selectdaysfile=c(),
                    window.summary.size=10,dayborder=0,bout.metric=2,closedbout=FALSE,desiredtz="Europe/London",
-                   IVIS_windowsize_minutes = 60, IVIS_epochsize_seconds = 3600, iglevels = c()) {
+                   IVIS_windowsize_minutes = 60, IVIS_epochsize_seconds = 3600, iglevels = c(),
+                   IVIS.activity.metric=1) {
   snloc= 1
   #---------------------------------
   # Specifying directories with meta-data and extracting filenames 
@@ -84,7 +85,8 @@ g.part2 = function(datadir=c(),metadatadir=c(),f0=c(),f1=c(),strategy = 1, hrs.d
                         mvpathreshold =mvpathreshold ,boutcriter=boutcriter,mvpadur=mvpadur,selectdaysfile=selectdaysfile,
                         window.summary.size=window.summary.size,dayborder=dayborder,bout.metric=bout.metric,closedbout=closedbout,
                         desiredtz=desiredtz,IVIS_windowsize_minutes = IVIS_windowsize_minutes,
-                        IVIS_epochsize_seconds = IVIS_epochsize_seconds, iglevels = iglevels)
+                        IVIS_epochsize_seconds = IVIS_epochsize_seconds, iglevels = iglevels,
+                        IVIS.activity.metric= IVIS.activity.metric)
         name=as.character(unlist(strsplit(fnames[i],"eta_"))[2])
         if (epochvalues2csv==TRUE) {
           if (length(IMP$metashort) > 0) {

--- a/R/g.shell.GGIR.R
+++ b/R/g.shell.GGIR.R
@@ -119,6 +119,8 @@ g.shell.GGIR = function(mode=c(1,2),datadir=c(),outputdir=c(),studyname=c(),f0=1
   if (length(which(ls() == "window.summary.size")) == 0) window.summary.size = 10
   if (length(which(ls() == "dayborder")) == 0)  dayborder = 0
   if (length(which(ls() == "iglevels")) == 0)  iglevels = c()
+  if (length(which(ls() == "IVIS.activity.metric")) == 0)  IVIS.activity.metric = 1
+  
   
   # PART 3
   if (length(which(ls() == "anglethreshold")) == 0)  anglethreshold = 5
@@ -203,7 +205,8 @@ g.shell.GGIR = function(mode=c(1,2),datadir=c(),outputdir=c(),studyname=c(),f0=1
             mvpadur=mvpadur,selectdaysfile=selectdaysfile,bout.metric=bout.metric,window.summary.size=window.summary.size,
             dayborder=dayborder,closedbout=closedbout,desiredtz=desiredtz,
             IVIS_windowsize_minutes = IVIS_windowsize_minutes,
-            IVIS_epochsize_seconds = IVIS_epochsize_seconds, iglevels = iglevels)
+            IVIS_epochsize_seconds = IVIS_epochsize_seconds, iglevels = iglevels,
+            IVIS.activity.metric=IVIS.activity.metric)
   }
   if (dopart3 == TRUE) {
     cat('\n')

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -5,6 +5,7 @@
 \itemize{
   \item Enabled multiple values for argument winhr, by which part2 can now calculated 
   for example L3M3, L5M5, L6M6, L10M10 all in one go.
+  \item Moved IVIS calculation to seperate function
   }
   }
 \section{Changes in version 1.9-2 (release date:03-07-2019)}{

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -1,6 +1,12 @@
 \name{NEWS}
 \title{News for Package \pkg{GGIR}}
 \newcommand{\cpkg}{\href{http://CRAN.R-project.org/package=#1}{\pkg{#1}}}
+\section{Changes in version 1.9-3 (release date:18-07-2019)}{
+\itemize{
+  \item Enabled multiple values for argument winhr, by which part2 can now calculated 
+  for example L3M3, L5M5, L6M6, L10M10 all in one go.
+  }
+  }
 \section{Changes in version 1.9-2 (release date:03-07-2019)}{
 \itemize{
   \item Added functionality to work with studies where accelerometer is configured in one

--- a/man/g.IVIS.Rd
+++ b/man/g.IVIS.Rd
@@ -1,0 +1,56 @@
+\name{g.IVIS}
+\alias{g.IVIS}
+\title{
+  Calculates IV and IS
+}
+\description{
+  To extract interdaily stability and interdaily variability as originally proposed by
+  van Someren. Note that we had to improvise our replication of his metric, because GGIR
+  does not attempt to calculate count values. The implementation in this function has so
+  far not be evaluated yet.
+}
+\usage{
+  g.IVIS(Xi, epochsizesecondsXi = 5, IVIS_epochsize_seconds = 3600, 
+  IVIS_windowsize_minutes = 60, IVIS.activity.metric = 1)
+}
+\arguments{
+  \item{Xi}{
+  Vector with acceleration values, e.g. ENMO metric.
+  }
+  \item{epochsizesecondsXi}{
+  Epoch size of the values in Xi expressed in seconds.
+  }
+  \item{IVIS_epochsize_seconds}{ 
+   Epoch size of the Intradaily Variability (IV) and Interdaily
+  Stability (IS) metrics in seconds
+  }
+  \item{IVIS_windowsize_minutes}{
+    Window size of the Intradaily Variability (IV) and Interdaily
+  Stability (IS) metrics in minutes
+  }
+  \item{IVIS.activity.metric}{
+  Metric used for activity calculation.
+  Value = 1, uses continuous scaled acceleration. 
+  Value = 2, tries to collapse itinto a binary score of rest versus active
+  to try to similate the original approach.
+  }
+}
+\value{
+  \item{InterdailyStability}{}
+  \item{IntradailyVariability}{}
+  
+}
+\examples{
+  Xi = abs(rnorm(n = 10000,mean = 0.2))
+  IVISvariables = g.IVIS(Xi=Xi)
+}
+\author{
+  Vincent T van Hees <vincentvanhees@gmail.com>
+}
+\references{
+\itemize{
+  \item Eus J. W. Van Someren, Dick F. Swaab, Christopher C. Colenda, Wayne Cohen, W. Vaughn McCall & Peter B. Rosenquist.
+  Bright Light Therapy: Improved Sensitivity to Its Effects on Rest-Activity Rhythms in Alzheimer Patients by Application of Nonparametric Methods/
+  Chronobiology International. 1999. Volume 16, issue 4.
+}
+}

--- a/man/g.analyse.Rd
+++ b/man/g.analyse.Rd
@@ -25,7 +25,7 @@ selectdaysfile=c(),window.summary.size=10,
 dayborder=0,bout.metric = 1,
 closedbout=FALSE,desiredtz = c(),
 IVIS_windowsize_minutes = 60,
-IVIS_epochsize_seconds = 3600, iglevels = c())
+IVIS_epochsize_seconds = 3600, iglevels = c(),IVIS.activity.metric=1)
 }
 
 \arguments{
@@ -143,6 +143,10 @@ IVIS_epochsize_seconds = 3600, iglevels = c())
     the bins c(seq(0,4000,by=25),8000) or the user could specify their own
     distribution. There is no constriction to the number of levels.
   }
+   \item{IVIS.activity.metric}{
+    see function \link{g.IVIS}
+  }
+   
 }
 \value{
 \item{\code{summary}}{summary for the file that was analysed (see details)}

--- a/man/g.analyse.Rd
+++ b/man/g.analyse.Rd
@@ -78,7 +78,7 @@ IVIS_epochsize_seconds = 3600, iglevels = c())
     There is no constriction to the number of levels.
   }
   \item{winhr}{
-    window size in hours of L5 and M5 analysis (dedault = 5 hours)
+    Vector of window size(s) (unit: hours) of L5 and M5 analysis (dedault = 5 hours)
   }
   \item{idloc}{
     If value = 1 (default) the code assumes that ID number is stored in the

--- a/man/g.part2.Rd
+++ b/man/g.part2.Rd
@@ -76,7 +76,7 @@ iglevels = c())
     resoltion of L5 and M5 analysis in minutes (default: 10 minutes)
   }
    \item{winhr}{
-    window size in hours of L5 and M5 analysis (dedault = 5 hours)
+    Vector of window size(s) (unit: hours) of L5 and M5 analysis (dedault = 5 hours)
   }
   \item{qwindow}{
    see \link{g.analyse}

--- a/man/g.part2.Rd
+++ b/man/g.part2.Rd
@@ -22,7 +22,7 @@ epochvalues2csv=FALSE, mvpadur=c(1,5,10),selectdaysfile=c(),
 window.summary.size=10,dayborder=0,
 bout.metric=2,closedbout=FALSE,desiredtz="Europe/London",
 IVIS_windowsize_minutes = 60, IVIS_epochsize_seconds = 3600,
-iglevels = c())
+iglevels = c(), IVIS.activity.metric=1)
 }
 \arguments{
 \item{datadir}{
@@ -155,16 +155,18 @@ iglevels = c())
   see \link{g.getmeta}
   }
     \item{IVIS_windowsize_minutes}{
-  Window size of the Intradaily Variability (IV) and Interdaily
-  Stability (IS) metrics in minutes
+  see function \link{g.IVIS}
   }
   \item{IVIS_epochsize_seconds}{
-  Epoch size of the Intradaily Variability (IV) and Interdaily
-  Stability (IS) metrics in seconds
+  see function \link{g.IVIS}
   }
   \item{iglevels}{
     see function \link{g.analyse}
   }
+  \item{IVIS.activity.metric}{
+    see function \link{g.IVIS}
+  }
+
 }
 \value{
  The function provides no values, it only ensures that other functions are called


### PR DESCRIPTION
- Enabled multiple values for argument winhr, by which part2 can now calculate for example L3M3, L5M5, L6M6, L10M10 all in one go.
- Moved IVIS calculation to separate function in an attempt to shorten function g.analyse. Further, also did some minor tidy up work in bottom half of the g.analyse code.