### PR TITLE
Fix to actigraph d m yyyy format handling

### DIFF
--- a/R/g.calibrate.R
+++ b/R/g.calibrate.R
@@ -345,7 +345,7 @@ g.calibrate = function(datafile,use.temp=TRUE,spherecrit=0.3,minloadcrit=72,prin
           QC = "recalibration not done because not enough points on all sides of the sphere"
         }
       } else {
-        cat("\nNo non-movement found\n")
+        cat(" No non-movement found\n")
         QC = "recalibration not done because no non-movement data available"
         meta_temp = c()
       }

--- a/R/g.getmeta.R
+++ b/R/g.getmeta.R
@@ -640,7 +640,7 @@ g.getmeta = function(datafile,desiredtz = c(),windowsizes = c(5,900,3600),
             minwacc = min(as.numeric(data[(1+hoc1):hoc2,jj]),na.rm=TRUE)
             CW[h,jj] = length(which(abs(as.numeric(data[(1+cliphoc1):cliphoc2,jj])) > clipthres))
             absrange = abs(maxwacc - minwacc)
-            if (is.numeric(absrange) == TRUE & is.numeric(sdwacc)) {
+            if (is.numeric(absrange) == TRUE & is.numeric(sdwacc) == TRUE & is.na(sdwacc) == FALSE) {
               if (sdwacc < sdcriter) {
                 if (absrange < racriter) {
                   NW[h,jj] = 1

--- a/R/g.getmeta.R
+++ b/R/g.getmeta.R
@@ -639,10 +639,14 @@ g.getmeta = function(datafile,desiredtz = c(),windowsizes = c(5,900,3600),
             maxwacc = max(as.numeric(data[(1+hoc1):hoc2,jj]),na.rm=TRUE)
             minwacc = min(as.numeric(data[(1+hoc1):hoc2,jj]),na.rm=TRUE)
             CW[h,jj] = length(which(abs(as.numeric(data[(1+cliphoc1):cliphoc2,jj])) > clipthres))
-            if (sdwacc < sdcriter) {
-              if (abs(maxwacc - minwacc) < racriter) {
-                NW[h,jj] = 1
+            if (length(sdwacc) > 0 & length(maxwacc) > 0 & length(minwacc) > 0) {
+              if (sdwacc < sdcriter) {
+                if (abs(maxwacc - minwacc) < racriter) {
+                  NW[h,jj] = 1
+                }
               }
+            } else {
+              NW[h,jj] = 1 # if sdwacc, maxwacc, or minwacc could not be derived then label as non-wear
             }
           }
           CW = CW / (window2) #changed 30-1-2012, was window*sf

--- a/R/g.getmeta.R
+++ b/R/g.getmeta.R
@@ -639,9 +639,10 @@ g.getmeta = function(datafile,desiredtz = c(),windowsizes = c(5,900,3600),
             maxwacc = max(as.numeric(data[(1+hoc1):hoc2,jj]),na.rm=TRUE)
             minwacc = min(as.numeric(data[(1+hoc1):hoc2,jj]),na.rm=TRUE)
             CW[h,jj] = length(which(abs(as.numeric(data[(1+cliphoc1):cliphoc2,jj])) > clipthres))
-            if (length(sdwacc) > 0 & length(maxwacc) > 0 & length(minwacc) > 0) {
+            absrange = abs(maxwacc - minwacc)
+            if (is.numeric(absrange) == TRUE & is.numeric(sdwacc)) {
               if (sdwacc < sdcriter) {
-                if (abs(maxwacc - minwacc) < racriter) {
+                if (absrange < racriter) {
                   NW[h,jj] = 1
                 }
               }

--- a/R/g.getstarttime.R
+++ b/R/g.getstarttime.R
@@ -132,8 +132,8 @@ g.getstarttime = function(datafile,P,header,mon,dformat,desiredtz,selectdaysfile
       if (fc$mdy == 1 & fc$bdy == 1) fc$mdy = 0 # not M(M) when MMM is also detected for yy
       fc$dmY = length(grep("d[.]M[.]yyyy|d[.]MM[.]yyyy",topline))
       fc$dmy = length(grep("d[.]M[.]yy|d[.]MM[.]yy",topline))
-      fc$dbY = length(grep("d[.]M[.]yyyy|d[.]MMM[.]yyyy",topline))
-      fc$dby = length(grep("d[.]M[.]yy|d[.]MMM[.]yy",topline))
+      fc$dbY = length(grep("d[.]MMM[.]yyyy",topline))
+      fc$dby = length(grep("d[.]MMM[.]yy",topline))
       if (fc$dmY == 1 & fc$dmy == 1) fc$dmy = 0 # not yy when yyyy is also detected
       if (fc$dbY == 1 & fc$dby == 1) fc$dby = 0 # not yy when yyyy is also detected
       if (fc$dmY == 1 & fc$dbY == 1) fc$dmY = 0 # not M(M) when MMM is also detected for yyyy

--- a/R/g.readaccfile.R
+++ b/R/g.readaccfile.R
@@ -281,7 +281,7 @@ g.readaccfile = function(filename,blocksize,blocknumber,selectdaysfile=c(),fileq
                           dec=decn,showProgress = FALSE, header = freadheader))
     },silent=TRUE)
     if (length(P) > 1) {
-      P = as.matrix(P)
+      P = data.matrix(P) # as.matrix turned num to char if there are missing values.
       if (nrow(P) < ((sf*ws*2)+1) & blocknumber == 1) {
         P = c() ; switchoffLD = 1 #added 30-6-2012
         filequality$filetooshort = TRUE


### PR DESCRIPTION
- This fixes a bug in the handling of the d m yyyy date in Actigraph data. This bug was introduced in the merged branch: issue240_actigraph_date_format, which is not part of the GGIR version on CRAN yet.
- Also I made the non-wear detection code robust to acceleration data with zero variance and zero value range, which seems to occur in Actigraph occasionally (clearly they are heavily filtering the signals).