### PR TITLE
Issue408 affecting read.myacc.csv

### DIFF
--- a/R/g.IVIS.R
+++ b/R/g.IVIS.R
@@ -1,6 +1,8 @@
 g.IVIS = function(Xi, epochsizesecondsXi = 5, IVIS_epochsize_seconds=NA, IVIS_windowsize_minutes = 60, IVIS.activity.metric = 1) {
-  if (!is.na(IVIS_epochsize_seconds)) {
-    warning("Argument IVIS_epochsize_seconds has been depricated")
+  if (length(IVIS_epochsize_seconds) > 0) {
+    if (!is.na(IVIS_epochsize_seconds)) {
+      warning("Argument IVIS_epochsize_seconds has been depricated")
+    }
   }
   IVIS_epochsize_seconds = IVIS_windowsize_minutes*60
   if (IVIS.activity.metric == 2) { # use binary scoring

--- a/R/g.analyse.R
+++ b/R/g.analyse.R
@@ -3,7 +3,7 @@ g.analyse =  function(I,C,M,IMP,qlevels=c(),qwindow=c(0,24),quantiletype = 7,L5M
                       mvpathreshold = c(),boutcriter=c(),mvpadur=c(1,5,10),selectdaysfile=c(),
                       window.summary.size=10,
                       dayborder=0,bout.metric = 1,closedbout=FALSE,desiredtz="",
-                      IVIS_windowsize_minutes = 60, IVIS_epochsize_seconds = 3600, iglevels = c(),
+                      IVIS_windowsize_minutes = 60, IVIS_epochsize_seconds = NA, iglevels = c(),
                       IVIS.activity.metric=2, qM5L5 = c(), myfun=c(), MX.ig.min.dur = 10) {
   L5M5window = c(0,24) # as of version 1.6-0 this is hardcoded because argument qwindow now
   # specifies the window over which L5M5 analysis is done. So, L5M5window is a depricated

--- a/R/g.calibrate.R
+++ b/R/g.calibrate.R
@@ -203,7 +203,9 @@ g.calibrate = function(datafile, spherecrit=0.3,minloadcrit=72,printsummary=TRUE
           dur = nrow(data)	#duration of experiment in data points
           durexp = nrow(data) / (sf*ws)	#duration of experiment in hrs
           # Initialization of variables
-          suppressWarnings(storage.mode(data) <- "numeric")
+          if (dformat != 5) {
+            suppressWarnings(storage.mode(data) <- "numeric")
+          } 
           if (mon == 1) {
             Gx = data[,1]; Gy = data[,2]; Gz = data[,3]
             use.temp = FALSE

--- a/R/g.getmeta.R
+++ b/R/g.getmeta.R
@@ -420,11 +420,18 @@ g.getmeta = function(datafile,desiredtz = "",windowsizes = c(5,900,3600),
                 data = apply(data, 2,as.numeric)
               }
             }
+            if (ncol(data) >= 4 & mon == 0) {
+              columns_to_use = rmc.col.acc
+            } else {
+              columns_to_use = 1:3
+            }
+            data = data[,columns_to_use]
+            suppressWarnings(storage.mode(data) <- "numeric")
             if ((mon == 3 | mon == 0 | mon == 6) & use.temp == FALSE) {
-              data[,1:3] = scale(data[,1:3],center = -offset, scale = 1/scale)  #rescale data
+              data = scale(data,center = -offset, scale = 1/scale)  #rescale data
             } else if ((mon == 2 | mon == 0) & use.temp == TRUE) {
               # meantemp replaced by meantempcal # 19-12-2013
-              data[,1:3] = scale(data[,1:3],center = -offset, scale = 1/scale) +
+              data = scale(data,center = -offset, scale = 1/scale) +
                 scale(yy, center = rep(meantempcal,3), scale = 1/tempoffset)  #rescale data
               rm(yy); gc()
             }

--- a/R/g.inspectfile.R
+++ b/R/g.inspectfile.R
@@ -10,8 +10,8 @@ g.inspectfile = function(datafile, desiredtz = "", ...) {
       eval(parse(text=txt))
     }
   }
-  # Althoguh it is documented, here as a reminder:
-  # monitor codes (mon):
+  # Although also documented in the package manuel files, here 
+  # for convenience the monitor codes (mon):
   # 0 - ad-hoc file (currently only .csv format)
   # 1 - GENEA (non-commercial); 2 - GENEActiv
   # 3 - Actigraph; 4 - Axivity (AX3, AX6)

--- a/R/g.inspectfile.R
+++ b/R/g.inspectfile.R
@@ -10,6 +10,15 @@ g.inspectfile = function(datafile, desiredtz = "", ...) {
       eval(parse(text=txt))
     }
   }
+  # Althoguh it is documented, here as a reminder:
+  # monitor codes (mon):
+  # 0 - ad-hoc file (currently only .csv format)
+  # 1 - GENEA (non-commercial); 2 - GENEActiv
+  # 3 - Actigraph; 4 - Axivity (AX3, AX6)
+  # 5 - Movisense; 6 - Verisense
+  # data formats:
+  # 1 - bin; 2 - csv; 3 - wav
+  # 4 - cwa; 5 - ad-hoc .csv
 
   if (length(which(ls() == "rmc.dec")) == 0) rmc.dec="."
   if (length(which(ls() == "rmc.firstrow.acc")) == 0) rmc.firstrow.acc = c()

--- a/R/g.report.part2.R
+++ b/R/g.report.part2.R
@@ -133,10 +133,15 @@ g.report.part2 = function(metadatadir=c(),f0=c(),f1=c(),maxdur = 7,selectdaysfil
         if (I$dformn == "csv") { #if it was stored in csv-format then underscores were replaced by spaces (by company)
           deviceSerialNumber = hvalues[which(hnames == "Device Unique Serial Code")] #serial number
         }
-      } else if (mon == "actigraph" | mon == "axivity" | mon == "verisense") { #todo: create automatic extraction of information from actigraph fileheader
+      } else if (mon == "actigraph" | mon == "axivity" | mon == "verisense") {
         deviceSerialNumber = "not extracted"
-      } else if (I$monc == 5 | I$monc == 0) { #todo: create automatic extraction of information from monc fileheader
+      } else if (I$monc == 5) { #movisense
         deviceSerialNumber = "not extracted"
+      } else if (I$monc == 0) {
+        deviceSerialNumber = hvalues[which(hnames == "device_serial_number")]
+        if (length(deviceSerialNumber) == 0) {
+          deviceSerialNumber = "not extracted"
+        }
       }
       if (length(C$offset) == 0) {
         C$offset = C$translate

--- a/R/g.report.part2.R
+++ b/R/g.report.part2.R
@@ -135,7 +135,7 @@ g.report.part2 = function(metadatadir=c(),f0=c(),f1=c(),maxdur = 7,selectdaysfil
         }
       } else if (mon == "actigraph" | mon == "axivity" | mon == "verisense") { #todo: create automatic extraction of information from actigraph fileheader
         deviceSerialNumber = "not extracted"
-      } else if (I$monc == 5) { #todo: create automatic extraction of information from monc fileheader
+      } else if (I$monc == 5 | I$monc == 0) { #todo: create automatic extraction of information from monc fileheader
         deviceSerialNumber = "not extracted"
       }
       if (length(C$offset) == 0) {

--- a/R/g.report.part2.R
+++ b/R/g.report.part2.R
@@ -138,8 +138,12 @@ g.report.part2 = function(metadatadir=c(),f0=c(),f1=c(),maxdur = 7,selectdaysfil
       } else if (I$monc == 5) { #movisense
         deviceSerialNumber = "not extracted"
       } else if (I$monc == 0) {
-        deviceSerialNumber = hvalues[which(hnames == "device_serial_number")]
-        if (length(deviceSerialNumber) == 0) {
+        if (header != "no header") {
+          deviceSerialNumber = hvalues[which(hnames == "device_serial_number")]
+          if (length(deviceSerialNumber) == 0) {
+            deviceSerialNumber = "not extracted"
+          }
+        } else {
           deviceSerialNumber = "not extracted"
         }
       }

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -4,7 +4,9 @@
 
 \section{Changes in version 2.3-2 (GitHub-only-release date:26-04-2021)}{
 \itemize{
-  \item Part 1 handling of timestamp column when using ad-hoc data format (monitor code = 0)
+  \item Part 1 when using ad-hoc data format: now able to handle timestamp column.
+  \item Part 1 when using ad-hoc data format: now able to store extract serial 
+  number in part2 report.
   \item Test file generation for unit tests improved. Thanks Lena Kushleyeva.
 }
 }

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -5,7 +5,7 @@
 \section{Changes in version 2.3-2 (GitHub-only-release date:26-04-2021)}{
 \itemize{
   \item Part 1 when using ad-hoc data format: now able to handle timestamp column.
-  \item Part 1 when using ad-hoc data format with header: now able to extract 
+  \item Part 2 report when using ad-hoc data format with header: now able to extract 
   and store serial number in part2 report.
   \item Test file generation for unit tests improved. Thanks Lena Kushleyeva.
 }

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -5,8 +5,8 @@
 \section{Changes in version 2.3-2 (GitHub-only-release date:26-04-2021)}{
 \itemize{
   \item Part 1 when using ad-hoc data format: now able to handle timestamp column.
-  \item Part 1 when using ad-hoc data format: now able to store extract serial 
-  number in part2 report.
+  \item Part 1 when using ad-hoc data format with header: now able to extract 
+  and store serial number in part2 report.
   \item Test file generation for unit tests improved. Thanks Lena Kushleyeva.
 }
 }

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -1,6 +1,13 @@
 \name{NEWS}
 \title{News for Package \pkg{GGIR}}
 \newcommand{\cpkg}{\href{http://CRAN.R-project.org/package=#1}{\pkg{#1}}}
+
+\section{Changes in version 2.3-2 (GitHub-only-release date:26-04-2021)}{
+\itemize{
+  \item Part 1 handling of timestamp column when using ad-hoc data format (monitor code = 0)
+  \item Test file generation for unit tests improved. Thanks Lena Kushleyeva.
+}
+}
 \section{Changes in version 2.3-1 (GitHub-only-release date:26-03-2021)}{
 \itemize{
   \item Part 3 bug fixed in usage of argument dayborder when not 0. 

--- a/man/g.analyse.Rd
+++ b/man/g.analyse.Rd
@@ -25,7 +25,7 @@ selectdaysfile=c(),window.summary.size=10,
 dayborder=0,bout.metric = 1,
 closedbout=FALSE,desiredtz = "",
 IVIS_windowsize_minutes = 60,
-IVIS_epochsize_seconds = 3600, iglevels = c(),IVIS.activity.metric=2,
+IVIS_epochsize_seconds = NA, iglevels = c(),IVIS.activity.metric=2,
 qM5L5=c(), myfun=c(), MX.ig.min.dur=10)
 }
 
@@ -142,12 +142,10 @@ qM5L5=c(), myfun=c(), MX.ig.min.dur=10)
   see \link{g.getmeta}
   }
   \item{IVIS_windowsize_minutes}{
-  Window size of the Intradaily Variability (IV) and Interdaily
-  Stability (IS) metrics in minutes
+    see \link{g.IVIS}
   }
   \item{IVIS_epochsize_seconds}{
-  Epoch size of the Intradaily Variability (IV) and Interdaily
-  Stability (IS) metrics in seconds
+    depricate, see \link{g.IVIS}
   }
   \item{iglevels}{
     Levels for acceleration value frequency distribution in mg used for intensity

--- a/man/g.dotorcomma.Rd
+++ b/man/g.dotorcomma.Rd
@@ -16,11 +16,12 @@ g.dotorcomma(inputfile,dformat,mon, desiredtz = "", ...)
   full path to inputfile
   }
    \item{dformat}{
-  Data format code: 1=.bin, 2=.csv, 3=.wav, 4=.cwa
+  Data format code: 1=.bin, 2=.csv, 3=.wav, 4=.cwa, 5=.csv for ad-hoc monitor 
+  brand
   }
   \item{mon}{
-  Monitor code (accelorometer brand): 1=GENEA,2=GENEActiv,3=Actigraph,
-  4=Axivity.
+  Monitor code (accelorometer brand): 0=undefined, 1=GENEA, 2=GENEActiv,
+  3=Actigraph, 4=Axivity, 5=Movisense, 6=Verisense
   }
   \item{desiredtz}{
   Desired timezone, see documentation \link{g.getmeta}


### PR DESCRIPTION
This pull request mostly relates to issue #408, which concerns .csv input data files with ad-hoc formats that come with a timestamp column in non-numeric format.

More specifically:
- In function `g.calibrate` when data format (`dformat`) value is 5 (ad-hoc csv) we now no longer auto-convert the data object to numeric at the top, because it may include timestamps in character.
- In function `g.getmeta` the acceleration columns are selected based on what is provided by argument `rmc.col.acc` and no longer assumed to be columns 1, 2, 3.

Other fixes:
- Part 2 report when using ad-hoc data format with header: now able to extract 
  and store serial number in part2 report.
- Updated documentation on monitor and data format coding.
- Improved handling of deprecated IVIS argument `IVIS_epochsize_seconds`.