### PR TITLE
fix plot5 error when minute was set to 60 instead of 0 

### DIFF
--- a/R/g.plot5.R
+++ b/R/g.plot5.R
@@ -391,14 +391,13 @@ g.plot5 = function(metadatadir=c(),dofirstpage=FALSE, viewingwindow = 1,f0=c(),f
             
             check_date = match(curr_date,sleep_dates)
             if (is.na(check_date) == FALSE) {
-              #sleeponset_time = summarysleep_tmp$sleeponset_ts[check_date]  # get the time of sleep_onset
               sleeponset_time = summarysleep_tmp$sleeponset[check_date]  # get the time of sleep_onset
-              #if (sleeponset_time < 24) {
               if (sleeponset_time >= sw_coefs[1] & sleeponset_time < sw_coefs[2]) {
                 sleeponset_hour = trunc(sleeponset_time)
                 if (sleeponset_hour == 24) sleeponset_hour = 0
                 if (sleeponset_hour > 24) sleeponset_hour = sleeponset_hour - 24 # only with viewingwindow==2
                 sleeponset_min = round((sleeponset_time - trunc(sleeponset_time)) * 60)
+                if (sleeponset_min == 60) sleeponset_min = 0
                 sleeponset_locations = which(hour[t0:t1] == sleeponset_hour & min_vec[t0:t1] == sleeponset_min)
                 if (!is.na(sleeponset_locations[1])) { 
                   sleeponset_loc = sleeponset_locations[1]
@@ -407,13 +406,13 @@ g.plot5 = function(metadatadir=c(),dofirstpage=FALSE, viewingwindow = 1,f0=c(),f
               
               wake_time = summarysleep_tmp$wakeup[check_date]
               if (wake_time >= sw_coefs[1] & wake_time < sw_coefs[2]) {
-              #if (wake_time < 24) {
                 wake_hour = trunc(wake_time)
                 if (wake_hour == 24) wake_hour = 0
                 if (wake_hour > 24) {
                   wake_hour = wake_hour - 24
                 }
                 wake_min = round((wake_time - trunc(wake_time)) * 60)
+                if (wake_min == 60) wake_min = 0
                 wake_locations = which(hour[t0:t1] == wake_hour & min_vec[t0:t1] == wake_min)
                 if (!is.na(wake_locations[1])) {
                   wake_loc = wake_locations[1]
@@ -427,12 +426,9 @@ g.plot5 = function(metadatadir=c(),dofirstpage=FALSE, viewingwindow = 1,f0=c(),f
             if (is.na(check_date) == FALSE) {
               wake_time = summarysleep_tmp$wakeup[check_date]
               if (wake_time >= sw_coefs[2]) {
-              #if (wake_time > 24) {
                 wake_hour = trunc(wake_time) - 24
-              #  if (viewingwindow==2) {
-              #    wake_hour = wake_hour + 24
-              #  }
                 wake_min = round((wake_time - trunc(wake_time)) * 60)
+                if (wake_min == 60) wake_min = 0
                 wake_locations = which(hour[t0:t1] == wake_hour & min_vec[t0:t1] == wake_min)
                 if (wake_loc > 0) {
                   if (!is.na(wake_locations[1])) {
@@ -448,9 +444,9 @@ g.plot5 = function(metadatadir=c(),dofirstpage=FALSE, viewingwindow = 1,f0=c(),f
               # new way 
               sleeponset_time = summarysleep_tmp$sleeponset[check_date]
               if (sleeponset_time >= sw_coefs[2]) {
-              #if (sleeponset_time > 24) {
                 sleeponset_hour = trunc(sleeponset_time) - 24
                 sleeponset_min = round((sleeponset_time - trunc(sleeponset_time)) * 60)
+                if (sleeponset_min == 60) sleeponset_min = 0
                 sleeponset_locations = which(hour[t0:t1] == sleeponset_hour & min_vec[t0:t1] == sleeponset_min)
                 if (sleeponset_loc > 0) {
                   if (!is.na(sleeponset_locations[1])) {
@@ -467,10 +463,7 @@ g.plot5 = function(metadatadir=c(),dofirstpage=FALSE, viewingwindow = 1,f0=c(),f
             if (viewingwindow==2) {
               next_day = curr_date + 1
               check_date = match(next_day,sleep_dates)
-              
-              
             }
-            
 
             # add extensions if <24hr of data
             first_day_adjust = 0 # hold adjustment amounts on first and last day plots


### PR DESCRIPTION
Fixes wadpac/GGIR #336 

Added lines of code to handle minute extraction when they ended up being 60, set them to 0 instead, so the code can locate the proper index for plotting either sleeponset or wakeup time in plot5.

Cleaned up some of the code as well.