### PR TITLE
Fix to issue531 sleeplog ignored if missing value on first night

### DIFF
--- a/R/g.part4.R
+++ b/R/g.part4.R
@@ -251,8 +251,11 @@ g.part4 = function(datadir = c(), metadatadir = c(), f0 = f0, f1 = f1,
         daysleeper = rep(FALSE, length(nnights.list))
         ###########################################################
         nightj = 1
+        sleeplog.t = data.frame(matrix(NA, length(nnights.list), 5), stringsAsFactors = FALSE)
+        names(sleeplog.t) = c("ID", "night", "duration", "sleeponset", "sleepwake")
+        sleeplog.t$night = nnights.list
         if (dolog == TRUE) {
-          sleeplog.t = sleeplog[wi, ]
+          sleeplog.t[which(sleeplog.t$night %in% sleeplog$night),] = sleeplog[wi, ]
         }
         for (j in nnights.list) {
           # go through the nights get default onset and wake (based on sleeplog or on heuristic
@@ -326,10 +329,6 @@ g.part4 = function(datadir = c(), metadatadir = c(), f0 = f0, f1 = f1,
             #-----------------------------------------------------------
             # If sleep log is not available available, use default values calculated above (with
             # the heuristic algorithm HDCZA or if that fails L5+/-6hr.
-            if (j == nnights.list[1] & dolog == FALSE) {
-              sleeplog.t = data.frame(matrix(0, length(nnightlist), 5), stringsAsFactors = FALSE)
-              names(sleeplog.t) = c("ID", "night", "duration", "sleeponset", "sleepwake")
-            }
             sleeplog.t[j, 1:5] = c(accid, j, defaultdur, convertHRsinceprevMN2Clocktime(defaultSptOnset),
                                    convertHRsinceprevMN2Clocktime(defaultSptWake))
             cleaningcode = 1
@@ -343,6 +342,7 @@ g.part4 = function(datadir = c(), metadatadir = c(), f0 = f0, f1 = f1,
           
           spocumi = 1  # counter for sleep periods
           # continue now with the specific data of the night
+          
           sleeplog.t2 = sleeplog.t[which(sleeplog.t$night == j), ]
           # ================================================================================ get
           # sleeplog (or HDCZA or L5+/-6hr algorithm) onset and waking time and assess whether it

--- a/R/g.part4.R
+++ b/R/g.part4.R
@@ -315,8 +315,11 @@ g.part4 = function(datadir = c(), metadatadir = c(), f0 = f0, f1 = f1,
           if (dolog == TRUE) {
             #-----------------------------------------------------------
             # If sleep log is available for at least one night use it
-            if (all(!is.na(sleeplog[wi[j], 4:5]))) {
-              sleeplog_used = TRUE
+            index_in_log = which(sleeplog$night == j)
+            if (length(index_in_log) > 0) {
+              if (all(!is.na(sleeplog[index_in_log, 4:5]))) {
+                sleeplog_used = TRUE
+              }
             }
           }
           if (sleeplog_used == FALSE) {

--- a/R/g.part4.R
+++ b/R/g.part4.R
@@ -317,12 +317,9 @@ g.part4 = function(datadir = c(), metadatadir = c(), f0 = f0, f1 = f1,
           sleeplog_used = FALSE
           if (dolog == TRUE) {
             #-----------------------------------------------------------
-            # If sleep log is available for at least one night use it
-            index_in_log = which(sleeplog$night == j)
-            if (length(index_in_log) > 0) {
-              if (all(!is.na(sleeplog[index_in_log, 4:5]))) {
-                sleeplog_used = TRUE
-              }
+            # If sleep log is available and values are not missing
+            if (all(!is.na(guider.df[j, 4:5]))) {
+              sleeplog_used = TRUE
             }
           }
           if (sleeplog_used == FALSE) {
@@ -330,7 +327,7 @@ g.part4 = function(datadir = c(), metadatadir = c(), f0 = f0, f1 = f1,
             # If sleep log is not available available, use default values calculated above (with
             # the heuristic algorithm HDCZA or if that fails L5+/-6hr.
             guider.df[j, 1:5] = c(accid, j, defaultdur, convertHRsinceprevMN2Clocktime(defaultSptOnset),
-                                   convertHRsinceprevMN2Clocktime(defaultSptWake))
+                                  convertHRsinceprevMN2Clocktime(defaultSptWake))
             cleaningcode = 1
           }
           nightj = nightj + 1

--- a/R/g.part4.R
+++ b/R/g.part4.R
@@ -251,11 +251,11 @@ g.part4 = function(datadir = c(), metadatadir = c(), f0 = f0, f1 = f1,
         daysleeper = rep(FALSE, length(nnights.list))
         ###########################################################
         nightj = 1
-        sleeplog.t = data.frame(matrix(NA, length(nnights.list), 5), stringsAsFactors = FALSE)
-        names(sleeplog.t) = c("ID", "night", "duration", "sleeponset", "sleepwake")
-        sleeplog.t$night = nnights.list
+        guider.df = data.frame(matrix(NA, length(nnights.list), 5), stringsAsFactors = FALSE)
+        names(guider.df) = c("ID", "night", "duration", "sleeponset", "sleepwake")
+        guider.df$night = nnights.list
         if (dolog == TRUE) {
-          sleeplog.t[which(sleeplog.t$night %in% sleeplog$night),] = sleeplog[wi, ]
+          guider.df[which(guider.df$night %in% sleeplog$night),] = sleeplog[wi, ]
         }
         for (j in nnights.list) {
           # go through the nights get default onset and wake (based on sleeplog or on heuristic
@@ -329,7 +329,7 @@ g.part4 = function(datadir = c(), metadatadir = c(), f0 = f0, f1 = f1,
             #-----------------------------------------------------------
             # If sleep log is not available available, use default values calculated above (with
             # the heuristic algorithm HDCZA or if that fails L5+/-6hr.
-            sleeplog.t[j, 1:5] = c(accid, j, defaultdur, convertHRsinceprevMN2Clocktime(defaultSptOnset),
+            guider.df[j, 1:5] = c(accid, j, defaultdur, convertHRsinceprevMN2Clocktime(defaultSptOnset),
                                    convertHRsinceprevMN2Clocktime(defaultSptWake))
             cleaningcode = 1
           }
@@ -343,15 +343,15 @@ g.part4 = function(datadir = c(), metadatadir = c(), f0 = f0, f1 = f1,
           spocumi = 1  # counter for sleep periods
           # continue now with the specific data of the night
           
-          sleeplog.t2 = sleeplog.t[which(sleeplog.t$night == j), ]
+          guider.df2 = guider.df[which(guider.df$night == j), ]
           # ================================================================================ get
           # sleeplog (or HDCZA or L5+/-6hr algorithm) onset and waking time and assess whether it
           # is a nightworker onset
-          tmp1 = as.character(sleeplog.t2$sleeponset[1])
+          tmp1 = as.character(guider.df2$sleeponset[1])
           tmp2 = unlist(strsplit(tmp1, ":"))
           SptOnset = as.numeric(tmp2[1]) + (as.numeric(tmp2[2])/60) + (as.numeric(tmp2[3])/3600)
           # wake
-          tmp4 = as.character(sleeplog.t2$sleepwake[1])
+          tmp4 = as.character(guider.df2$sleepwake[1])
           tmp5 = unlist(strsplit(tmp4, ":"))
           SptWake = as.numeric(tmp5[1]) + (as.numeric(tmp5[2])/60) + (as.numeric(tmp5[3])/3600)
           # Assess whether it is a daysleeper or a nightsleeper
@@ -445,7 +445,7 @@ g.part4 = function(datadir = c(), metadatadir = c(), f0 = f0, f1 = f1,
             } else {
               acc_available = TRUE
             }
-            # we now have sleeplog (or HDCZA or L5+/-6hr) data for one night (sleeplog.t2) and we
+            # we now have sleeplog (or HDCZA or L5+/-6hr) data for one night (guider.df2) and we
             # have acc data for one night (sleepdet)
             defs = unique(sleepdet$definition)  # definition of sleep episode metric (see van Hees 2015 PLoSONE paper)
             for (k in defs) {

--- a/R/g.part4.R
+++ b/R/g.part4.R
@@ -307,9 +307,9 @@ g.part4 = function(datadir = c(), metadatadir = c(), f0 = f0, f1 = f1,
           defaultdur = defaultSptWake - defaultSptOnset  #default sleep duration based on sleeplog, L5+/-6hr, or HDCZA algorithm
           sleeplog_used = FALSE
           if (dolog == TRUE) {
-            if (is.na(sleeplog[wi[j], 3]) == FALSE) {
-              #-----------------------------------------------------------
-              # If sleep log is available for a specific night then use it
+            #-----------------------------------------------------------
+            # If sleep log is available for at least one night use it
+            if (all(is.na(sleeplog[wi[j], params_sleep[["coln1"]]:ncol(sleeplog)])) == FALSE) {
               sleeplog_used = TRUE
             }
           }

--- a/R/g.part4.R
+++ b/R/g.part4.R
@@ -202,7 +202,8 @@ g.part4 = function(datadir = c(), metadatadir = c(), f0 = f0, f1 = f1,
         sib.cla.sum$sib.onset.time = iso8601chartime2POSIX(sib.cla.sum$sib.onset.time, tz = params_general[["desiredtz"]])
         sib.cla.sum$sib.end.time = iso8601chartime2POSIX(sib.cla.sum$sib.end.time, tz = params_general[["desiredtz"]])
         # extract the identifier from accelerometer data and matching indices of sleeplog:
-        idwi = g.part4_extractid(params_general[["idloc"]], fname = fnames[i], dolog, params_sleep[["sleeplogidnum"]], sleeplog, accid = accid)
+        idwi = g.part4_extractid(params_general[["idloc"]], fname = fnames[i],
+                                 dolog, params_sleep[["sleeplogidnum"]], sleeplog, accid = accid)
         accid = idwi$accid
         wi = idwi$matching_indices_sleeplog
         #-----------------------------------------------------------
@@ -314,7 +315,7 @@ g.part4 = function(datadir = c(), metadatadir = c(), f0 = f0, f1 = f1,
           if (dolog == TRUE) {
             #-----------------------------------------------------------
             # If sleep log is available for at least one night use it
-            if (all(is.na(sleeplog[wi[j], params_sleep[["coln1"]]:ncol(sleeplog)])) == FALSE) {
+            if (all(!is.na(sleeplog[wi[j], 4:5]))) {
               sleeplog_used = TRUE
             }
           }
@@ -390,6 +391,7 @@ g.part4 = function(datadir = c(), metadatadir = c(), f0 = f0, f1 = f1,
             SptWake = defaultSptWake + 24  #use default assumption about wake
             logdur[i] = SptWake - SptOnset
             cleaningcode = 1  # no diary available for this night, so fall back on detaults
+            sleeplog_used = FALSE
           }
           #-----------------------------------------
           # plan analysis according to knowledge about whether it is a daysleeper or not if you

--- a/R/g.sib.det.R
+++ b/R/g.sib.det.R
@@ -112,6 +112,9 @@ g.sib.det = function(M, IMP, I, twd = c(-12, 12),
         angley = fix_NA_invector(angley)
       }
     }
+    if (acc.metric %in% colnames(IMP$metashort) == FALSE) {
+      warning("Argument acc.metric is set to ",acc.metric," but not found in GGIR part 1 output data")
+    }
     ACC = as.numeric(as.matrix(IMP$metashort[,which(colnames(IMP$metashort) == acc.metric)]))
     night = rep(0, length(anglez))
     if (params_sleep[["HASIB.algo"]] == "Sadeh1994" | params_sleep[["HASIB.algo"]] == "Galland2012") { # extract zeroCrossingCount

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -6,6 +6,7 @@
     \item Part 4: Now able to work with idloc values other than 2 and 5
     \item Minor documentation updates to cover BrondCounts and to reflect that 
       bout.metric is no longer 4 by default
+    \item Part 4: Fix bug #531 re. sleeplog being ignored if first night is missing
     }
 }
 \section{Changes in version 2.6-2 (GitHub-only-release date:06-03-2022)}{


### PR DESCRIPTION
<!-- Describe your PR here -->

Fixes #531 by making sure that sleeplog is used if any (not just the first) night of sleep has a data entry in the sleeplog.

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Updated or expanded the documentation.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
