### PR TITLE
Issue #535 - set number of cores to number of files

### DIFF
--- a/R/g.part1.R
+++ b/R/g.part1.R
@@ -439,7 +439,7 @@ g.part1 = function(datadir = c(), outputdir = c(), f0 = 1, f1 = c(),
         params_rawdata[["chunksize"]] = 0.4 # put limit to chunksize, because when processing in parallel memory is more limited
       }
       if (length(params_general[["maxNcores"]]) == 0) params_general[["maxNcores"]] = Ncores
-      Ncores2use = min(c(Ncores - 1, params_general[["maxNcores"]]))
+      Ncores2use = min(c(Ncores - 1, params_general[["maxNcores"]], (f1 - f0) + 1))
       cl <- parallel::makeCluster(Ncores2use) #not to overload your computer
       doParallel::registerDoParallel(cl)
       

--- a/R/g.part2.R
+++ b/R/g.part2.R
@@ -206,7 +206,7 @@ g.part2 = function(datadir = c(), metadatadir = c(), f0 = c(), f1 = c(),
     Ncores = cores[1]
     if (Ncores > 3) {
       if (length(params_general[["maxNcores"]]) == 0) params_general[["maxNcores"]] = Ncores
-      Ncores2use = min(c(Ncores - 1, params_general[["maxNcores"]]))
+      Ncores2use = min(c(Ncores - 1, params_general[["maxNcores"]], (f1 - f0) + 1))
       cl <- parallel::makeCluster(Ncores2use) #not to overload your computer
       doParallel::registerDoParallel(cl)
     } else {

--- a/R/g.part3.R
+++ b/R/g.part3.R
@@ -124,7 +124,7 @@ g.part3 = function(metadatadir = c(), f0, f1, myfun = c(),
     Ncores = cores[1]
     if (Ncores > 3) {
       if (length(params_general[["maxNcores"]]) == 0) params_general[["maxNcores"]] = Ncores
-      Ncores2use = min(c(Ncores - 1, params_general[["maxNcores"]]))
+      Ncores2use = min(c(Ncores - 1, params_general[["maxNcores"]], (f1 - f0) + 1))
       cl <- parallel::makeCluster(Ncores2use) #not to overload your computer
       doParallel::registerDoParallel(cl)
     } else {

--- a/R/g.part5.R
+++ b/R/g.part5.R
@@ -966,7 +966,7 @@ g.part5 = function(datadir = c(), metadatadir = c(), f0=c(), f1=c(),
     Ncores = cores[1]
     if (Ncores > 3) {
       if (length(params_general[["maxNcores"]]) == 0) params_general[["maxNcores"]] = Ncores
-      Ncores2use = min(c(Ncores - 1, params_general[["maxNcores"]]))
+      Ncores2use = min(c(Ncores - 1, params_general[["maxNcores"]], (f1 - f0) + 1))
       cl <- parallel::makeCluster(Ncores2use) #not to overload your computer
       doParallel::registerDoParallel(cl)
     } else {

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -7,6 +7,8 @@
     if that fails. Previously it extracted the ID twice.
     \item Minor documentation updates to cover brondcounts and to reflect that 
       bout.metric is no longer 4 by default
+    \item Minor change to parallel processing so that GGIR does not create a cluster larger than the number of 
+      files to process. Fixes #535
     }
 }
 \section{Changes in version 2.6-2 (GitHub-only-release date:06-03-2022)}{

--- a/man/g.part1.Rd
+++ b/man/g.part1.Rd
@@ -289,8 +289,8 @@
       \item{do.parallel}{Boolean. whether to use multi-core processing
         (only works if at least 4 CPU cores are available).}
       \item{maxNcores}{Numeric. Maximum number of cores to use when argument do.parallel is set to true.
-        GGIR by default uses the maximum number of available cores, but this argument
-        allows you to set a lower maximum.}
+        GGIR by default uses either the maximum number of available cores or the number of files to 
+        process (whichever is lower), but this argument allows you to set a lower maximum.}
       \item{acc.metric}{Boolean. Which one of the metrics do you want to consider to analyze L5.
         The metric of interest need to be calculated in M.}
       \item{part5_agg2_60seconds}{Boolean. Wether to use aggregate epochs to 60 seconds


### PR DESCRIPTION
See discussion in #535. This change restricts GGIR to creating clusters only as large as the number of files to process, in instances where more cores are available. This prevents the creation of unnecessary workers.

Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [x] Updated or expanded the documentation.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.

**Note**: There are no existing tests on the number of cores, and without wrapping at a function (a bit overkill) I'm not sure how you would test it. All current tests pass on my machine. I'm not sure that a four-line commit rises to inclusion at a contributor so I haven't updated DESCRIPTION, but happy for you to adjudicate this.