### PR TITLE
Fix g.cwaread to account for serial numbers > 32767

### DIFF
--- a/R/g.cwaread.R
+++ b/R/g.cwaread.R
@@ -95,7 +95,7 @@ g.cwaread = function(fileName, start = 0, end = 0, progressBar = FALSE, desiredt
       # It is correct header block read information from it
       # skip 3 bytes
       readChar(fid,3,useBytes = TRUE)
-      uniqueSerialCode = readBin(fid, integer(), size = 2)
+      uniqueSerialCode = readBin(fid, integer(), size = 2, signed = FALSE)
       # skip 29 bytes and read 36th byte as frequency of measurement
       readChar(fid, 29, useBytes = TRUE)
       frequency = round( 3200 / bitwShiftL(1, 15 - bitwAnd(readBin(fid, integer(), size = 1), 15)))

--- a/tests/testthat/test_greadaccfile.R
+++ b/tests/testthat/test_greadaccfile.R
@@ -15,7 +15,7 @@ test_that("g.readaccfile and g.inspectfile can read genea and cwa file correctly
   IDH = g.getidfromheaderobject(binfile,Icwa$header,4,4)
   expect_equal(IDH,binfile)
   EHV = g.extractheadervars(Icwa)
-  expect_equal(EHV$deviceSerialNumber,"-26102")
+  expect_equal(EHV$deviceSerialNumber,"39434")
   Mcwa = g.getmeta(cwafile, desiredtz=desiredtz, windowsize = c(1,300,300))
   expect_true(Mcwa$filetooshort)
   expect_false(Mcwa$filecorrupt)


### PR DESCRIPTION
There is a problem in g.cwaread where the sensor serial number is above the signed integer range.

I have a sensor with serial number 32846, and the serial returned in the header is -32690 so it has overflowed. 

I have changed it to expect an unsigned integer, as the serial number will never be negative. 


