### PR TITLE
update isfilelist.R to treat single .cwa file as isfilelist=TRUE

### DIFF
--- a/R/isfilelist.R
+++ b/R/isfilelist.R
@@ -5,6 +5,7 @@ isfilelist = function(datadir) {
     if (length(unlist(strsplit(datadir,"[.]bi")))>1) filelist = TRUE
     if (length(unlist(strsplit(datadir,"[.]cs")))>1) filelist = TRUE
     if (length(unlist(strsplit(datadir,"[.]wa")))>1) filelist = TRUE
+    if (length(unlist(strsplit(datadir,"[.]cw")))>1) filelist = TRUE #XD added this line to make it possible to process single cwa file
   } else { #multiple files
     filelist = TRUE    
   }


### PR DESCRIPTION
Hi Vincent @vincentvanhees,

This is Xiangnan. 

I'm making a small change on the isfilelist.R, to allow single ".cwa" file from ax3 treated as filelist, as already implemented for .csv, .bin, and .wav. This will allow a single .cwa file to be used for "datadir" argument.

Best,
Xiangnan