### PR TITLE
Issue390 ordering qwindow variables

### DIFF
--- a/R/g.analyse.perfile.R
+++ b/R/g.analyse.perfile.R
@@ -251,11 +251,11 @@ g.analyse.perfile = function(ID, fname, deviceSerialNumber, BodyLocation, startt
   options(encoding = "UTF-8")
   if (length(columns2order) > 0) {
     selectcolumns = c(names(filesummary)[1:(columns2order[1] - 1)],
-                      grep(pattern = "^AD_", x = names(filesummary)),
-                      grep(pattern = "^WD_", x = names(filesummary)),
-                      grep(pattern = "^WE_", x = names(filesummary)),
-                      grep(pattern = "^WWD_", x = names(filesummary)),
-                      grep(pattern = "^WWE_", x = names(filesummary)),
+                      grep(pattern = "^AD_", x = names(filesummary), value = T),
+                      grep(pattern = "^WD_", x = names(filesummary), value = T),
+                      grep(pattern = "^WE_", x = names(filesummary), value = T),
+                      grep(pattern = "^WWD_", x = names(filesummary), value = T),
+                      grep(pattern = "^WWE_", x = names(filesummary), value = T),
                       names(filesummary)[(columns2order[length(columns2order)] + 1):ncol(filesummary)])
   } else {
     selectcolumns = names(filesummary)

--- a/R/g.analyse.perfile.R
+++ b/R/g.analyse.perfile.R
@@ -241,18 +241,22 @@ g.analyse.perfile = function(ID, fname, deviceSerialNumber, BodyLocation, startt
     s_names = s_names[-cut]
     filesummary = filesummary[-cut]
   }
-  filesummary = data.frame(value=t(filesummary),stringsAsFactors=FALSE) #needs to be t() because it will be a column otherwise
+  filesummary = data.frame(value = t(filesummary), stringsAsFactors = FALSE) #needs to be t() because it will be a column otherwise
   names(filesummary) = s_names
   
   columns2order = c()
   if (ncol(filesummary) > 37) {
-    columns2order = 30:(ncol(filesummary)-6)
+    columns2order = grep(pattern = "AD_|WE_|WD_|WWD_|WWE_", x = names(filesummary))
   }
   options(encoding = "UTF-8")
   if (length(columns2order) > 0) {
-    selectcolumns = c(names(filesummary)[1:29],
-                      sort(names(filesummary[,columns2order])),
-                      names(filesummary)[(ncol(filesummary)-5):ncol(filesummary)])
+    selectcolumns = c(names(filesummary)[1:(columns2order[1] - 1)],
+                      grep(pattern = "^AD_", x = names(filesummary)),
+                      grep(pattern = "^WD_", x = names(filesummary)),
+                      grep(pattern = "^WE_", x = names(filesummary)),
+                      grep(pattern = "^WWD_", x = names(filesummary)),
+                      grep(pattern = "^WWE_", x = names(filesummary)),
+                      names(filesummary)[(columns2order[length(columns2order)] + 1):ncol(filesummary)])
   } else {
     selectcolumns = names(filesummary)
   }

--- a/R/g.analyse.perfile.R
+++ b/R/g.analyse.perfile.R
@@ -104,12 +104,11 @@ g.analyse.perfile = function(ID, fname, deviceSerialNumber, BodyLocation, startt
                                IVIS_windowsize_minutes)
     iNA = which(is.na(filesummary[vi:(vi+3)]) == TRUE)
     if (length(iNA) > 0) filesummary[(vi:(vi+3))[iNA]] = " "
-    s_names[vi:(vi+2)] = c("IS_interdailystability","IV_intradailyvariability",
-                           "IVIS_windowsize_minutes")
+    s_names[vi:(vi+2)] = c("IS_interdailystability", "IV_intradailyvariability", "IVIS_windowsize_minutes")
     vi = vi + 4
     # Variables per metric - summarise with stratification to weekdays and weekend days
     daytoweekvar = c(5:length(ds_names))
-    md = unique(which(ds_names[daytoweekvar] %in% c("measurementday", "weekday") == TRUE), grep(x = ds_names, pattern="qwindow_timestamps|qwindow_names"))
+    md = which(ds_names[daytoweekvar] %in% c("measurementday", "weekday", "qwindow_timestamps", "qwindow_names"))
     if (length(md) > 0) daytoweekvar = daytoweekvar[-md]
 
     dtwtel = 0

--- a/R/g.analyse.perfile.R
+++ b/R/g.analyse.perfile.R
@@ -207,7 +207,8 @@ g.analyse.perfile = function(ID, fname, deviceSerialNumber, BodyLocation, startt
   }
   rm(LD); rm(ID)
   # tidy up daysummary object
-  mw = which(is.na(daysummary) == T | is.nan(daysummary) == T | grep(pattern = "NaN", x = daysummary))
+  mw = which(is.na(daysummary) == T)
+  mw = c(mw, grep(pattern = "NaN", x = daysummary))
   if (length(mw) > 0) {
     daysummary[mw] = " "
   }
@@ -229,7 +230,8 @@ g.analyse.perfile = function(ID, fname, deviceSerialNumber, BodyLocation, startt
     daysummary = daysummary[,-columnswith16am[2:length(columnswith16am)]]
   }
   # tidy up filesummary object
-  mw = which(is.na(filesummary) == T | is.nan(filesummary) == T | grep(pattern = "NaN", x = filesummary))
+  mw = which(is.na(filesummary) == T)
+  mw = c(mw, grep(pattern = "NaN", x = filesummary))
   if (length(mw) > 0) {
     filesummary[mw] = " "
   }

--- a/R/g.analyse.perfile.R
+++ b/R/g.analyse.perfile.R
@@ -233,7 +233,7 @@ g.analyse.perfile = function(ID, fname, deviceSerialNumber, BodyLocation, startt
   if (length(mw) > 0) {
     filesummary[which(is.na(filesummary)==T)] = " "
   }
-  cut = which(as.character(s_names) == " " | as.character(s_names) == "" | is.na(s_names)==T |
+  cut = which(as.character(s_names) == " " | as.character(s_names) == "" | is.na(s_names)==T | duplicated(s_names) |
                 s_names %in% c("AD_", "WE_", "WD_", "WWD_", "WWE_",
                                "AD_N hours", "WE_N hours", "WD_N hours", "WWD_N hours", "WWE_N hours",
                                "AD_N valid hours", "WE_N valid hours", "WD_N valid hours", "WWD_N valid hours", "WWE_N valid hours"))

--- a/R/g.analyse.perfile.R
+++ b/R/g.analyse.perfile.R
@@ -207,9 +207,9 @@ g.analyse.perfile = function(ID, fname, deviceSerialNumber, BodyLocation, startt
   }
   rm(LD); rm(ID)
   # tidy up daysummary object
-  mw = which(is.na(daysummary)==T)
+  mw = which(is.na(daysummary) == T | is.nan(daysummary) == T)
   if (length(mw) > 0) {
-    daysummary[which(is.na(daysummary)==T)] = " "
+    daysummary[which(is.na(daysummary) == T | is.nan(daysummary) == T)] = " "
   }
   cut = which(ds_names == " " | ds_names == "" | is.na(ds_names)==T)
   if (length(cut > 0)) {
@@ -229,9 +229,9 @@ g.analyse.perfile = function(ID, fname, deviceSerialNumber, BodyLocation, startt
     daysummary = daysummary[,-columnswith16am[2:length(columnswith16am)]]
   }
   # tidy up filesummary object
-  mw = which(is.na(filesummary)==T)
+  mw = which(is.na(filesummary) == T | is.nan(filesummary) == T)
   if (length(mw) > 0) {
-    filesummary[which(is.na(filesummary)==T)] = " "
+    filesummary[which(is.na(filesummary) == T | is.nan(filesummary) == T)] = " "
   }
   cut = which(as.character(s_names) == " " | as.character(s_names) == "" | is.na(s_names)==T | duplicated(s_names) |
                 s_names %in% c("AD_", "WE_", "WD_", "WWD_", "WWE_",

--- a/R/g.analyse.perfile.R
+++ b/R/g.analyse.perfile.R
@@ -207,9 +207,9 @@ g.analyse.perfile = function(ID, fname, deviceSerialNumber, BodyLocation, startt
   }
   rm(LD); rm(ID)
   # tidy up daysummary object
-  mw = which(is.na(daysummary) == T | is.nan(daysummary) == T)
+  mw = which(is.na(daysummary) == T | is.nan(daysummary) == T | grep(pattern = "NaN", x = daysummary))
   if (length(mw) > 0) {
-    daysummary[which(is.na(daysummary) == T | is.nan(daysummary) == T)] = " "
+    daysummary[mw] = " "
   }
   cut = which(ds_names == " " | ds_names == "" | is.na(ds_names)==T)
   if (length(cut > 0)) {
@@ -229,9 +229,9 @@ g.analyse.perfile = function(ID, fname, deviceSerialNumber, BodyLocation, startt
     daysummary = daysummary[,-columnswith16am[2:length(columnswith16am)]]
   }
   # tidy up filesummary object
-  mw = which(is.na(filesummary) == T | is.nan(filesummary) == T)
+  mw = which(is.na(filesummary) == T | is.nan(filesummary) == T | grep(pattern = "NaN", x = filesummary))
   if (length(mw) > 0) {
-    filesummary[which(is.na(filesummary) == T | is.nan(filesummary) == T)] = " "
+    filesummary[mw] = " "
   }
   cut = which(as.character(s_names) == " " | as.character(s_names) == "" | is.na(s_names)==T | duplicated(s_names) |
                 s_names %in% c("AD_", "WE_", "WD_", "WWD_", "WWE_",

--- a/R/g.convert.part2.long.R
+++ b/R/g.convert.part2.long.R
@@ -77,24 +77,24 @@ g.convert.part2.long = function(daySUMMARY) {
   daySUMMARY2$timesegment2 = sapply(daySUMMARY2$variable, FUN = gettimeseg)
   daySUMMARY2 = as.data.frame(daySUMMARY2)
   # tidy up
-  rem = which(colnames(daySUMMARY2) =="variable")
-  daySUMMARY2 = daySUMMARY2[,-rem] # It is a data.table object so column removal works different
-  id.vars = c(id.vars,"timesegment2")
+  rem = which(colnames(daySUMMARY2) == "variable")
+  daySUMMARY2 = daySUMMARY2[, -rem] # It is a data.table object so column removal works different
+  id.vars = c(id.vars, "timesegment2")
   cnt = 1
   # long format that is undersirable is now moved back to wide format
   for (i in unique(daySUMMARY2$variable2)) {
     if (cnt == 1) {
       df = daySUMMARY2[which(daySUMMARY2$variable2 == i),]
       colnames(df)[which(colnames(df) == "value")] = i
-      rem = which(colnames(df) =="variable2")
+      rem = which(colnames(df) == "variable2")
       df = df[,-rem]
     } else {
-      df = base::merge(df, daySUMMARY2[which(daySUMMARY2$variable2 == i),], by=id.vars, all.x=T) #
+      df = base::merge(df, daySUMMARY2[which(daySUMMARY2$variable2 == i),], by = id.vars, all.x = T, sort = F)
       colnames(df)[which(colnames(df) == "value")] = i
-      rem = which(colnames(df) =="variable2")
-      df = df[,-rem]
+      rem = which(colnames(df) == "variable2")
+      df = df[, -rem]
     }
-    cnt = cnt+1
+    cnt = cnt + 1
   }
   # tidy up variable names
   Nvh.1 = which(colnames(df) == "N_valid_hours.1")

--- a/R/g.part2.R
+++ b/R/g.part2.R
@@ -90,7 +90,6 @@ g.part2 = function(datadir = c(), metadatadir = c(), f0 = c(), f1 = c(),
     }
     if (params_general[["overwrite"]] == TRUE) skip = 0
     if (skip == 0) {
-      cat(paste0(" ", i))
       M = c()
       filename_dir = c()
       filefoldername = c()

--- a/R/g.part3.R
+++ b/R/g.part3.R
@@ -65,7 +65,6 @@ g.part3 = function(metadatadir = c(), f0, f1, myfun = c(),
     if (params_general[["overwrite"]] == TRUE) skip = 0
     if (skip == 0) {  
       # Load previously stored meta-data from part1.R
-      cat(paste(" ", i, sep = ""))
       SUM = IMP = M = c()
       load(paste(metadatadir, "/meta/basic/meta_", fnames[i], sep = ""))
       load(paste(metadatadir, "/meta/ms2.out/", fnames[i], sep = ""))

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -4,6 +4,7 @@
 \section{Changes in version 2.6-1 (release date:??-??-2022)}{
 \itemize{
     \item Part 1: Fixed bug that prohibitted processing files in subfolders.
+    \item Part 2: Qwindows logically ordered in reports.
     \item Part 4: Fixed bug introduced in 2.6-0 relating to sleeplog guider being assined even when no sleeplog used.
     \item Part 5: Improved handling of missing sleep estimate for first night.
     \item General: Fix bug introduced in 2.6-0 relating to storage of configuration file on comma-separated machines


### PR DESCRIPTION
<!-- Describe your PR here -->
#390 addressed. Q window variables are now logically ordered in the daysummary, summary, and long.format reports (part 2). Additionally, NaN values are now replaced for empty cells as it was done with NA values (NaN values are produced when e.g.  averaging weekend days and there are not weekend days with enough valid time). Also, small improvements in the identification of variables to be avaraged per week (i.e., day to week variables), and in the selection of variables to be sorted (i.e., AD, WD, WE, WWD, and WWE variables; this was hard coded with the variables indices which may be problematic if the number of variables change).

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [x] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [x] Updated or expanded the documentation.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [x] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.

Fixes #390 