### PR TITLE
fix minor issues when working with custom csv files

### DIFF
--- a/R/g.extractheadervars.R
+++ b/R/g.extractheadervars.R
@@ -48,12 +48,12 @@ g.extractheadervars = function(I) {
     }
     iid = "not extracted" #investigator id
     HN = "not extracted" #handedness
-    BL = "not extracted" #body location
+    BodyLocation = "not extracted" #body location
     SX = "not extracted" #gender
     if (length(which(hnames == "device_serial_number")) > 0) {
-      SN = hvalues[which(hnames == "device_serial_number")]			 #serial number
+      deviceSerialNumber = hvalues[which(hnames == "device_serial_number")]			 #serial number
     } else {
-      SN = "not extracted" #gender
+      deviceSerialNumber = "not extracted" #gender
     }
   }
   invisible(list(id=id,iid=iid,HN=HN,BodyLocation=BodyLocation,SX=SX,deviceSerialNumber=deviceSerialNumber)) #  wdayname=wdayname,wdaycode=wdaycode,wday=wday,ws3=ws3,ws2=ws2

--- a/R/g.getmeta.R
+++ b/R/g.getmeta.R
@@ -281,14 +281,16 @@ g.getmeta = function(datafile,desiredtz = "",windowsizes = c(5,900,3600),
           data = P #as.matrix(P,dimnames = list(rownames(P),colnames(P)))
         } else if (dformat == 3) {
           data = P$rawxyz
-        } else if (dformat == 4  | dformat == 5) {
-          if (dformat == 4 & P$header$hardwareType == "AX6") { # cwa AX6
+        } else if (dformat == 4) {
+          if (P$header$hardwareType == "AX6") { # cwa AX6
             # Note 18-Feb-2020: For the moment GGIR ignores the AX6 gyroscope signals until robust sensor
             # fusion algorithms and gyroscope metrics have been prepared
             data = P$data[,-c(2:4)]
           } else { # cwa AX3
             data = P$data
           }
+        } else if (dformat == 5) {
+          data = P$data
         }
         #add left over data from last time
         if (nrow(S) > 0) {


### PR DESCRIPTION
Hi Vincent @vincentvanhees ,

I was setting up a data flow to use GGIR with our data in plain csv format with four columns and no headers, generated by a different brand not handled in this package. Luckily, GGIR has this function in mind already, with rmc.* arguments, as well as dformat=5 and mon=5 branches. 

During the setup, I encountered and solved two errors before the data flow is running. I'm submitting this pull request to fix the following two issues:

1. In g.getmeta.R, the logic is only slightly changed, and in fact the changed logic now is the exact same as a counterpart in g.calibrate.R. Specifically, in this part: 
else if (dformat == 4  | dformat == 5) {
          if (dformat == 4 & P$header$hardwareType == "AX6")
if dformat==5 as the custom csv, it will still try to assess P$header$hardwareType == "AX6", raising error as there's no "header" in "P". this can be fixed in multiple ways, and I chose to make this logic consistent with the same one in g.calibrate.R.

2. in g.extractheadervars.R, there was a couple of obvious issues that towards the end in the csv file handling section, "BL" needed to change to "BodyLocation" and "SN" needed to change to "deviceSerialNumber" to be consistent with the object as output.

After I fixed these two issues, the package runs smoothly for the custom csv files we have.

Let me know if you find any issues with this pull request, or need any additional modifications.

Best,
Xiangnan