### PR TITLE
Issue373 daymisclassification

### DIFF
--- a/R/g.part5.R
+++ b/R/g.part5.R
@@ -349,7 +349,8 @@ g.part5 = function(datadir=c(),metadatadir=c(),f0=c(),f1=c(),strategy=1,maxdur=7
                                                     }
                                                     if (timewindowi == "MM") {
                                                     #  Nwindows = nrow(summarysleep_tmp2)
-                                                      Nwindows = length(which(diff(ts$diur) == -1)) + 1
+                                                    #  Nwindows = length(which(diff(ts$diur) == -1)) + 1
+                                                       Nwindows = length(nightsi) + 1
                                                     } else {
                                                       Nwindows = length(which(diff(ts$diur) == -1))
                                                     }

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -3,8 +3,8 @@
 \newcommand{\cpkg}{\href{http://CRAN.R-project.org/package=#1}{\pkg{#1}}}
 \section{Changes in version 2.1-4 (GitHub-only-release date:20-11-2020)}{
 \itemize{
-  \item Improved midnights identification when the recording starts at 0am
-  \item Fixed days misclassification for recordings starting with some non-wear days
+  \item Part 5 improved midnights identification when the recording starts at 0am
+  \item Part 5 fixed days misclassification for MM output when recordings starts with some non-wear days
 }
 }
 \section{Changes in version 2.1-3 (GitHub-only-release date:20-10-2020)}{

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -4,6 +4,7 @@
 \section{Changes in version 2.1-4 (GitHub-only-release date:20-11-2020)}{
 \itemize{
   \item Improved midnights identification when the recording starts at 0am
+  \item Fixed days misclassification for recordings starting with some non-wear days
 }
 }
 \section{Changes in version 2.1-3 (GitHub-only-release date:20-10-2020)}{


### PR DESCRIPTION
Re-defined Nwindows so that all days are evaluated in g.part5. This solves the issue with files starting with several non-wear days for MM time windows.