### PR TITLE
minor doc update: the default enmoa value is FALSE

### DIFF
--- a/man/g.part1.Rd
+++ b/man/g.part1.Rd
@@ -108,7 +108,7 @@ g.part1(datadir=c(),outputdir=c(),f0=1,f1=c(),
   if TRUE, calculate the angle of the z-axis relative to the horizontal plane
   (degrees) utilizing all three axes
   }
-  \item{do.enmoa}{if TRUE (default), calculate metric ENMOa which is equal to
+  \item{do.enmoa}{if TRUE, calculate metric ENMOa which is equal to
   metric ENMO but with the absolute taken from the Euclidean norm minus one.
   }
  \item{do.roll_med_acc_x}{ see \link{g.getmeta}


### PR DESCRIPTION
This is just a very minor documentation discrepancy I noticed -- the default for do.enmoa value is FALSE, not TRUE.
No code changes.
