### PR TITLE
Add separate contributors guide

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,6 @@ prepareNewRelease.R
 ^Meta$
 ^pdf_vignettes_for_github_only
 ^\.github
+CODE_OF_CONDUCT.md
+CONTRIBUTING.md
+RELEASE_CYCLE.md

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+<!-- Describe your PR here -->
+
+<!-- Please, make sure the following items are checked -->
+Checklist before merging:
+
+- [ ] Existing tests still work (check by running the test suite, e.g. from RStudio).
+- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
+- [ ] Updated or expanded the documentation.
+- [ ] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
+- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,15 +55,11 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at  **DISCUSSIEPUNT: WIL JE HIER EEN EMAIL ADRES VOOR OPENEN?**. All
+reported by contacting the main project maintainer v.vanhees@accelting.com. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.
 Further details of specific enforcement policies may be posted separately.
-
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
 
 ## Attribution
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,71 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at  **DISCUSSIEPUNT: WIL JE HIER EEN EMAIL ADRES VOOR OPENEN?**. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ The sections below outline the steps in each case.
 
 1. use the search functionality [here](https://groups.google.com/g/RpackageGGIR) to see if someone already experienced the same issue;
 2. if your search did not yield any relevant results, start a new conversation.
+
 ## Bugs
 
 1. use the search functionality [here](https://github.com/wadpac/GGIR/issues) to see if someone already filed the same issue;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing guidelines
+
+We welcome any kind of contribution to our software, from simple comment or question to a full fledged [pull request](https://help.github.com/articles/about-pull-requests/). Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+A contribution can be one of the following cases:
+
+1. you have a question;
+2. you think you may have found a bug (including unexpected behavior);
+3. you want to make some kind of change to the code base (e.g. to fix a bug, to add a new feature, to update documentation);
+4. you want to make a new release of the code base.
+
+The sections below outline the steps in each case.
+
+## You have a question
+
+**DISCUSSIEPUNT: wil je issues gebruiken of de nieuwe GitHub discussions pagina?**
+
+1. use the search functionality [here](https://github.com/wadpac/GGIR/issues) to see if someone already filed the same issue;
+2. if your issue search did not yield any relevant results, make a new issue;
+3. apply the "Question" label; apply other labels when relevant. **DISCUSSIEPUNT (labels?)**
+
+## You think you may have found a bug
+
+1. use the search functionality [here](https://github.com/wadpac/GGIR/issues) to see if someone already filed the same issue;
+2. if your issue search did not yield any relevant results, make a new issue, making sure to provide enough information to the rest of the community to understand the cause and context of the problem. Depending on the issue, you may want to include:
+    - the release version or [SHA hashcode](https://help.github.com/articles/autolinked-references-and-urls/#commit-shas) of the commit that is causing your problem;
+    - some identifying information (name and version number) for dependencies you're using;
+    - information about the operating system;
+3. apply relevant labels to the newly created issue. **DISCUSSIEPUNT**
+
+## You want to make some kind of change to the code base
+
+1. (**important**) announce your plan to the rest of the community *before you start working*. This announcement should be in the form of a (new) issue;
+2. (**important**) wait until some kind of consensus is reached about your idea being a good idea;
+3. if needed, fork the repository to your own Github profile and create your own feature branch off of the latest master commit. While working on your feature branch, make sure to stay up to date with the master branch by pulling in changes, possibly from the 'upstream' repository (follow the instructions [here](https://help.github.com/articles/configuring-a-remote-for-a-fork/) and [here](https://help.github.com/articles/syncing-a-fork/));
+4. make sure the existing tests still work by running ``???``;  **DISCUSSIEPUNT: HOE DRAAI JE TESTS? Je noemt in de huidige guide "Run the tests and checks as CRAN, make sure they pass." Is daar een handig commando voor? Of een link naar een guide?**
+5. add your own tests (if necessary);
+6. update or expand the documentation;
+7. make sure the release notes in `NEWS.Rd` are updated. **DISCUSSIEPUNT: waar staat dit? pad is mss handig**
+8. add your name to the contributors list in the `DESCRIPTION` file.
+9. push your feature branch to (your fork of) the GGIR repository on GitHub;
+10. create the pull request, e.g. following the instructions [here](https://help.github.com/articles/creating-a-pull-request/).
+
+**DISCUSSIEPUNT: wil je ook nog iets zeggen over copyright en licensing? Mss beetje nitpicky en doen de meeste projecten ook niet.**
+
+In case you feel like you've made a valuable contribution, but you don't know how to write or run tests for it, or how to generate the documentation: don't let this discourage you from making the pull request; we can help you! Just go ahead and submit the pull request, but keep in mind that you might be asked to append additional commits to your pull request.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,43 +4,52 @@ We welcome any kind of contribution to our software, from simple comment or ques
 
 A contribution can be one of the following cases:
 
-1. you have a question;
-2. you think you may have found a bug (including unexpected behavior);
-3. you want to make some kind of change to the code base (e.g. to fix a bug, to add a new feature, to update documentation);
-4. you want to make a new release of the code base.
+1. [you have a question](#questions);
+2. [you think you may have found a bug](#bugs) (including unexpected behavior);
+3. [you want to make some kind of change to the code base](#changes-or-additions) (e.g. to fix a bug, to add a new feature, to update documentation);
+4. [you want to make a new release of the code base](#new-release).
 
 The sections below outline the steps in each case.
 
-## You have a question
+## Questions
 
-**DISCUSSIEPUNT: wil je issues gebruiken of de nieuwe GitHub discussions pagina?**
-
-1. use the search functionality [here](https://github.com/wadpac/GGIR/issues) to see if someone already filed the same issue;
-2. if your issue search did not yield any relevant results, make a new issue;
-3. apply the "Question" label; apply other labels when relevant. **DISCUSSIEPUNT (labels?)**
-
-## You think you may have found a bug
+1. use the search functionality [here](https://groups.google.com/g/RpackageGGIR) to see if someone already experienced the same issue;
+2. if your search did not yield any relevant results, start a new conversation.
+## Bugs
 
 1. use the search functionality [here](https://github.com/wadpac/GGIR/issues) to see if someone already filed the same issue;
-2. if your issue search did not yield any relevant results, make a new issue, making sure to provide enough information to the rest of the community to understand the cause and context of the problem. Depending on the issue, you may want to include:
-    - the release version or [SHA hashcode](https://help.github.com/articles/autolinked-references-and-urls/#commit-shas) of the commit that is causing your problem;
-    - some identifying information (name and version number) for dependencies you're using;
-    - information about the operating system;
-3. apply relevant labels to the newly created issue. **DISCUSSIEPUNT**
+2. if your issue search did not yield any relevant results, make a new issue, and choose the Bug report type. This includes a checklist to make sure you provide enough information to the rest of the community to understand the cause and context of the problem.
 
-## You want to make some kind of change to the code base
+## Changes or additions
 
-1. (**important**) announce your plan to the rest of the community *before you start working*. This announcement should be in the form of a (new) issue;
+1. (**important**) announce your plan to the rest of the community *before you start working*. This announcement should be in the form of a (new) issue. Choose the Feature request type, which includes a checklist of things to consider to get the discussion going;
 2. (**important**) wait until some kind of consensus is reached about your idea being a good idea;
 3. if needed, fork the repository to your own Github profile and create your own feature branch off of the latest master commit. While working on your feature branch, make sure to stay up to date with the master branch by pulling in changes, possibly from the 'upstream' repository (follow the instructions [here](https://help.github.com/articles/configuring-a-remote-for-a-fork/) and [here](https://help.github.com/articles/syncing-a-fork/));
-4. make sure the existing tests still work by running ``???``;  **DISCUSSIEPUNT: HOE DRAAI JE TESTS? Je noemt in de huidige guide "Run the tests and checks as CRAN, make sure they pass." Is daar een handig commando voor? Of een link naar een guide?**
+4. make sure the existing tests still work by running the test suite from RStudio;
 5. add your own tests (if necessary);
 6. update or expand the documentation;
-7. make sure the release notes in `NEWS.Rd` are updated. **DISCUSSIEPUNT: waar staat dit? pad is mss handig**
-8. add your name to the contributors list in the `DESCRIPTION` file.
+7. make sure the release notes in `inst/NEWS.Rd` are updated;
+8. add your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files;
 9. push your feature branch to (your fork of) the GGIR repository on GitHub;
-10. create the pull request, e.g. following the instructions [here](https://help.github.com/articles/creating-a-pull-request/).
-
-**DISCUSSIEPUNT: wil je ook nog iets zeggen over copyright en licensing? Mss beetje nitpicky en doen de meeste projecten ook niet.**
+10. create the pull request, e.g. following the instructions [here](https://help.github.com/articles/creating-a-pull-request/). The pull request template includes a checklist with the above items.
 
 In case you feel like you've made a valuable contribution, but you don't know how to write or run tests for it, or how to generate the documentation: don't let this discourage you from making the pull request; we can help you! Just go ahead and submit the pull request, but keep in mind that you might be asked to append additional commits to your pull request.
+
+### Coding style
+
+We loosely follow the [tidyverse style guide](https://style.tidyverse.org/), but do not enforce every rule strictly.
+For instance, we prefer `=` instead of `<-` as the default assignment operator.
+When in doubt about what style to use, don't hesitate to get in touch.
+
+Some general guidelines that we try to adhere to:
+
+- Use standard R as much as possible, keep dependencies to a minimum.
+- Keep loops to a minimum.
+- Don't make lines too long.
+
+If you are a first time contributor, don't worry about coding style too much.
+We will help you get things in shape.
+
+## New release
+
+GGIR follows the [release cycle process described in this document](RELEASE_CYCLE.md).

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ The package [vignette](https://CRAN.R-project.org/package=GGIR/vignettes/GGIR.ht
 
 ## Contribution guidelines:
 We always welcome contributions to the package.
+If you want to contribute to the development of GGIR, have a look at the [contribution guidelines](CONTRIBUTING.md).
 
-### When you are familiar with GitHub:
+<!-- ### When you are familiar with GitHub:
 We work with [GitHub Flow](https://guides.github.com/introduction/flow/) branching model.
 
 Key steps:
@@ -45,7 +46,7 @@ With this new release structure I will use the following version coding. **A.B-C
 
 - A increases with major changes that affect backward compatibility with previous releases like changes in function names, function arguments or file format.
 - B increases with every CRAN release.
-- C increases with every GitHub release.
+- C increases with every GitHub release. -->
 
 ### Images usaged
 The copyright of the GGIR logo as contained in the file vignettes/GGIR-MASTERLOGO-RGB.png lies with Accelting (Almere, The Netherlands), please contact v.vanhees@accelting.com to ask for permission to use this logo.

--- a/README.md
+++ b/README.md
@@ -12,42 +12,6 @@ The package [vignette](https://CRAN.R-project.org/package=GGIR/vignettes/GGIR.ht
 We always welcome contributions to the package.
 If you want to contribute to the development of GGIR, have a look at the [contribution guidelines](CONTRIBUTING.md).
 
-<!-- ### When you are familiar with GitHub:
-We work with [GitHub Flow](https://guides.github.com/introduction/flow/) branching model.
-
-Key steps:
-1. Create a GitHub issue in this repository with description of the work that you plan to do.
-2. Assign yourself to the GitHub issue you are working on, to inform other developers that you are working on it.
-3. Create your own working branch or fork.
-4. Make your changes in that branch or fork.
-5. Commit your changes to your working branch/fork as long as you are not finished with your development.
-6. Make sure the release notes in NEWS.Rd are updated.
-7. Add your name to the contributors list in the DESCRIPTION file.
-8. Run the tests and checks as CRAN, make sure they pass.
-9. Once your work is finished, make a pull request, such that another developer can review your changes before merging them with the master branch.
-
-### When you are unfamiliar with GitHub:
-If you would like to propose additional functionalities or report an issue. Go to [issues](https://github.com/wadpac/GGIR/issues) and create a new issue.
-
-If you would like to propose changes to the text of the manual this is possible.
-1. Please go to the [man](https://github.com/wadpac/GGIR/tree/master/man) folder which holds all the parts of the manual.
-2. Go to the part of the manual you want to edit and click on edit button (little pencil symbol) and make your changes.
-3. Once you are finished, scroll down and describe you update and select the radio button "Create a new branch for this commit and start a pull request". One of the developers will then be able to review your changes and merge them in the master version of the code.
-4. Click the green button "Propose file changes"
-
-### Version numbers:
-For a number of years I created a new GGIR release on CRAN with every major improvement to GGIR. This resulted in 18 releases in just two years, which is not very practical.
-
-As of 2020 I am reducing the number of CRAN releases to only two or three per year, with intermediate releases on GitHub only. New features and bug fixes will first be released on GitHub, which creates a time window for extra testing before they end up in the next CRAN release. This will make the GGIR CRAN releases more stable and a good starting point for new GGIR users, while GitHub releases will become the place for the latest bug fixes and feature additions.
-
-If possible, please use the GitHub version whenever you can to help spot issues timely before they end up in a CRAN release.
-
-With this new release structure I will use the following version coding. **A.B-C**:
-
-- A increases with major changes that affect backward compatibility with previous releases like changes in function names, function arguments or file format.
-- B increases with every CRAN release.
-- C increases with every GitHub release. -->
-
 ### Images usaged
 The copyright of the GGIR logo as contained in the file vignettes/GGIR-MASTERLOGO-RGB.png lies with Accelting (Almere, The Netherlands), please contact v.vanhees@accelting.com to ask for permission to use this logo.
 

--- a/RELEASE_CYCLE.md
+++ b/RELEASE_CYCLE.md
@@ -1,0 +1,29 @@
+# GitHub releases
+
+We typically release GGIR on GitHub no more than once per month, typically in the last week of the month.
+
+When you do this please inform the others that you are going to do this.
+Before releasing, please make sure to check the following:
+
+1. Make sure the change log `inst/NEWS.Rd` is up to date and that it says "GitHub-only-release date" rather than "release date"
+2. Make sure the third (last) digit in the version number is incremented by one relative to the master branch and the date is the present date. This applies to the files `DESCRIPTION`, `CITATION.cff` (not the cff-version, but the version on line 56), `GGIR-package.Rd` and `NEWS.Rd` file. Use function `prepareNewRelease.R` in the root of GGIR to double check that version number and date are consistent between these files.
+3. Update package contributor list if new people have contributed.
+4. Run `R CMD check --as-cran` to make sure all tests and checks pass.
+
+Then, create a new GitHub release.
+Note that GitHub releases require a release name.
+We typically choose a random name of a city or town in South America.
+Whatever you choose this should be an easy to read and remember.
+
+# CRAN releases
+
+To do a CRAN release, follow the following steps:
+
+1. Create GitHub issue at least 4 weeks before the intended CRAN release announcing the release and indicating what will be in the release and a to do list.
+2. A CRAN release should not come with major changes that have not been covered by any of the GitHub releases, except from full version updates (1.0 -> 2.0 -> 3.0 -> ...). If a full version update is the case, create a branch in the wadpac/GGIR repository dedicated to the new release.
+3. When everything looks ready for the release, repeat the same process as for the GitHub release with a few differences:
+    - In the change log it should now say "release data" rather than "GitHub-only-release date".
+    - Second digit in the version number is incremented by 1 relative to the current CRAN version.
+    - Check whether a new R version has been released or is coming up and make sure GGIR is also tested with that version.
+    - Run in RStudio `devtools::check( manual = TRUE, remote = TRUE, incoming = TRUE)` which will help to check urls
+    - All of us will review the new release, and when all are happy I will submit it to CRAN as this needs to come from my e-mail address.

--- a/RELEASE_CYCLE.md
+++ b/RELEASE_CYCLE.md
@@ -1,29 +1,32 @@
+# Version numbering
+
+We use version encoding **A.B-C**:
+
+- A increases with major changes that affect backward compatibility with previous releases like changes in function names, function arguments or file format.
+- B increases with every CRAN release. We aim to avoid more than four CRAN releases per year.
+- C increases with every GitHub release. We aim to avoid more than one GitHub release per month.
+
 # GitHub releases
 
-We typically release GGIR on GitHub no more than once per month, typically in the last week of the month.
-
-When you do this please inform the others that you are going to do this.
 Before releasing, please make sure to check the following:
 
-1. Make sure the change log `inst/NEWS.Rd` is up to date and that it says "GitHub-only-release date" rather than "release date"
-2. Make sure the third (last) digit in the version number is incremented by one relative to the master branch and the date is the present date. This applies to the files `DESCRIPTION`, `CITATION.cff` (not the cff-version, but the version on line 56), `GGIR-package.Rd` and `NEWS.Rd` file. Use function `prepareNewRelease.R` in the root of GGIR to double check that version number and date are consistent between these files.
-3. Update package contributor list if new people have contributed.
-4. Run `R CMD check --as-cran` to make sure all tests and checks pass.
+1. Create GitHub issue at least 1 weeks before the intended release to announce the release and indicate what will be in the release.
+2. Make sure the change log `inst/NEWS.Rd` is up to date and that it says "GitHub-only-release date" rather than "release date"
+3. Make sure the third (last) digit in the version number is incremented by one relative to the master branch and the date is the present date. This applies to the files `DESCRIPTION`, `CITATION.cff` (not the cff-version, but the version on line 56 of the .cff-file), `GGIR-package.Rd` and `NEWS.Rd` file. Use function `prepareNewRelease.R` in the root of GGIR to double check that version number and date are consistent between these files.
+4. Update package contributor list if new people have contributed.
+5. Run `R CMD check --as-cran` to make sure all tests and checks pass.
 
-Then, create a new GitHub release.
-Note that GitHub releases require a release name.
-We typically choose a random name of a city or town in South America.
-Whatever you choose this should be an easy to read and remember.
+Note that GitHub releases require a release name. We typically choose a random name of a city or town in South America. Whatever you choose this should be an easy to read and remember word.
 
 # CRAN releases
 
 To do a CRAN release, follow the following steps:
 
 1. Create GitHub issue at least 4 weeks before the intended CRAN release announcing the release and indicating what will be in the release and a to do list.
-2. A CRAN release should not come with major changes that have not been covered by any of the GitHub releases, except from full version updates (1.0 -> 2.0 -> 3.0 -> ...). If a full version update is the case, create a branch in the wadpac/GGIR repository dedicated to the new release.
+2. A CRAN release should not come with major changes that have not been covered by any of the GitHub-only releases.
 3. When everything looks ready for the release, repeat the same process as for the GitHub release with a few differences:
-    - In the change log it should now say "release data" rather than "GitHub-only-release date".
+    - In the change log it should now say "release date" rather than "GitHub-only-release date".
     - Second digit in the version number is incremented by 1 relative to the current CRAN version.
     - Check whether a new R version has been released or is coming up and make sure GGIR is also tested with that version.
     - Run in RStudio `devtools::check( manual = TRUE, remote = TRUE, incoming = TRUE)` which will help to check urls
-    - All of us will review the new release, and when all are happy I will submit it to CRAN as this needs to come from my e-mail address.
+4. Ask Vincent (GitHub tag: vincentvanhees) to submit the release to CRAN as it needs to come from my e-mail address.

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -5,6 +5,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // numUnpack
 IntegerMatrix numUnpack(IntegerVector pack);
 RcppExport SEXP _GGIR_numUnpack(SEXP packSEXP) {


### PR DESCRIPTION
This PR adds a contributors guide, a code of conduct, a release cycle document and a PR template, integrating all of them together with links and also linking from the README.md.

There are still some commented out things in the README that may need to be copied over to the other files:
- the Version numbers to RELEASE_CYCLE.md
- maybe add the GitHub flow link to point 3 under Changes
- maybe the "unfamiliar with GitHub" section