### PR TITLE
fix bug in daysleeper detection

### DIFF
--- a/R/g.sib.det.R
+++ b/R/g.sib.det.R
@@ -312,8 +312,9 @@ g.sib.det = function(M,IMP,I,twd=c(-12,12),anglethreshold = 5,
           if (length(inbedout$sptwindow_HDCZA_end) != 0 & length(inbedout$sptwindow_HDCZA_start) != 0) {
             if (inbedout$sptwindow_HDCZA_end+qqq1 >= qqq2-(1*(3600/ws3))) {
               # if estimated SPT ends within one hour of noon, re-run with larger window to be able to detect daysleepers
-              newqqq1 = qqq1+(6*(3600/ws3))
-              newqqq2 = qqq2+(6*(3600/ws3))
+              daysleep_offset = 6 # hours in which the window of data sent to HDCZA is moved fwd from noon
+              newqqq1 = qqq1+(daysleep_offset*(3600/ws3))
+              newqqq2 = qqq2+(daysleep_offset*(3600/ws3))
               if (newqqq2 > length(angle)) newqqq2 = length(angle)
               # only try to extract SPT again if it is possible to extrat a window of more than there is more than 23 hour
               if (newqqq1 < length(angle) & (newqqq2 - newqqq1) > (23*(3600/ws3)) ) {
@@ -324,21 +325,17 @@ g.sib.det = function(M,IMP,I,twd=c(-12,12),anglethreshold = 5,
                   inbedout$sptwindow_HDCZA_start = (newqqq2-newqqq1)-1
                 }
               }
+            } else {
+              daysleep_offset = 0
             }
-            # if(j == 1 & midnightsi[j] == 1) {
-            #   sptwindow_HDCZA_end[j] = (inbedout$sptwindow_HDCZA_end/(3600/ws3))
-            #   sptwindow_HDCZA_start[j] = (inbedout$sptwindow_HDCZA_start/(3600/ws3))
-            # } else if(j == 1 & midnightsi[j] != 1){   #added 02/12/2019. First night get shifted start and end bedtimes depending on the initial time
             if (qqq1 == 1) {  # only use startTimeRecord if the start of the block send into HDCZA was after noon
-            #if (j == 1){   #added 02/12/2019. First night get shifted start and end bedtimes depending on the initial time
               startTimeRecord = unlist(iso8601chartime2POSIX(IMP$metashort$timestamp[1], tz = desiredtz))
               startTimeRecord = sum(as.numeric(startTimeRecord[c("hour","min","sec")]) / c(1,60,3600))
               sptwindow_HDCZA_end[j] = (inbedout$sptwindow_HDCZA_end/(3600/ws3)) + startTimeRecord
               sptwindow_HDCZA_start[j] = (inbedout$sptwindow_HDCZA_start/(3600/ws3)) + startTimeRecord
             } else {
-            #} else  if(j != 1) {
-              sptwindow_HDCZA_end[j] = (inbedout$sptwindow_HDCZA_end/(3600/ws3)) + 12
-              sptwindow_HDCZA_start[j] = (inbedout$sptwindow_HDCZA_start/(3600/ws3)) + 12
+              sptwindow_HDCZA_end[j] = (inbedout$sptwindow_HDCZA_end/(3600/ws3)) + 12 + daysleep_offset
+              sptwindow_HDCZA_start[j] = (inbedout$sptwindow_HDCZA_start/(3600/ws3)) + 12 + daysleep_offset
             }
             sptwindow_HDCZA_end[j] = dstime_handling_check(tmpTIME=tmpTIME,inbedout=inbedout,
                                                 tz=desiredtz,calc_sptwindow_HDCZA_end=sptwindow_HDCZA_end[j],

--- a/R/g.sib.det.R
+++ b/R/g.sib.det.R
@@ -306,6 +306,7 @@ g.sib.det = function(M,IMP,I,twd=c(-12,12),anglethreshold = 5,
           # Estimate Sleep Period Time window, because this will be used by g.part4 if sleeplog is not available
           tmpANGLE = angle[qqq1:qqq2]
           tmpTIME = time[qqq1:qqq2]
+          daysleep_offset = 0
           inbedout = sptwindow_HDCZA(tmpANGLE,ws3=ws3,constrain2range=constrain2range,
                                      perc = perc, inbedthreshold = inbedthreshold,
                                      bedblocksize = bedblocksize, outofbedsize = outofbedsize)
@@ -325,9 +326,7 @@ g.sib.det = function(M,IMP,I,twd=c(-12,12),anglethreshold = 5,
                   inbedout$sptwindow_HDCZA_start = (newqqq2-newqqq1)-1
                 }
               }
-            } else {
-              daysleep_offset = 0
-            }
+            } 
             if (qqq1 == 1) {  # only use startTimeRecord if the start of the block send into HDCZA was after noon
               startTimeRecord = unlist(iso8601chartime2POSIX(IMP$metashort$timestamp[1], tz = desiredtz))
               startTimeRecord = sum(as.numeric(startTimeRecord[c("hour","min","sec")]) / c(1,60,3600))


### PR DESCRIPTION
Fixes #324 

Small bug fix to ensure that correct start block time is used when performing daysleeper detection

Cleaned up some of the legacy code that was commented out as well.

@vincentvanhees - not sure if you want this fix into v2.1-0 or not, I put it here for now, but let me know if you'd rather hold off and save it for the next release. Is a relatively small fix, so hopefully ok for this release.