### PR TITLE
Issue352 includeddays

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: GGIR
 Type: Package
 Title: Raw Accelerometer Data Analysis
-Version: 2.1-1
-Date: 2020-09-07
+Version: 2.1-2
+Date: 2020-09-15
 Authors@R: c(person("Vincent T","van Hees",role=c("aut","cre"),
                   email="v.vanhees@accelting.com"),
                   person("Zhou","Fang",role="ctb"),

--- a/R/g.part5.R
+++ b/R/g.part5.R
@@ -347,11 +347,11 @@ g.part5 = function(datadir=c(),metadatadir=c(),f0=c(),f1=c(),strategy=1,maxdur=7
                                                                           nightsi <= (startend_sleep[length(startend_sleep)] + Nepochsin12Hours)]  # newly added on 25-11-2019
                                                       #nightsi = nightsi[which(nightsi >= startend_sleep[1] & nightsi <= startend_sleep[length(startend_sleep)])]
                                                     }
-                                                    if (timewindowi == "MM") {
-                                                      Nwindows = nrow(summarysleep_tmp2)
-                                                    } else {
+                                                    #if (timewindowi == "MM") {
+                                                    #  Nwindows = nrow(summarysleep_tmp2)
+                                                    #} else {
                                                       Nwindows = length(which(diff(ts$diur) == -1))
-                                                    }
+                                                    #}
                                                     indjump = 1
                                                     qqq_backup = c()
                                                     add_one_day_to_next_date = FALSE

--- a/R/g.part5.R
+++ b/R/g.part5.R
@@ -358,7 +358,7 @@ g.part5 = function(datadir=c(),metadatadir=c(),f0=c(),f1=c(),strategy=1,maxdur=7
                                                     add_one_day_to_next_date = FALSE
                                                     for (wi in 1:Nwindows) { #loop through 7 windows (+1 to include the data after last awakening)
                                                       # Define indices of start and end of the day window (e.g. midnight-midnight, or waking-up or wakingup
-                                                      defdays = g.part5.definedays(nightsi, wi, summarysleep_tmp2, indjump,
+                                                      defdays = g.part5.definedays(nightsi, wi, indjump,
                                                                                    nightsi_bu, ws3new, qqq_backup, ts, Nts,
                                                                                    timewindowi, Nwindows)
                                                       qqq = defdays$qqq

--- a/R/g.part5.R
+++ b/R/g.part5.R
@@ -347,11 +347,12 @@ g.part5 = function(datadir=c(),metadatadir=c(),f0=c(),f1=c(),strategy=1,maxdur=7
                                                                           nightsi <= (startend_sleep[length(startend_sleep)] + Nepochsin12Hours)]  # newly added on 25-11-2019
                                                       #nightsi = nightsi[which(nightsi >= startend_sleep[1] & nightsi <= startend_sleep[length(startend_sleep)])]
                                                     }
-                                                    #if (timewindowi == "MM") {
+                                                    if (timewindowi == "MM") {
                                                     #  Nwindows = nrow(summarysleep_tmp2)
-                                                    #} else {
+                                                      Nwindows = length(which(diff(ts$diur) == -1)) + 1
+                                                    } else {
                                                       Nwindows = length(which(diff(ts$diur) == -1))
-                                                    #}
+                                                    }
                                                     indjump = 1
                                                     qqq_backup = c()
                                                     add_one_day_to_next_date = FALSE

--- a/R/g.part5.definedays.R
+++ b/R/g.part5.definedays.R
@@ -1,4 +1,4 @@
-g.part5.definedays = function(nightsi, wi, summarysleep_tmp2, indjump, nightsi_bu, 
+g.part5.definedays = function(nightsi, wi, indjump, nightsi_bu, 
                               ws3new, qqq_backup=c(), ts, Nts, timewindowi, Nwindows) {
   
   
@@ -13,11 +13,11 @@ g.part5.definedays = function(nightsi, wi, summarysleep_tmp2, indjump, nightsi_b
       if (wi==1) {
         qqq[1] = 1
         qqq[2] = nightsi[wi]
-      } else if (wi<=nrow(summarysleep_tmp2)) {
+      } else if (wi<=length(nightsi)) {
         qqq[1] = nightsi[wi-1] + 1
         qqq[2] = nightsi[wi]
         qqq_backup = qqq
-      } else if (wi>nrow(summarysleep_tmp2)) {
+      } else if (wi>length(nightsi)) {
         qqq[1] = qqq_backup[2] + 1
         if (wi <= length(nightsi)) {
           qqq[2] = nightsi[wi]

--- a/R/g.part5.wakesleepwindows.R
+++ b/R/g.part5.wakesleepwindows.R
@@ -110,31 +110,32 @@ g.part5.wakesleepwindows = function(ts, summarysleep_tmp2, desiredtz, nightsi, s
         # If non-wear is high for this day and if sleeplog is available
         sleeplogonset = sleeplog$sleeponset[which(sleeplog$ID == ID & sleeplog$night == summarysleep_tmp2$night[k])]
         sleeplogwake = sleeplog$sleepwake[which(sleeplog$ID == ID & sleeplog$night == summarysleep_tmp2$night[k])]
-        if (length(sleeplogonset) != 0 & !is.na(sleeplogonset) &
-            length(sleeplogwake) != 0 & !is.na(sleeplogwake)) {
-          # ... and if there is sleeplog data for the relevant night
-          # rely on sleeplog for defining the start and end of the night
-          sleeplogonset_hr = clock2numtime(sleeplogonset)
-          sleeplogwake_hr= clock2numtime(sleeplogwake)
-          # express hour relative to midnight within the noon-noon:
-          if (sleeplogonset_hr > 12) {
-            sleeplogonset_hr = sleeplogonset_hr - 24
+        if (length(sleeplogonset) != 0 & length(sleeplogwake) != 0) {
+          if (!is.na(sleeplogonset) &  !is.na(sleeplogwake)) {
+            # ... and if there is sleeplog data for the relevant night
+            # rely on sleeplog for defining the start and end of the night
+            sleeplogonset_hr = clock2numtime(sleeplogonset)
+            sleeplogwake_hr= clock2numtime(sleeplogwake)
+            # express hour relative to midnight within the noon-noon:
+            if (sleeplogonset_hr > 12) {
+              sleeplogonset_hr = sleeplogonset_hr - 24
+            }
+            if (sleeplogwake_hr > 18 & summarysleep_tmp2$daysleeper[k] == 1) {
+              sleeplogwake_hr = sleeplogwake_hr - 24 # 18 because daysleepers can wake up after 12
+            } else if (sleeplogwake_hr > 12 & summarysleep_tmp2$daysleeper[k] == 0) {
+              sleeplogwake_hr = sleeplogwake_hr - 24
+            }
+            if (sleeplogwake_hr > 36 &  sleeplogonset_hr > 36) {
+              sleeplogwake_hr = sleeplogwake_hr - 24
+              sleeplogonset_hr = sleeplogonset_hr - 24
+            }
+            s0 = closestmidnight + round(sleeplogonset_hr * Nepochsinhour)
+            if (s0 < 1) {
+              warning("Impossible index for first night, consider setting excludefirst.part4=TRUE")
+              s0 = 1
+            }
+            s1 = closestmidnight + round(sleeplogwake_hr * Nepochsinhour)
           }
-          if (sleeplogwake_hr > 18 & summarysleep_tmp2$daysleeper[k] == 1) {
-            sleeplogwake_hr = sleeplogwake_hr - 24 # 18 because daysleepers can wake up after 12
-          } else if (sleeplogwake_hr > 12 & summarysleep_tmp2$daysleeper[k] == 0) {
-            sleeplogwake_hr = sleeplogwake_hr - 24
-          }
-          if (sleeplogwake_hr > 36 &  sleeplogonset_hr > 36) {
-            sleeplogwake_hr = sleeplogwake_hr - 24
-            sleeplogonset_hr = sleeplogonset_hr - 24
-          }
-          s0 = closestmidnight + round(sleeplogonset_hr * Nepochsinhour)
-          if (s0 < 1) {
-            warning("Impossible index for first night, consider setting excludefirst.part4=TRUE")
-            s0 = 1
-          }
-          s1 = closestmidnight + round(sleeplogwake_hr * Nepochsinhour)
         }
       }
       ts$diur[s0:(s1-1)] = 1

--- a/R/g.part5.wakesleepwindows.R
+++ b/R/g.part5.wakesleepwindows.R
@@ -110,7 +110,8 @@ g.part5.wakesleepwindows = function(ts, summarysleep_tmp2, desiredtz, nightsi, s
         # If non-wear is high for this day and if sleeplog is available
         sleeplogonset = sleeplog$sleeponset[which(sleeplog$ID == ID & sleeplog$night == summarysleep_tmp2$night[k])]
         sleeplogwake = sleeplog$sleepwake[which(sleeplog$ID == ID & sleeplog$night == summarysleep_tmp2$night[k])]
-        if (length(sleeplogonset) != 0 & length( sleeplogwake) != 0) {
+        if (length(sleeplogonset) != 0 & !is.na(sleeplogonset) &
+            length(sleeplogwake) != 0 & !is.na(sleeplogwake)) {
           # ... and if there is sleeplog data for the relevant night
           # rely on sleeplog for defining the start and end of the night
           sleeplogonset_hr = clock2numtime(sleeplogonset)

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -6,6 +6,8 @@
 \itemize{
   \item Part 5 bug fixed with day name and date allocation for daysleepers for MM report
   \item Fix bug part 4 and 5 with missing nights which are not accounted for when assessing max night number.
+  \item Part 5 Nwindows redefined for MM output
+
 }
 }
 

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -2,12 +2,11 @@
 \title{News for Package \pkg{GGIR}}
 \newcommand{\cpkg}{\href{http://CRAN.R-project.org/package=#1}{\pkg{#1}}}
 
-\section{Changes in version 2.1-2 (GitHub-only-release date:15-09-2020)}{
+\section{Changes in version 2.1-2 (GitHub-only-release date:25-09-2020)}{
 \itemize{
   \item Part 5 bug fixed with day name and date allocation for daysleepers for MM report
-  \item Fix bug part 4 and 5 with missing nights which are not accounted for when assessing max night number.  
+  \item Fix bug part 4 and 5 with missing nights which are not accounted for when assessing max night number.
   \item Fix bug part 3 introduced in version 2.1-0 re. SPT detection for daysleepers.
-  \item Part 5 Nwindows redefined for MM output
 }
 }
 

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -7,7 +7,6 @@
   \item Part 5 bug fixed with day name and date allocation for daysleepers for MM report
   \item Fix bug part 4 and 5 with missing nights which are not accounted for when assessing max night number.
   \item Part 5 Nwindows redefined for MM output
-
 }
 }
 

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -5,7 +5,8 @@
 \section{Changes in version 2.1-2 (GitHub-only-release date:15-09-2020)}{
 \itemize{
   \item Part 5 bug fixed with day name and date allocation for daysleepers for MM report
-  \item Fix bug part 4 and 5 with missing nights which are not accounted for when assessing max night number.
+  \item Fix bug part 4 and 5 with missing nights which are not accounted for when assessing max night number.  
+  \item Fix bug part 3 introduced in version 2.1-0 re. SPT detection for daysleepers.
   \item Part 5 Nwindows redefined for MM output
 }
 }

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -7,6 +7,7 @@
   \item Part 5 bug fixed with day name and date allocation for daysleepers for MM report
   \item Fix bug part 4 and 5 with missing nights which are not accounted for when assessing max night number.
   \item Fix bug part 3 introduced in version 2.1-0 re. SPT detection for daysleepers.
+  \item Fix redefinition of the time windows (with "MM") in part 5 to include all recording days when the measurement starts with multiple non-wear days.
 }
 }
 


### PR DESCRIPTION
I found that the MM personSummary output skips the last days of measurement when the data recording starts with some days of non-wear. In g.part5, line 351, the Nwindows definition for "MM" was the number of nights included in the nightsummary of part 4. This included the first non-wear days and then stopped before than expected. Now, I have re-defined the Nwindows as in the "WW" report plus one extra day to account for differences between timewindows.