### PR TITLE
Issue303 and minor other things

### DIFF
--- a/R/g.getbout.R
+++ b/R/g.getbout.R
@@ -98,6 +98,33 @@ g.getbout = function(x,boutduration,boutcriter=0.8,closedbout=FALSE,bout.metric=
     x[xt != 2] = 0
     x[xt == 2] = 1
     boutcount = x
+  }  else if (bout.metric == 5) { # bout metric simply looks at percentage of moving window that meets criterium
+      x[is.na(x)] = 0 # ignore NA values in the unlikely event that there are any
+      xt = x
+      #look for breaks larger than 1 minute
+      # Note: we do + 1 to make sure we look for breaks larger than but not equal to a minute,
+      # this is critical when working with 1 minute epoch data
+      lookforbreaks = zoo::rollmean(x=x,k=(60/ws3)+1,align="center",fill=rep(0,3))
+      #insert negative numbers to prevent these minutes to be counted in bouts
+      #in this way there will not be bouts breaks lasting longer than 1 minute
+      xt[lookforbreaks == 0] = -(60/ws3) * boutduration 
+      RM = zoo::rollmean(x=xt,k=boutduration,align="center",fill=rep(0,3)) #,
+      # p = which(RM > boutcriter)
+      p = which(RM >=boutcriter) # changed to be able to detect bouts with bout criteria 1.0
+      starti = round(boutduration/2)
+      # only consider windows that at least start and end with value that meets criterium
+      tri = p-starti
+      kep = which(tri > 0 & tri < (length(x)-(boutduration-1)))
+      if (length(kep) > 0) tri = tri[kep]
+      p = p[which(x[tri] == 1 & x[tri+(boutduration-1)] == 1)]
+      # now mark all epochs that are covered by the remaining windows
+      for (gi in 1:boutduration) {
+        inde = p-starti+(gi-1)
+        xt[inde[which(inde > 0 & inde < length(xt))]] = 2
+      }
+      x[xt != 2] = 0
+      x[xt == 2] = 1
+      boutcount = x
   }  
   invisible(list(x=x,boutcount=boutcount))
 }

--- a/R/g.part5.R
+++ b/R/g.part5.R
@@ -76,7 +76,7 @@ g.part5 = function(datadir=c(),metadatadir=c(),f0=c(),f1=c(),strategy=1,maxdur=7
   cnt = 1
   fnames.ms3 = sort(fnames.ms3)
   if (f1 == 0) length(fnames.ms4)
-  if (f1 > length(fnames.ms4)) f1 = length(fnames.ms4)
+  if (f1 > length(fnames.ms3)) f1 = length(fnames.ms3) # this is intentionally ms3 and not ms4, do not change!
   boutdur.mvpa = sort(boutdur.mvpa,decreasing = TRUE)
   boutdur.lig = sort(boutdur.lig,decreasing = TRUE)
   boutdur.in = sort(boutdur.in,decreasing = TRUE)

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -2,12 +2,13 @@
 \title{News for Package \pkg{GGIR}}
 \newcommand{\cpkg}{\href{http://CRAN.R-project.org/package=#1}{\pkg{#1}}}
 
-\section{Changes in version 2.1-2 (GitHub-only-release date:25-09-2020)}{
+\section{Changes in version 2.1-2 (GitHub-only-release date:28-09-2020)}{
 \itemize{
   \item Part 5 bug fixed with day name and date allocation for daysleepers for MM report
   \item Fix bug part 4 and 5 with missing nights which are not accounted for when assessing max night number.
   \item Fix bug part 3 introduced in version 2.1-0 re. SPT detection for daysleepers.
   \item Fix redefinition of the time windows (with "MM") in part 5 to include all recording days when the measurement starts with multiple non-wear days.
+  \item Bout metric 5 added to enable not allowing for gaps in bouts.
 }
 }
 

--- a/man/g.getbout.Rd
+++ b/man/g.getbout.Rd
@@ -35,11 +35,11 @@ bout.metric=1,ws3=5)
   towards MVPA may simplify interpretation and still counts the two persons in
   the example as each others equal. If value=3, using sliding window across the
   data to test bout criteria per window and do not allow for breaks larger than 1 minute
-  and with percentage of time larger than the boutcriter threshold.
+  and with fraction of time larger than the boutcriter threshold.
   If value=4, same as 3 but also requires the first and last epoch to 
-  require the threshold criteria. If value=5, same as 4, but now looking for break
-  larger than but not equal to a minute, and percentage of time that meets
-  the thresholds can be equal than or greater than the bout criteria.
+  meet the threshold criteria. If value=5, same as 4, but now allowing for breaks
+  shorter than but not equal to a minute, and the fraction of time that meets
+  the threshold should be equal than or greater than the bout.criter threshold.
 }
   \item{ws3}{epoch length in seconds, only needed for bout.metric =3, because
   it needs to measure how many epochs equal 1 minute breaks

--- a/man/g.getbout.Rd
+++ b/man/g.getbout.Rd
@@ -37,8 +37,8 @@ bout.metric=1,ws3=5)
   data to test bout criteria per window and do not allow for breaks larger than 1 minute
   and with fraction of time larger than the boutcriter threshold.
   If value=4, same as 3 but also requires the first and last epoch to 
-  meet the threshold criteria. If value=5, same as 4, but now allowing for breaks
-  shorter than but not equal to a minute, and the fraction of time that meets
+  meet the threshold criteria. If value=5, same as 4, but now looks for breaks larger
+  than a minute such that 1 minute breaks are allowe, and the fraction of time that meets
   the threshold should be equal than or greater than the bout.criter threshold.
 }
   \item{ws3}{epoch length in seconds, only needed for bout.metric =3, because

--- a/man/g.getbout.Rd
+++ b/man/g.getbout.Rd
@@ -25,18 +25,21 @@ bout.metric=1,ws3=5)
   been available since 2014 (see papers by Sabia AJE 2014 and da Silva IJE 2014).
   Here, the algorithm looks for 10 minute windows in which more than XX percent
   of the epochs are above mvpathreshold, and then counts the entire window as mvpa.
-  If value=2 the code looks for a group or groups of epochs with a value above
+  If value=2 the code looks for groups of epochs with a value above
   mvpathreshold that span a time window of at least mvpadur minutes in  which
   more than boutcriter percent of the epochs are above the threshold. The motivation 
   for the defition 1 was: A person who spends 10 minutes in MVPA with a 2 minute
   break in the middle is equally active as a person who spends 8 minutes in MVPA
   without taking a break. Therefore, both should be counted equal and counted as
   10 minute MVPA bout. The motivation for the definition 2 is: not counting breaks
-  towards MVPA simplifies interpretation and still counts the two persons in
+  towards MVPA may simplify interpretation and still counts the two persons in
   the example as each others equal. If value=3, using sliding window across the
-  data to test bout criteria per window and do not allow for breaks of 1 minute or
-  longer. If value=4, same as 3 but also requires the first and last epoch to 
-  require the threshold criteria.
+  data to test bout criteria per window and do not allow for breaks larger than 1 minute
+  and with percentage of time larger than the boutcriter threshold.
+  If value=4, same as 3 but also requires the first and last epoch to 
+  require the threshold criteria. If value=5, same as 4, but now looking for break
+  larger than but not equal to a minute, and percentage of time that meets
+  the thresholds can be equal than or greater than the bout criteria.
 }
   \item{ws3}{epoch length in seconds, only needed for bout.metric =3, because
   it needs to measure how many epochs equal 1 minute breaks

--- a/man/g.part5.definedays.Rd
+++ b/man/g.part5.definedays.Rd
@@ -8,15 +8,13 @@
   Defines when day windows start and end as part of \link{g.part5}.
 }
 \usage{
-  g.part5.definedays(nightsi, wi, summarysleep_tmp2, indjump, nightsi_bu, 
+  g.part5.definedays(nightsi, wi, indjump, nightsi_bu, 
                               ws3new, qqq_backup=c(), ts, Nts, timewindowi, Nwindows)
 }
 \arguments{
   \item{nightsi}{
   }
   \item{wi}{
-  }
-  \item{summarysleep_tmp2}{
   }
   \item{indjump}{
   }

--- a/tests/testthat/test_ggetbout.R
+++ b/tests/testthat/test_ggetbout.R
@@ -51,4 +51,14 @@ test_that("g.getbout produces expected output", {
   expect_that(sum(bm4$boutcount),equals(124))
   expect_that(bm4$x,equals(bm4Ex))
   expect_that(bm4$boutcount,equals(bm4Eboutcount))
+  
+  # Metric 5
+  set.seed(300)
+  bm5 = g.getbout(x=round(runif(1000,0.4,1)),boutduration = 120,boutcriter=0.9,
+                  closedbout=FALSE,bout.metric=5,ws3=5)
+  bm5Ex = c(rep(0,42), rep(1,285), rep(0,673))
+  bm5Eboutcount = c(rep(0,42), rep(1,285), rep(0,673))
+  expect_that(sum(bm5$x),equals(285))
+  expect_that(sum(bm5$boutcount),equals(285))
+ 
 })


### PR DESCRIPTION
**This pull request adds bout metric 5:**

Bout metric 5 is an modified copy of bout metric 4 (current default), and is different in two ways:
- It look for breaks larger than but not equal to a minute when distinguishing multiple bouts. In metric 4 breaks could not last 1 minute, but had to be shorter than a minute.
- It requires that the fraction of time in a bout that meets the thresholds should be _equal than or greater than_ the bout.criter value. For metric 4 this fraction of time had to be _greater than but not equal_ to the bout criteria.

The first change is valuable when working with 1 minute epoch data, when we want to allow for 1 minute breaks. If working with 5 second epoch data and using bout.metric 4 then practically the maximum break duration is 55 seconds. With bout.metric 5 this now has become a 1 minute, which is probably more intuitive..

The second change makes it possible to calculate bouts with `bout.criter = 1.0`, which means that no bout breaks are allowed (see #303).

For the time being I will keep bout metric 4 as the default. I am involved in a project where we use metric 5, once this is published it may be good to reflect on whether `bout.metric=5` should be default.

**Other minor updates:**

- Recognition of the number of files that need to be processed in part 5, This looked at part 4, but it should look at part 3.
- Updated documentation of `part5.definedays`.