### PR TITLE
Issue419_ENMOa

### DIFF
--- a/R/g.applymetrics.R
+++ b/R/g.applymetrics.R
@@ -214,7 +214,6 @@ g.applymetrics = function(data,n=4,sf,ws3,metrics2do, lb=0.2, hb=15){
   }
   if (do.enmoa == TRUE) {
     ENMOa = abs(EN - gravity)
-    ENMOa[which(ENMOa < 0)] = 0
     allmetrics$ENMOa = averageperws3(x=ENMOa,sf,ws3)
   }
   return(allmetrics)

--- a/R/g.getmeta.R
+++ b/R/g.getmeta.R
@@ -780,7 +780,7 @@ g.getmeta = function(datafile,desiredtz = "",windowsizes = c(5,900,3600),
         cat(paste("\nstopped reading data because this analysis is limited to ",ceiling(daylimit)," days\n",sep=""))
       }
     }
-    i = i + 1; cat(sum(nchar(metashort[,2]) > 0, na.rm = T)) #go to next block
+    i = i + 1 #go to next block
   }
   # deriving timestamps
   if (filecorrupt == FALSE & filetooshort == FALSE & filedoesnotholdday == FALSE) {

--- a/R/g.getmeta.R
+++ b/R/g.getmeta.R
@@ -660,7 +660,7 @@ g.getmeta = function(datafile,desiredtz = "",windowsizes = c(5,900,3600),
           metashort[count:(count-1+nrow(OutputExternalFunction)),col_msi:(col_msi+NcolEF)] = as.matrix(OutputExternalFunction); col_msi = col_msi + NcolEF + 1
         }
         # count = count + length(EN_shortepoch) #increasing "count" the indicator of how many seconds have been read
-        count = count + length(accmetrics[[1]]) # changing indicator to whatever metric is calculated, EN produces incompatibility when deriving both ENMO and ENMOa 
+        count = count + nrow(accmetrics) # changing indicator to whatever metric is calculated, EN produces incompatibility when deriving both ENMO and ENMOa 
         rm(accmetrics)
         # update blocksize depending on available memory
         BlocksizeNew = updateBlocksize(blocksize=blocksize, bsc_qc=bsc_qc)

--- a/R/g.getmeta.R
+++ b/R/g.getmeta.R
@@ -660,7 +660,7 @@ g.getmeta = function(datafile,desiredtz = "",windowsizes = c(5,900,3600),
           metashort[count:(count-1+nrow(OutputExternalFunction)),col_msi:(col_msi+NcolEF)] = as.matrix(OutputExternalFunction); col_msi = col_msi + NcolEF + 1
         }
         # count = count + length(EN_shortepoch) #increasing "count" the indicator of how many seconds have been read
-        count = count + nrow(accmetrics) # changing indicator to whatever metric is calculated, EN produces incompatibility when deriving both ENMO and ENMOa 
+        count = count + length(accmetrics[[1]]) # changing indicator to whatever metric is calculated, EN produces incompatibility when deriving both ENMO and ENMOa 
         rm(accmetrics)
         # update blocksize depending on available memory
         BlocksizeNew = updateBlocksize(blocksize=blocksize, bsc_qc=bsc_qc)

--- a/R/g.getmeta.R
+++ b/R/g.getmeta.R
@@ -780,7 +780,7 @@ g.getmeta = function(datafile,desiredtz = "",windowsizes = c(5,900,3600),
         cat(paste("\nstopped reading data because this analysis is limited to ",ceiling(daylimit)," days\n",sep=""))
       }
     }
-    i = i + 1 #go to next block
+    i = i + 1; cat(sum(nchar(metashort[,2]) > 0, na.rm = T)) #go to next block
   }
   # deriving timestamps
   if (filecorrupt == FALSE & filetooshort == FALSE & filedoesnotholdday == FALSE) {

--- a/R/g.getmeta.R
+++ b/R/g.getmeta.R
@@ -659,7 +659,8 @@ g.getmeta = function(datafile,desiredtz = "",windowsizes = c(5,900,3600),
           NcolEF = ncol(OutputExternalFunction)-1 # number of extra columns needed
           metashort[count:(count-1+nrow(OutputExternalFunction)),col_msi:(col_msi+NcolEF)] = as.matrix(OutputExternalFunction); col_msi = col_msi + NcolEF + 1
         }
-        count = count + length(EN_shortepoch) #increasing "count" the indicator of how many seconds have been read
+        # count = count + length(EN_shortepoch) #increasing "count" the indicator of how many seconds have been read
+        count = count + length(accmetrics[[1]]) # changing indicator to whatever metric is calculated, EN produces incompatibility when deriving both ENMO and ENMOa 
         rm(accmetrics)
         # update blocksize depending on available memory
         BlocksizeNew = updateBlocksize(blocksize=blocksize, bsc_qc=bsc_qc)

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -2,6 +2,11 @@
 \title{News for Package \pkg{GGIR}}
 \newcommand{\cpkg}{\href{http://CRAN.R-project.org/package=#1}{\pkg{#1}}}
 
+\section{Changes in version 2.3-3 (GitHub-only-release date:04-05-2021)}{
+\itemize{
+  \item Part 1 fixed bug related with ENMOa calculation which made the metashort data frame to be empty
+}
+
 \section{Changes in version 2.3-2 (GitHub-only-release date:21-04-2021)}{
 \itemize{
   \item Part 1 when using ad-hoc data format: now able to handle timestamp column.

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -6,7 +6,7 @@
 \itemize{
   \item Part 1 fixed bug related with ENMOa calculation which made the metashort data frame to be empty
 }
-
+}
 \section{Changes in version 2.3-2 (GitHub-only-release date:21-04-2021)}{
 \itemize{
   \item Part 1 when using ad-hoc data format: now able to handle timestamp column.


### PR DESCRIPTION
Minor changes in g.applymetrics and g.getmeta to fix bug related to ENMOa calculation. 

1. In g.applymetrics, removed "ENMOa[which(ENMOa < 0)] = 0"; as it is abosolute, there are no values < 0.
2. In g.getmeta, changed the "count" indicator to fill the metashort data frame from "length(accmetrics$EN)" to "length(accmetrics[[1]]). Now it just takes the first metric calculated, independently of which metric it is.