### PR TITLE
Additional fix to SPT window detection in daysleepers

### DIFF
--- a/R/g.sib.det.R
+++ b/R/g.sib.det.R
@@ -10,7 +10,6 @@ g.sib.det = function(M,IMP,I,twd=c(-12,12),anglethreshold = 5,
       angvar = stats::median(abs(diff(angle))) #50th percentile, do not use mean because that will be outlier dependent
       return(angvar)
     }
-
     x = zoo::rollapply(angle, k, medabsdi) # 5 minute rolling median of the absolute difference
     nomov = rep(0,length(x)) # no movement
     inbedtime = rep(NA,length(x))
@@ -102,7 +101,6 @@ g.sib.det = function(M,IMP,I,twd=c(-12,12),anglethreshold = 5,
         calc_sptwindow_HDCZA_end = calc_sptwindow_HDCZA_end + 1
       }
     }
-
     return(calc_sptwindow_HDCZA_end)
   }
   #==================================================
@@ -155,7 +153,6 @@ g.sib.det = function(M,IMP,I,twd=c(-12,12),anglethreshold = 5,
         getSleepFromExternalFunction = TRUE
       }
     }
-
     angle[which(is.na(angle) == T)] = 0
     if (getSleepFromExternalFunction == FALSE) {
       cnt = 1
@@ -202,7 +199,6 @@ g.sib.det = function(M,IMP,I,twd=c(-12,12),anglethreshold = 5,
     midnights=detemout$midnights
     midnightsi=detemout$midnightsi
     countmidn = length(midnightsi)
-
     tib.threshold = sptwindow_HDCZA_end = sptwindow_HDCZA_start = L5list = rep(NA,countmidn)
     if (countmidn != 0) {
       if (countmidn == 1) {
@@ -227,6 +223,7 @@ g.sib.det = function(M,IMP,I,twd=c(-12,12),anglethreshold = 5,
         if (length(inbedout$sptwindow_HDCZA_end) != 0 & length(inbedout$sptwindow_HDCZA_start) != 0) {
           if (inbedout$sptwindow_HDCZA_end+qqq1 >= qqq2-(1*(3600/ws3))) {
             # if estimated SPT ends within one hour of noon, re-run with larger window to be able to detect daysleepers
+            daysleep_offset = 6 # hours in which the window of data sent to HDCZA is moved fwd from noon
             newqqq1 = qqq1+(6*(3600/ws3))
             newqqq2 = qqq2+(6*(3600/ws3))
             if (newqqq2 > length(angle)) newqqq2 = length(angle)
@@ -238,20 +235,24 @@ g.sib.det = function(M,IMP,I,twd=c(-12,12),anglethreshold = 5,
               if (inbedout$sptwindow_HDCZA_start+newqqq1 >= newqqq2) {
                 inbedout$sptwindow_HDCZA_start = (newqqq2-newqqq1)-1
               }
+            } else {
+              daysleep_offset  = 0
             }
           }
-
-          startTimeRecord = unlist(iso8601chartime2POSIX(IMP$metashort$timestamp[1], tz = desiredtz))
-          startTimeRecord = sum(as.numeric(startTimeRecord[c("hour","min","sec")]) / c(1,60,3600))
-          sptwindow_HDCZA_end[1] = inbedout$sptwindow_HDCZA_end/(3600/ws3) + startTimeRecord
-          sptwindow_HDCZA_start[1] = inbedout$sptwindow_HDCZA_start/(3600/ws3)  + startTimeRecord
+          if (qqq1 == 1) {  # only use startTimeRecord if the start of the block send into HDCZA was after noon
+            startTimeRecord = unlist(iso8601chartime2POSIX(IMP$metashort$timestamp[1], tz = desiredtz))
+            startTimeRecord = sum(as.numeric(startTimeRecord[c("hour","min","sec")]) / c(1,60,3600))
+            sptwindow_HDCZA_end[1] = inbedout$sptwindow_HDCZA_end/(3600/ws3) + startTimeRecord
+            sptwindow_HDCZA_start[1] = inbedout$sptwindow_HDCZA_start/(3600/ws3)  + startTimeRecord
+          } else {
+            sptwindow_HDCZA_end[1] = (inbedout$sptwindow_HDCZA_end/(3600/ws3)) + 12 + daysleep_offset
+            sptwindow_HDCZA_start[1] = (inbedout$sptwindow_HDCZA_start/(3600/ws3)) + 12 + daysleep_offset
+          }
           sptwindow_HDCZA_end[1] = dstime_handling_check(tmpTIME=tmpTIME,inbedout=inbedout,
-                                              tz=desiredtz,calc_sptwindow_HDCZA_end=sptwindow_HDCZA_end[1],
-                                              calc_sptwindow_HDCZA_start=sptwindow_HDCZA_start[1])
+                                                         tz=desiredtz,calc_sptwindow_HDCZA_end=sptwindow_HDCZA_end[1],
+                                                         calc_sptwindow_HDCZA_start=sptwindow_HDCZA_start[1])
           tib.threshold[1] = inbedout$tib.threshold
         }
-
-
         #------------------------------------------------------------------
         # calculate L5 because this is used in case the sleep diary is not available (added 17-11-2014)
         tmpACC = ACC[qqq1:qqq2]
@@ -313,18 +314,20 @@ g.sib.det = function(M,IMP,I,twd=c(-12,12),anglethreshold = 5,
           if (length(inbedout$sptwindow_HDCZA_end) != 0 & length(inbedout$sptwindow_HDCZA_start) != 0) {
             if (inbedout$sptwindow_HDCZA_end+qqq1 >= qqq2-(1*(3600/ws3))) {
               # if estimated SPT ends within one hour of noon, re-run with larger window to be able to detect daysleepers
+              daysleep_offset = 6 # hours in which the window of data sent to HDCZA is moved fwd from noon
               newqqq1 = qqq1+(daysleep_offset*(3600/ws3))
               newqqq2 = qqq2+(daysleep_offset*(3600/ws3))
               if (newqqq2 > length(angle)) newqqq2 = length(angle)
               # only try to extract SPT again if it is possible to extrat a window of more than there is more than 23 hour
               if (newqqq1 < length(angle) & (newqqq2 - newqqq1) > (23*(3600/ws3)) ) {
-                daysleep_offset = 6 # hours in which the window of data sent to HDCZA is moved fwd from noon
                 inbedout = sptwindow_HDCZA(angle[newqqq1:newqqq2],ws3=ws3,constrain2range=constrain2range,
                                            perc = perc, inbedthreshold = inbedthreshold, bedblocksize = bedblocksize,
                                            outofbedsize = outofbedsize)
                 if (inbedout$sptwindow_HDCZA_start+newqqq1 >= newqqq2) {
                   inbedout$sptwindow_HDCZA_start = (newqqq2-newqqq1)-1
                 }
+              } else {
+                daysleep_offset  = 0
               }
             } 
             if (qqq1 == 1) {  # only use startTimeRecord if the start of the block send into HDCZA was after noon

--- a/R/g.sib.det.R
+++ b/R/g.sib.det.R
@@ -224,8 +224,8 @@ g.sib.det = function(M,IMP,I,twd=c(-12,12),anglethreshold = 5,
           if (inbedout$sptwindow_HDCZA_end+qqq1 >= qqq2-(1*(3600/ws3))) {
             # if estimated SPT ends within one hour of noon, re-run with larger window to be able to detect daysleepers
             daysleep_offset = 6 # hours in which the window of data sent to HDCZA is moved fwd from noon
-            newqqq1 = qqq1+(6*(3600/ws3))
-            newqqq2 = qqq2+(6*(3600/ws3))
+            newqqq1 = qqq1+(daysleep_offset*(3600/ws3))
+            newqqq2 = qqq2+(daysleep_offset*(3600/ws3))
             if (newqqq2 > length(angle)) newqqq2 = length(angle)
             # only try to extract SPT again if it is possible to extrat a window of more than there is more than 23 hour
             if (newqqq1 < length(angle) & (newqqq2 - newqqq1) > (23*(3600/ws3)) ) {

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -2,10 +2,11 @@
 \title{News for Package \pkg{GGIR}}
 \newcommand{\cpkg}{\href{http://CRAN.R-project.org/package=#1}{\pkg{#1}}}
 
-\section{Changes in version 2.1-2 (GitHub-only-release date:15-09-2020)}{
+\section{Changes in version 2.1-2 (GitHub-only-release date:25-09-2020)}{
 \itemize{
   \item Part 5 bug fixed with day name and date allocation for daysleepers for MM report
   \item Fix bug part 4 and 5 with missing nights which are not accounted for when assessing max night number.
+  \item Fix bug part 3 introduced in version 2.1-0 re. SPT detection for daysleepers.
 }
 }
 


### PR DESCRIPTION
PR #325 attempted to improve the SPT detection for daysleeprs. At the time it seemed everything worked well. However, I have now encountered a recording where the detection goes wrong. The person in the recording is a 'daysleeper' for most of the days and SPT window is estimated on those days to end after 6pm rather than somewhere in the afternoon.

It seems this is because `daysleep_offset` is assigned to zero after `newqqq1` and `newqqq2` are calculated, by which the calculations that follow are half based on daysleep_offset = 0 and half based on daysleep_offset = 6. The result is that the end of SPT is 6 hours late.

To address this I have now re-ordered the code to use a consistent value for `daysleep_offset` in the calculation of SPT, and reverse to zero if the procedure is not used. Further, I have copied the whole procedure to the SPT estimation for recordings where there is only 1 night, which is done at the top of the function.

@m-patterson would you mind reviewing this as you made PR #325. Thanks.