### PR TITLE
Issue523 idle sleep mode calibration

### DIFF
--- a/R/g.calibrate.R
+++ b/R/g.calibrate.R
@@ -166,7 +166,7 @@ g.calibrate = function(datafile, params_rawdata = c(),
       }
       # remove 0s if ActiGraph csv (idle sleep mode)
       if (isTRUE(check_sleepMode)) {
-        data = g.imputeTimegaps(x = as.data.frame(data), xyzCol = 1:3, timeCol = c(), sf = sf, impute == FALSE)
+        data = g.imputeTimegaps(x = as.data.frame(data), xyzCol = 1:3, timeCol = c(), sf = sf, impute = FALSE)
         data = as.matrix(data)
       }
       LD = nrow(data)

--- a/R/g.calibrate.R
+++ b/R/g.calibrate.R
@@ -71,6 +71,8 @@ g.calibrate = function(datafile, params_rawdata = c(),
   mon = INFI$monc
   if (mon == 6) mon = 3
   dformat = INFI$dformc
+  # If ActiGraph and csv format, then check sleep mode
+  check_sleepMode = ifelse(test = (mon == 3 & dformat == 2), yes = TRUE, no = FALSE)
   sf = INFI$sf
   if (length(sf) == 0) { # if sf is not available then try to retrieve sf from rmc.sf
     if (length(params_rawdata[["rmc.sf"]]) == 0) {
@@ -162,7 +164,10 @@ g.calibrate = function(datafile, params_rawdata = c(),
       if (min(dim(S)) > 1) {
         data = rbind(S,data)
       }
-      
+      # remove 0s if ActiGraph csv (idle sleep mode)
+      if (isTRUE(check_sleepMode)) {
+        data = g.imputeTimegaps(x = data, xyzCol = 1:3, timeCol = c(), sf = sf, impute == FALSE)
+      }
       LD = nrow(data)
       #store data that could not be used for this block, but will be added to next block
       use = (floor(LD / (ws*sf))) * (ws*sf) #number of datapoint to use

--- a/R/g.calibrate.R
+++ b/R/g.calibrate.R
@@ -167,6 +167,7 @@ g.calibrate = function(datafile, params_rawdata = c(),
       # remove 0s if ActiGraph csv (idle sleep mode)
       if (isTRUE(check_sleepMode)) {
         data = g.imputeTimegaps(x = as.data.frame(data), xyzCol = 1:3, timeCol = c(), sf = sf, impute == FALSE)
+        data = as.matrix(data)
       }
       LD = nrow(data)
       #store data that could not be used for this block, but will be added to next block

--- a/R/g.calibrate.R
+++ b/R/g.calibrate.R
@@ -67,7 +67,7 @@ g.calibrate = function(datafile, params_rawdata = c(),
                        rmc.headername.recordingid = params_rawdata[["rmc.headername.sn"]],
                        rmc.header.structure = params_rawdata[["rmc.header.structure"]],
                        rmc.check4timegaps = params_rawdata[["rmc.check4timegaps"]])  # Check which file type and monitor brand it is
-  options(warn = 0) #turn off warnings
+  options(warn = 0) #turn on warnings
   mon = INFI$monc
   if (mon == 6) mon = 3
   dformat = INFI$dformc
@@ -90,7 +90,7 @@ g.calibrate = function(datafile, params_rawdata = c(),
   suppressWarnings(expr = {decn = g.dotorcomma(datafile, dformat, mon, 
                                                desiredtz = params_general[["desiredtz"]],
                                                rmc.dec = params_rawdata[["rmc.dec"]])}) #detect dot or comma dataformat
-  options(warn = 0) #turn off warnings
+  options(warn = 0) #turn on warnings
   #creating matrixes for storing output
   S = matrix(0,0,4) #dummy variable needed to cope with head-tailing succeeding blocks of data
   NR = ceiling((90*10^6) / (sf*ws4)) + 1000 #NR = number of 'ws4' second rows (this is for 10 days at 80 Hz)
@@ -166,7 +166,7 @@ g.calibrate = function(datafile, params_rawdata = c(),
       }
       # remove 0s if ActiGraph csv (idle sleep mode)
       if (isTRUE(check_sleepMode)) {
-        data = g.imputeTimegaps(x = data, xyzCol = 1:3, timeCol = c(), sf = sf, impute == FALSE)
+        data = g.imputeTimegaps(x = as.data.frame(data), xyzCol = 1:3, timeCol = c(), sf = sf, impute == FALSE)
       }
       LD = nrow(data)
       #store data that could not be used for this block, but will be added to next block

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -5,6 +5,7 @@
 \itemize{
     \item Part 1: Can now handle .gt3x produced by CentrePoint but for now user needs to change upercase file extension to lowercase
     \item Part 1: Fixed issue #520 with handling Movisens data
+    \item Part 1: Fixed issue #523 with calibration of ActiGraph csv files
     \item Report generation per window: Fix undefined function call introduced in 2.6-1
   }
 }

--- a/man/g.imputeTimegaps.Rd
+++ b/man/g.imputeTimegaps.Rd
@@ -4,11 +4,11 @@
   Impute gaps in three axis raw accelerometer data
 }
 \description{
-  Removes all sample with a zero in each of the three axes, and then imputes time 
+  Removes all sample with a zero in each of the three axes, and then (as default) imputes time 
   gaps by the last recorded value per axis normalised to 1 _g_
 }
 \usage{
-  g.imputeTimegaps(x, xyzCol, timeCol, sf, k=0.25)
+  g.imputeTimegaps(x, xyzCol, timeCol, sf, k = 0.25, impute = TRUE)
 }
 \arguments{
   \item{x}{
@@ -26,10 +26,13 @@
    \item{k}{
     Minimum time gap length to be imputed
   }
+   \item{impute}{
+    Boolean to indicate whether the time gaps identified should be imputed
+  }
 }
 \value{
-  Data.frame based on input x with timegaps inputed
-
+  Data.frame based on input x with timegaps imputed (as default) or with
+  recordings with 0 values in the three axes removed (if impute = FALSE)
 }
 \author{
   Vincent T van Hees <v.vanhees@accelting.com>

--- a/tests/testthat/test_imputeTimegaps.R
+++ b/tests/testthat/test_imputeTimegaps.R
@@ -15,26 +15,34 @@ library(testthat)
   x1 = x
   zeros = c(1:200, 6000:6500, 7000:7500, 8000:8500)
   x1[zeros, xyzCol] = 0
-  x1_imputed = g.imputeTimegaps(x1, xyzCol, timeCol = "time", sf = sf, k = 2/sf)
+  x1_imputed = g.imputeTimegaps(x1, xyzCol, timeCol = "time", sf = sf, k = 2/sf, impute = TRUE)
+  x1_removed = g.imputeTimegaps(x1, xyzCol, timeCol = "time", sf = sf, k = 2/sf, impute = FALSE)
   
   expect_equal(nrow(x1_imputed), N)
   expect_equal(sum(x1_imputed$X), 39068022)
+  expect_equal(nrow(x1_removed), N - length(zeros) + 1)
+  expect_equal(sum(x1_removed$X), 39088150)
   
   x2 = x
   zeros = c(7000:7500, 8000:8500)
   x2[zeros, xyzCol] = 0
-  x2_imputed = g.imputeTimegaps(x2, xyzCol, timeCol = "time", sf = sf, k = 2/sf)
+  x2_imputed = g.imputeTimegaps(x2, xyzCol, timeCol = "time", sf = sf, k = 2/sf, impute = TRUE)
+  x2_removed = g.imputeTimegaps(x2, xyzCol, timeCol = "time", sf = sf, k = 2/sf, impute = FALSE)
   
   expect_equal(nrow(x2_imputed), N)
   expect_equal(sum(x2_imputed$X), 42225082)
+  expect_equal(nrow(x2_removed), N - length(zeros))
+  expect_equal(sum(x2_removed$X), 42239500)
   
   x3 = x_without_time
   zeros = c(7000:7500, 8000:8500)
   x3[zeros, xyzCol] = 0
-  x3_imputed = g.imputeTimegaps(x3, xyzCol, sf = sf, k = 2/sf)
+  x3_imputed = g.imputeTimegaps(x3, xyzCol, sf = sf, k = 2/sf, impute = TRUE)
+  x3_removed = g.imputeTimegaps(x3, xyzCol, sf = sf, k = 2/sf, impute = FALSE)
   
   expect_equal(nrow(x3_imputed), N - 2)
   expect_equal(sum(x3_imputed$X), 42225081)
-  
+  expect_equal(nrow(x3_removed), N - length(zeros))
+  expect_equal(sum(x3_removed$X), 42239500)
 })
  


### PR DESCRIPTION
<!-- Describe your PR here -->
Fixes #523 
Now the rows in which the idle sleep mode is activated are removed from the data before calculating the calibration coefficients. The test file for the g.imputeTimegaps function is extended.

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [x] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [x] Updated or expanded the documentation.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [x] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
