### PR TITLE
Issue525 paramscheck

### DIFF
--- a/R/check_params.R
+++ b/R/check_params.R
@@ -121,7 +121,7 @@ check_params = function(params_sleep = c(), params_metrics = c(),
   
   #-----------------------------------------------------------------------------------
   # Check value combinations and apply corrections if not logical
-  if (length(params_metrics) > 0 & length(params_metrics) > 0) {
+  if (length(params_metrics) > 0 & length(params_sleep) > 0) {
     if (length(params_sleep[["def.noc.sleep"]]) != 2) {
       if (params_sleep[["HASPT.algo"]] != "HorAngle") {
         params_sleep[["HASPT.algo"]] = "HDCZA"

--- a/R/extract_params.R
+++ b/R/extract_params.R
@@ -1,7 +1,9 @@
 extract_params = function(params_sleep = c(), params_metrics = c(),
                           params_rawdata = c(), params_247 = c(),
                           params_phyact = c(), params_cleaning = c(),
-                          params_output = c(), params_general = c(), input = c(), configfile_csv = c()) {
+                          params_output = c(), params_general = c(), input = c(), configfile_csv = c(),
+                          params2check = c("sleep", "metrics", "rawdata", "247", "phyact",
+                                           "cleaning", "output", "general")) {
   # Order of priority using parameters:
   # 1. Arguments provided as direct input by user
   # 2. Arguments provided via configuration file
@@ -44,7 +46,6 @@ extract_params = function(params_sleep = c(), params_metrics = c(),
     params = load_params(group = "general")
     params_general = params$params_general
   }
-  
   #==================================================================================
   # Overwrite them by arguments provided via configuration file
   if (length(configfile_csv) > 0) {
@@ -191,6 +192,17 @@ extract_params = function(params_sleep = c(), params_metrics = c(),
   #==================================================================================
   # Check that all parameter values have expect data class
   # and perform some checks on reasonable parameter combinations
+  
+  # prevent checking of parameters that are not used in GGIR part
+  if (!"sleep" %in% params2check) params_sleep = c()
+  if (!"metrics" %in% params2check) params_metrics = c()
+  if (!"rawdata" %in% params2check) params_rawdata = c()
+  if (!"247" %in% params2check) params_247 = c()
+  if (!"phyact" %in% params2check) params_phyact = c()
+  if (!"cleaning" %in% params2check) params_cleaning = c()
+  if (!"output" %in% params2check) params_output = c()
+  if (!"general" %in% params2check) params_general = c()
+
   params = check_params(params_sleep = params_sleep, params_metrics = params_metrics, 
                         params_rawdata = params_rawdata, params_247 = params_247,
                         params_phyact = params_phyact, params_cleaning = params_cleaning,

--- a/R/g.part1.R
+++ b/R/g.part1.R
@@ -10,7 +10,9 @@ g.part1 = function(datadir = c(), outputdir = c(), f0 = 1, f1 = c(),
                           params_rawdata = params_rawdata,
                           params_cleaning = params_cleaning,
                           params_general = params_general,
-                          input = input) # load default parameters
+                          input = input, 
+                          params2check = c("metrics", "rawdata",
+                                           "cleaning", "general")) # load default parameters
   params_metrics = params$params_metrics
   params_rawdata = params$params_rawdata
   params_cleaning = params$params_cleaning

--- a/R/g.part2.R
+++ b/R/g.part2.R
@@ -9,13 +9,14 @@ g.part2 = function(datadir = c(), metadatadir = c(), f0 = c(), f1 = c(),
                           params_247 = params_247,
                           params_phyact = params_phyact,
                           params_output = params_output,
-                          params_general = params_general, input = input) # load default parameters
+                          params_general = params_general, input = input,
+                          params2check = c("cleaning", "247", "phyact", "output", "general")) # load default parameters
   params_cleaning = params$params_cleaning
   params_247 = params$params_247
   params_phyact = params$params_phyact
   params_output = params$params_output
   params_general = params$params_general
-  
+
   #-----------------------------
   if (is.numeric(params_247[["qwindow"]])) {
     params_247[["qwindow"]] = params_247[["qwindow"]][order(params_247[["qwindow"]])]
@@ -190,6 +191,7 @@ g.part2 = function(datadir = c(), metadatadir = c(), f0 = c(), f1 = c(),
           SUM$daysummary$filename_dir = fullfilenames[i] #full filename structure
           SUM$daysummary$foldername = foldername[i] #store the lowest foldername
         }
+        
         save(SUM,IMP,file = paste0(metadatadir, ms2.out, "/", name)) #IMP is needed for g.plot in g.report.part2
       }
       if (M$filecorrupt == FALSE & M$filetooshort == FALSE) rm(IMP)

--- a/R/g.part3.R
+++ b/R/g.part3.R
@@ -7,7 +7,10 @@ g.part3 = function(metadatadir = c(), f0, f1, myfun = c(),
   input = list(...)
   params = extract_params(params_sleep = params_sleep,
                           params_metrics = params_metrics,
-                          params_general = params_general, params_output = params_output, input = input) # load default parameters
+                          params_general = params_general, 
+                          params_output = params_output, input = input,
+                          params2check = c("sleep", "metrics",
+                                           "general", "output")) # load default parameters
   params_sleep = params$params_sleep
   params_metrics = params$params_metrics
   params_general = params$params_general

--- a/R/g.part4.R
+++ b/R/g.part4.R
@@ -9,7 +9,9 @@ g.part4 = function(datadir = c(), metadatadir = c(), f0 = f0, f1 = f1,
   input = list(...)
   params = extract_params(params_sleep = params_sleep, params_metrics = params_metrics,
                           params_general = params_general, params_output = params_output,
-                          params_cleaning = params_cleaning, input = input) # load default parameters
+                          params_cleaning = params_cleaning, input = input,
+                          params2check = c("sleep", "metrics",
+                                           "general", "output", "cleaning")) # load default parameters
   params_sleep = params$params_sleep
   params_metrics = params$params_metrics
   params_cleaning = params$params_cleaning

--- a/R/g.part5.R
+++ b/R/g.part5.R
@@ -19,7 +19,9 @@ g.part5 = function(datadir = c(), metadatadir = c(), f0=c(), f1=c(),
                           params_cleaning = params_cleaning,
                           params_output = params_output,
                           params_general = params_general,
-                          input = input)
+                          input = input, params2check = c("sleep", "metrics", "247",
+                                                          "phyact", "cleaning",
+                                                          "general", "output"))
   params_sleep = params$params_sleep
   params_metrics = params$params_metrics
   params_247 = params$params_247

--- a/R/g.report.part2.R
+++ b/R/g.report.part2.R
@@ -93,6 +93,9 @@ g.report.part2 = function(metadatadir=c(),f0=c(),f1=c(),maxdur = 0,selectdaysfil
           }
         }
       }
+      if (length(SUMMARY) == 0 |length(daySUMMARY) == 0) {
+        warning("No summary data available to be stored in csv-reports")
+      }
       SUMMARY_clean = tidyup_df(SUMMARY)
       daySUMMARY_clean = tidyup_df(daySUMMARY)
       #-----------------

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -5,6 +5,7 @@
 \itemize{
     \item Part 1: Can now handle .gt3x produced by CentrePoint but for now user needs to change upercase file extension to lowercase
     \item Part 1: Fixed issue #520 with handling Movisens data
+    \item General: Prevent warnings resulting from some unnecessary checks of params objects
     \item Report generation per window: Fix undefined function call introduced in 2.6-1
   }
 }

--- a/man/extract_params.Rd
+++ b/man/extract_params.Rd
@@ -49,8 +49,9 @@
     Csv configuration file
   }
   \item{params2check}{
-    Character vector to indicate which parameters need to be checked, otherwise the
-    function also checks the default values.
+    Character vector to indicate which params objects need to be checked.
+    This allows us to prevent the function from checking params objects that are not used
+    in the context where function extract_params is used.
   }
 }
 \value{

--- a/man/extract_params.Rd
+++ b/man/extract_params.Rd
@@ -12,7 +12,9 @@
                  params_rawdata = c(), params_247 = c(),
                  params_phyact = c(), params_cleaning = c(),
                  params_output = c(), params_general = c(), input = c(),
-                 configfile_csv = c())
+                 configfile_csv = c(), params2check = c("sleep", "metrics",
+                 "rawdata", "247", "phyact",
+                                           "cleaning", "output", "general"))
 }
 \arguments{
   \item{params_sleep}{
@@ -45,6 +47,10 @@
   }
   \item{configfile_csv}{
     Csv configuration file
+  }
+  \item{params2check}{
+    Character vector to indicate which parameters need to be checked, otherwise the
+    function also checks the default values.
   }
 }
 \value{


### PR DESCRIPTION
<!-- Describe your PR here -->

Fixes #525: params_check is now skipped for params objects that are not used in the GGIR part it is used in. This avoids unnecessary warning messages.


<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Updated or expanded the documentation.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
