### PR TITLE
Fixing 1 minute shift to timestamps

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -45,7 +45,7 @@ authors:
     family-names: Patterson
     given-names: "Matt"
 cff-version: "1.0.3"
-date-released: 2020-09-25
+date-released: 2020-10-10
 doi: "10.5281/zenodo.1051064"
 keywords:
   - "activity tracker"
@@ -57,5 +57,5 @@ license: "LGPL-2.0-only"
 message: "If you use this software, please cite it using these metadata."
 repository-code: "https://github.com/wadpac/GGIR"
 title: GGIR
-version: "2.1-2"
+version: "2.1-3"
 ...

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: GGIR
 Type: Package
 Title: Raw Accelerometer Data Analysis
-Version: 2.1-2
-Date: 2020-09-25
+Version: 2.1-3
+Date: 2020-10-10
 Authors@R: c(person("Vincent T","van Hees",role=c("aut","cre"),
                   email="v.vanhees@accelting.com"),
                   person("Zhou","Fang",role="ctb"),

--- a/R/g.part1.R
+++ b/R/g.part1.R
@@ -244,7 +244,8 @@ g.part1 = function(datadir=c(),outputdir=c(),f0=1,f1=c(),windowsizes = c(5,900,3
                          "g.binread", "g.cwaread", "g.readaccfile", "g.wavread", "g.downsample", "updateBlocksize",
                          "g.getidfromheaderobject", "g.getstarttime", "POSIXtime2iso8601", "chartime2iso8601",
                          "iso8601chartime2POSIX", "g.metric", "datadir2fnames", "read.myacc.csv",
-                         "get_nw_clip_block_params", "get_starttime_weekday_meantemp_truncdata", "ismovisens")
+                         "get_nw_clip_block_params", "get_starttime_weekday_meantemp_truncdata", "ismovisens",
+                         "g.extractheadervars")
     errhand = 'stop'
     # Note: This will not work for cwa files, because those also need Rcpp functions.
     # So, it is probably best to turn off parallel when debugging cwa data.

--- a/R/get_starttime_weekday_meantemp_truncdata.R
+++ b/R/get_starttime_weekday_meantemp_truncdata.R
@@ -38,8 +38,8 @@ get_starttime_weekday_meantemp_truncdata = function(temp.available, monc, dforma
     if (dformat == 1) { #not sure whether this is required for csv-format (2)
       if (length(which(timezone == "GMT")) > 0) {
         if (length(desiredtz) == 0) {
-          print("desiredtz not specified, Europe/London used as default")
-          desiredtz = "Europe/London"
+          print("desiredtz not specified, local timezoneused as default")
+          desiredtz = ""
         }
         starttime = as.POSIXlt(starttime[1],tz=desiredtz)
       }
@@ -72,13 +72,12 @@ get_starttime_weekday_meantemp_truncdata = function(temp.available, monc, dforma
     if (secshift != 60) {
       start_min = start_min +1 #shift in minutes needed (+1 one to account for seconds comp)
     }
-    #-----------
+    if (secshift == 60) secshift = 0 # if starttime is 00:00 then we do not want to remove data
     minshift = start_meas - (((start_min/start_meas) - floor(start_min/start_meas)) * start_meas)
     if (minshift == start_meas) {
       minshift = 0;
-      if (secshift == 60) secshift = 0 # if starttime is 00:00 then we do not want to remove data
+      
     }
-    #-----------
     sampleshift = ((minshift)*60*sf) + (secshift*sf) #derive sample shift
     if (floor(sampleshift) > 1) {
       data = data[-c(1:floor(sampleshift)),] #delete data accordingly
@@ -90,16 +89,15 @@ get_starttime_weekday_meantemp_truncdata = function(temp.available, monc, dforma
       newmin = newmin - 60
       start_hr = start_hr + 1
       if (start_hr == 24) { #if measurement is started in 15 minutes before midnight
-        #there used to be a nasty hack here for measurements that start in the 15 minutes before midnight, now fixed
         start_hr = 0
         remem2add24 = TRUE #remember to add 24 hours because this is now the wrong day
       }
     }
-    starttime3 = paste(temp[1]," ",start_hr,":",newmin,":",newsec,sep="") #<<<====  changed 17-12-2013
+    starttime3 = paste(temp[1]," ",start_hr,":",newmin,":",newsec,sep="")
     #create timestamp from string (now desiredtz is added)
     if (length(desiredtz) == 0) {
-      print("desiredtz not specified, Europe/London used as default")
-      desiredtz = "Europe/London"
+      print("desiredtz not specified, local timezone used as default")
+      desiredtz = ""
     }
     starttime_a = as.POSIXct(starttime3,format="%d/%m/%Y %H:%M:%S",tz=desiredtz) #,origin="1970-01-01"
     starttime_b = as.POSIXct(starttime3,format="%d-%m-%Y %H:%M:%S",tz=desiredtz) #,origin="1970-01-01"

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -4,7 +4,7 @@
 
 \section{Changes in version 2.1-3 (GitHub-only-release date:10-10-2020)}{
 \itemize{
-  \item Part 1 fix to 1 minute time shift when recording starts at the hours
+  \item Part 1 fix to 1 minute time shift when recording starts at full minute.
   }
 }
 

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -2,6 +2,12 @@
 \title{News for Package \pkg{GGIR}}
 \newcommand{\cpkg}{\href{http://CRAN.R-project.org/package=#1}{\pkg{#1}}}
 
+\section{Changes in version 2.1-3 (GitHub-only-release date:10-10-2020)}{
+\itemize{
+  \item Part 1 fix to 1 minute time shift when recording starts at the hours
+  }
+}
+
 \section{Changes in version 2.1-2 (GitHub-only-release date:25-09-2020)}{
 \itemize{
   \item Part 5 bug fixed with day name and date allocation for daysleepers for MM report

--- a/man/GGIR-package.Rd
+++ b/man/GGIR-package.Rd
@@ -22,8 +22,8 @@ citing the supporting publications (e.g. Migueles et al. 2019) in your publicati
 \tabular{ll}{
 Package: \tab GGIR\cr
 Type: \tab Package\cr
-Version: \tab 2.1-2\cr
-Date: \tab 2020-09-25\cr
+Version: \tab 2.1-3\cr
+Date: \tab 2020-10-10\cr
 License: \tab LGPL (>= 2.0, < 3)\cr
 Discussion group: \tab https://groups.google.com/forum/#!forum/rpackageggir\cr
 }


### PR DESCRIPTION
I thought I fixed this in July, but it seems the fix was not complete. This pull request should truly resolve the 1 minute shift in timestamps when a recording start at the full minute (0 seconds past the minute).

Additionally, I tidied up function R/get_starttime_weekday_meantemp_truncdata.R, which had Europe/London as backup timezone. Elsewhere in GGIR I replaced this by "" (local timezone) previously, but clearly I forgot to do it in this function.
