### PR TITLE
Part 4 updates: Improved ID extraction and aggregation now file- instead of ID-based.

### DIFF
--- a/R/g.part4_extractid.R
+++ b/R/g.part4_extractid.R
@@ -54,6 +54,10 @@ g.part4_extractid = function(idloc, fname, dolog, sleeplogidnum, sleeplog, accid
   if (dolog == TRUE) {
     accid_num = suppressWarnings(as.numeric(accid))
     if (sleeplogidnum == FALSE) {
+      # remove spaces in ID, to ease matching, because some accelerometer brands at several spaces behind ID
+      sleeplog$ID = gsub(pattern = " ", replacement = "", x = as.character(sleeplog$ID))
+      accid = gsub(pattern = " ", replacement = "", x = as.character(accid))
+      # attempt to match
       matching_indices_sleeplog = which(as.character(sleeplog$ID) == as.character(accid))
       if (length(matching_indices_sleeplog) == 0) {
         matching_indices_sleeplog_alternative = which(sleeplog$ID == accid_num)

--- a/R/g.report.part4.R
+++ b/R/g.report.part4.R
@@ -196,29 +196,31 @@ g.report.part4 = function(datadir = c(), metadatadir = c(), loglocation = c(), f
         } else {
           personSummary = matrix(0, NIDS, ((NDEF * 3 * 22) + 13 + (6 * 3)))
         }
-        uid = unique(nightsummary$ID)
+        # unique filenames, previously we used unique IDs, but that would not allow
+        # for repeated measurements of the same ID to be summarised separately
+        uniquefn = unique(nightsummary$filename) 
         if (nrow(nightsummary) > 0) {
-          for (i in 1:length(uid)) {
+          for (i in 1:length(uniquefn)) {
             personSummarynames = c()  #moved here on 3/12/2014
             # fully cleaned from nights that need to be deleted
-            nightsummary.tmp = nightsummary[which(nightsummary$ID == uid[i]), ]  #back up
+            this_file = which(nightsummary$filename == uniquefn[i])
+            nightsummary.tmp = nightsummary[this_file, ]  #back up
             udef = as.character(unique(nightsummary.tmp$sleepparam))
             if (length(which(as.character(udef) == "0") > 0))
               udef = udef[-c(which(as.character(udef) == "0"))]
             udefn = udef
             #-------------------------------------------
             # general info about file
-            personSummary[i, 1] = uid[i]  #id
+            personSummary[i, 1] = nightsummary.tmp$ID[1]  #id
             personSummarynames = c(personSummarynames, "ID")
-            personSummary[i, 2] = as.character(nightsummary$filename[which(nightsummary$ID == uid[i])][1])  #filename
+            personSummary[i, 2] = uniquefn[i] #as.character(nightsummary$filename[which(nightsummary$ID == uid[i])][1])  #filename
             if (length(unlist(strsplit(as.character(personSummary[i, 2]), ".RDa"))) > 1)
               personSummary[i, 2] = unlist(strsplit(personSummary[i, 2], ".RDa"))[1]
             personSummarynames = c(personSummarynames, "filename")
             cntt = 2
-            personSummary[i, cntt + 1] = as.character(nightsummary$calendar_date[which(nightsummary$ID ==
-                                                                                         uid[i])][1])  #date
+            personSummary[i, cntt + 1] = as.character(nightsummary$calendar_date[this_file[1]])  #date
             personSummarynames = c(personSummarynames, "calendar_date")
-            personSummary[i, cntt + 2] = nightsummary$weekday[which(nightsummary$ID == uid[i])][1]  #date
+            personSummary[i, cntt + 2] = nightsummary$weekday[this_file[1]]  #date
             personSummarynames = c(personSummarynames, "weekday")
             # sleep log used
             personSummary[i, cntt + 3] = as.character(nightsummary.tmp$sleeplog_used[1])
@@ -316,20 +318,20 @@ g.report.part4 = function(datadir = c(), metadatadir = c(), loglocation = c(), f
             }
             nightsummary$cleaningcode = as.numeric(nightsummary$cleaningcode)
             nightsummary$ID = as.character(nightsummary$ID)
-            uid = as.character(uid)
+            # uid = as.character(uid)
             #-------------------------------------------
             # accelerometer summary
             #----------------------------------------------
             if (only.use.sleeplog == FALSE) {
               # when sleep log is not available
               if (dotwice == 2) {
-                CRIT = which(nightsummary$ID == uid[i] & (nightsummary$cleaningcode == 0 | nightsummary$cleaningcode ==
+                CRIT = which(nightsummary$filename == uniquefn[i] & (nightsummary$cleaningcode == 0 | nightsummary$cleaningcode ==
                                                             1))
               } else {
-                CRIT = which(nightsummary$ID == uid[i])
+                CRIT = which(nightsummary$filename == uniquefn[i])
               }
             } else {
-              CRIT = which(nightsummary$ID == uid[i] & nightsummary$cleaningcode == 0)  #when sleep log is available
+              CRIT = which(nightsummary$filename == uniquefn[i] & nightsummary$cleaningcode == 0)  #when sleep log is available
             }
             personSummarynames_backup = c()
             if (length(CRIT) > 0) {


### PR DESCRIPTION
<!-- Describe your PR here -->

Fixes #587 by removing spaces in the ID values right before an attempt it made to match the character values during the ID recognition in part4.

Fixes #583 by aggregating the part4 report based on filename instead of participant ID. This should be identical for most studies, but is important for studies with repeated recordings with the same ID.

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Updated or expanded the documentation.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
