### PR TITLE
Issue349 console message

### DIFF
--- a/R/g.shell.GGIR.R
+++ b/R/g.shell.GGIR.R
@@ -297,6 +297,13 @@ g.shell.GGIR = function(mode=1:5,datadir=c(),outputdir=c(),studyname=c(),f0=1,f1
   if (exists("dofirstpage") == FALSE)  dofirstpage = TRUE
   if (exists("visualreport") == FALSE)  visualreport = FALSE
   
+  
+  GGIRversion = ""
+  SI = sessionInfo()
+  try(expr = {GGIRversion = SI$loadedOnly$GGIR$Version},silent=TRUE)
+  if (length(GGIRversion) == 0) GGIRversion = "could not extract version"
+  GGIRversion = paste0(" ",GGIRversion)
+  cat(paste0("\n   GGIR version: ",GGIRversion,"\n"))
   cat("\n   Do not forget to cite GGIR in your publications via a version number and\n")
   cat("   Migueles et al. 2019 JMPB. doi: 10.1123/jmpb.2018-0063. \n")
   cat("   See also: https://cran.r-project.org/package=GGIR/vignettes/GGIR.html#citing-ggir \n")

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -8,6 +8,7 @@
   \item Fix bug part 4 and 5 with missing nights which are not accounted for when assessing max night number.
   \item Fix bug part 3 introduced in version 2.1-0 re. SPT detection for daysleepers.
   \item Fix redefinition of the time windows (with "MM") in part 5 to include all recording days when the measurement starts with multiple non-wear days.
+  \item GGIR version now displayed in console when running GGIR
 }
 }
 


### PR DESCRIPTION
only small edit, when running g.shell.GGIR we now also print the GGIR version to the console output as extra check for the user that the correct version of GGIR is being used.