### PR TITLE
Issue438 movisens files reading

### DIFF
--- a/R/g.getmeta.R
+++ b/R/g.getmeta.R
@@ -251,11 +251,12 @@ g.getmeta = function(datafile,desiredtz = "",windowsizes = c(5,900,3600),
       NFilePagesSkipped = filequality$NFilePagesSkipped
       switchoffLD = accread$switchoffLD
       PreviousEndPage = accread$endpage
+      startpage = accread$startpage
       options(warn=-1) # to ignore warnings relating to failed mmap.load attempt
       rm(accread); gc()
       options(warn=0) # to ignore warnings relating to failed mmap.load attempt
       if(mon == 5) { # if movisens, then read temperature
-        PreviousStartPage = accread$startpage
+        PreviousStartPage = startpage
         temperature = g.readtemp_movisens(datafile, desiredtz, PreviousStartPage, PreviousEndPage)
         P = cbind(P, temperature[1:nrow(P)])
         colnames(P)[4] = "temp"

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -2,6 +2,11 @@
 \title{News for Package \pkg{GGIR}}
 \newcommand{\cpkg}{\href{http://CRAN.R-project.org/package=#1}{\pkg{#1}}}
 
+\section{Changes in version 2.4-1 (GitHub-only-release date:20-07-2021)}{
+\itemize{
+  \item Part 1 fixed bug related to g.getmeta reading movisens files
+}
+}
 \section{Changes in version 2.4-0 (release date:03-06-2021)}{
 \itemize{
   \item Part 5 LUX variables per segment of the day improved


### PR DESCRIPTION
The object accread was removed and then required again to access to accread$startpage. Now this is fixed (see issue #438).