### PR TITLE
fix to #378

### DIFF
--- a/R/g.part5.R
+++ b/R/g.part5.R
@@ -75,7 +75,6 @@ g.part5 = function(datadir=c(),metadatadir=c(),f0=c(),f1=c(),strategy=1,maxdur=7
   di = 1
   cnt = 1
   fnames.ms3 = sort(fnames.ms3)
-  if (f1 == 0) length(fnames.ms4)
   if (f1 > length(fnames.ms3)) f1 = length(fnames.ms3) # this is intentionally ms3 and not ms4, do not change!
   boutdur.mvpa = sort(boutdur.mvpa,decreasing = TRUE)
   boutdur.lig = sort(boutdur.lig,decreasing = TRUE)
@@ -96,7 +95,6 @@ g.part5 = function(datadir=c(),metadatadir=c(),f0=c(),f1=c(),strategy=1,maxdur=7
     fullfilenames = folderstructure$fullfilenames
     foldername = folderstructure$foldername
   }
-  if (f1 > length(fnames.ms3)) f1 = length(fnames.ms3)
   if (f0 > length(fnames.ms3)) f0 = 1
   if (f1 == 0 | length(f1) == 0 | f1 > length(fnames.ms3))  f1 = length(fnames.ms3)
   #======================================================================

--- a/R/g.shell.GGIR.R
+++ b/R/g.shell.GGIR.R
@@ -409,7 +409,7 @@ g.shell.GGIR = function(mode=1:5,datadir=c(),outputdir=c(),studyname=c(),f0=1,f1
     cat('\n')
     cat(paste0(rep('_',options()$width),collapse=''))
     cat("\nPart 5\n")
-    if (f1 == 0) f1 = length(dir(paste(metadatadir,"/meta/ms4.out",sep="")))
+    if (f1 == 0) f1 = length(dir(paste(metadatadir,"/meta/ms3.out",sep=""))) # this is intentionally ms3 and not ms4, do not change!
     g.part5(datadir=datadir,metadatadir=metadatadir,f0=f0,f1=f1,strategy=strategy,maxdur=maxdur,
             hrs.del.start=hrs.del.start,
             hrs.del.end=hrs.del.end,

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -5,6 +5,7 @@
 \itemize{
   \item Fix bug part 3 introduced in 2.2-0 for recordings without sustained inactivity bouts
   \item Transitioned from Travis+Appveyor CI to GitHub Actions
+  \item Part 5 fixed issue with max number of files to process causing files to be missed.
 }
 }
 \section{Changes in version 2.2-0 (release date:22-11-2020)}{


### PR DESCRIPTION
Fixes issue as described in #378 relating to the detection of the number of files to process in part 5.

The calculation needs to rely on the number of milestone files produced by part 3 (not 4!). If there are less part4 milestone file than there are part3 milestone files this leads to files unnecessarily not being including the part5 report.