### PR TITLE
Issue 244 geneactiv bin loading with GGIR part 1

### DIFF
--- a/R/g.getmeta.R
+++ b/R/g.getmeta.R
@@ -414,7 +414,7 @@ g.getmeta = function(datafile,desiredtz = c(),windowsizes = c(5,900,3600),
       if (LD >= (ws*sf)) {
         if (useRDA == FALSE) {
           use = (floor(LD / (ws2*sf))) * (ws2*sf) #number of datapoint to use # changes from ws to ws2 Vvh 23/4/2017
-          if (use != LD) {
+          if ((LD - use) > 1) { #replacement of use != LD & (6-Nov-2019)
             # S = as.matrix(data[(use+1):LD,]) #Note: as.matrix removed on 22May 2019 because redundant and introduced errors when
             # reading csv files
             S = data[(use+1):LD,] #store left over

--- a/R/g.shell.GGIR.R
+++ b/R/g.shell.GGIR.R
@@ -405,7 +405,7 @@ g.shell.GGIR = function(mode=1:5,datadir=c(),outputdir=c(),studyname=c(),f0=1,f1
     } else {
       cat("Warning: First run g.shell.GGIR with mode = 4 to generate required milestone data\n")
       cat("before you can use argument visualreport or create a report for part 4\n")
-      stop()
+      # stop()
     }
   }
   if (length(which(do.report == 2)) > 0) {

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -5,7 +5,7 @@
 \section{Changes in version 1.10-8 (release date:06-11-2019)}{
 \itemize{
   \item Fixed issue that emerged in previous version with GENEActiv .bin data not
-  being processed by g.getmeta.
+  being processed by g.getmeta for all files.
   }
 }
 

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -1,6 +1,14 @@
 \name{NEWS}
 \title{News for Package \pkg{GGIR}}
 \newcommand{\cpkg}{\href{http://CRAN.R-project.org/package=#1}{\pkg{#1}}}
+
+\section{Changes in version 1.10-8 (release date:06-11-2019)}{
+\itemize{
+  \item Fixed issue that emerged in previous version with GENEActiv .bin data not
+  being processed by g.getmeta.
+  }
+}
+
 \section{Changes in version 1.10-7 (release date:06-10-2019)}{
 \itemize{
   \item Fixed functionality to supply calibration coefficients file to backup.cal.coef.

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -5,7 +5,7 @@
 \section{Changes in version 1.10-8 (release date:06-11-2019)}{
 \itemize{
   \item Fixed issue that emerged in previous version with GENEActiv .bin data not
-  being processed by g.getmeta for all files.
+  being processed by g.getmeta for some files.
   }
 }
 


### PR DESCRIPTION
Fixes issue #244 that emerged in previous version off GGIR with GENEActiv .bin data not being processed by g.getmeta for some files. It is not clear to me why the issue did not occur previously.