### PR TITLE
Issue 575 - inform user when GGIR version is behind CRAN

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -55,5 +55,6 @@ importFrom("stats", "aggregate.data.frame", "weighted.mean",
             "residuals", "fitted")
 import(data.table)
 importFrom("methods", "is")
+importFrom("utils", "available.packages", "packageVersion")
 useDynLib(GGIR, .registration = TRUE)
 importFrom(Rcpp, sourceCpp)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -6,7 +6,7 @@
   behind_cran <- cran_version > local_version
   if (interactive()) {
     if (behind_cran) {
-      msg <- paste0("A new version of GGIR (", cran_version,") is available with bug fixes and new features. Do not forget to install it.")
+      msg <- paste0("A newer version of GGIR is available with bug fixes and new features. [", local_version," --> ", cran_version, "]")
       packageStartupMessage(msg)
     }   
   }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,13 @@
+.onAttach <- function(...) {
+  if (!interactive()) return()
+  pkgs <- available.packages()
+  cran_version <- package_version(pkgs[which(pkgs[,1] == "GGIR"),"Version"])
+  local_version <- packageVersion("GGIR")
+  behind_cran <- cran_version > local_version
+  if (interactive()) {
+    if (behind_cran) {
+      msg <- paste0("Did you know that a newer version of GGIR (", cran_version,") is available with bug fixes and new features? Do not forget to install it.")
+      packageStartupMessage(msg)
+    }   
+  }
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -4,7 +4,6 @@
   cran_version <- package_version(pkgs[which(pkgs[,1] == "GGIR"),"Version"])
   local_version <- packageVersion("GGIR")
   behind_cran <- cran_version > local_version
-  behind_cran = TRUE
   if (interactive()) {
     if (behind_cran) {
       msg <- paste0("A new version of GGIR (", cran_version,") is available with bug fixes and new features. Do not forget to install it.")

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -4,9 +4,10 @@
   cran_version <- package_version(pkgs[which(pkgs[,1] == "GGIR"),"Version"])
   local_version <- packageVersion("GGIR")
   behind_cran <- cran_version > local_version
+  behind_cran = TRUE
   if (interactive()) {
     if (behind_cran) {
-      msg <- paste0("Did you know that a newer version of GGIR (", cran_version,") is available with bug fixes and new features? Do not forget to install it.")
+      msg <- paste0("A new version of GGIR (", cran_version,") is available with bug fixes and new features. Do not forget to install it.")
       packageStartupMessage(msg)
     }   
   }

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -1,6 +1,11 @@
 \name{NEWS}
 \title{News for Package \pkg{GGIR}}
 \newcommand{\cpkg}{\href{http://CRAN.R-project.org/package=#1}{\pkg{#1}}}
+\section{Changes in version 2.7-2 (GitHub-only-release date:06-06-2022)}{
+\itemize{
+    \item Inform user (onAttach) when local GGIR version is behind CRAN version.
+  }
+}
 \section{Changes in version 2.7-1 (release date:29-05-2022)}{
 \itemize{
     \item Fixing bug #566 concerning decision to not parallel process being made too late


### PR DESCRIPTION
<!-- Describe your PR here -->
fixes #575 

NEW: When user loads GGIR with `library(GGIR)` and their local GGIR version is behind CRAN version the user is informed about it via a console message.

I did this by adding the zzz.R function file with an onAttach() element.

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Updated or expanded the documentation.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
