### PR TITLE
fix test file generation to allow for sessions of different length

### DIFF
--- a/tests/testthat/test_create_test_acc_csv.R
+++ b/tests/testthat/test_create_test_acc_csv.R
@@ -5,4 +5,19 @@ test_that("create_test_acc_csv produces a file", {
   fn = "123A_testaccfile.csv"
   expect_true(file.exists(fn))
   if (file.exists(fn)) file.remove(fn)
+
+  # generate a test file with a non-wear block straddling the end of the recording 
+  create_test_acc_csv(Nmin = 3000)
+  expect_true(file.exists(fn))
+  if (file.exists(fn)) file.remove(fn)
+
+  # generate a test file with a sleep block straddling the end of the recording 
+  create_test_acc_csv(Nmin = 2309)
+  expect_true(file.exists(fn))
+  if (file.exists(fn)) file.remove(fn)
+
+  # generate a test file with an activity block straddling the end of the recording 
+  create_test_acc_csv(Nmin = 2311)
+  expect_true(file.exists(fn))
+  if (file.exists(fn)) file.remove(fn)
 })


### PR DESCRIPTION
`create_test_acc_csv()` was failing whenever `Nmin` was such that one of the sleep blocks started just before the end of the recording but didn't end within the recording. Same issue for non-wear periods and activity periods.

For instance, `create_test_acc_csv(Nmin = 3000)` was attempting to create a non-wear block that ran past the end of the recording, resulting in an error:

> GGIR::create_test_acc_csv(Nmin = 3000)
Error in `[<-`(`*tmp*`, nw3, 1, value = accx) : subscript out of bounds


I modified `create_test_acc_csv.R` to test these various `Nmin` values that lead to errors.

Basically the problem was that `create_test_acc_csv()` was making sure sleep/non-wear/activity blocks started within the recording period, but it wasn't making sure that these blocks also *ended* within the recording period.

The fix ensures that no sleep block (or non-wear block, or activity block) ends after the end of the recording. If a block is too long to fully fit within a recording, it gets truncated.