### PR TITLE
fixed error with handling the AX6 gyroscope data

### DIFF
--- a/R/g.getmeta.R
+++ b/R/g.getmeta.R
@@ -310,13 +310,12 @@ g.getmeta = function(datafile, params_metrics = c(), params_rawdata = c(),
           data = P$rawxyz
         } else if (dformat == 4) { #cwa
           if (P$header$hardwareType == "AX6") { # cwa AX6
-            gyro_available = TRUE
-          }
-          if (P$header$hardwareType == "AX6") { # cwa AX6
             # GGIR now ignores the AX6 gyroscope signals until added value has robustly been demonstrated
             data = P$data[,-c(2:4)]
             P$data = P$data[1:min(100,nrow(P$data)),-c(2:4)] # trim object, because rest of data is not needed anymore
-            gyro_available = FALSE
+            gyro_available = FALSE 
+            # If we ever want to use gyroscope data then
+            # comment out this if statement and set gyro_available = TRUE
           } else {
             data = P$data
             P$data = P$data[1:min(100,nrow(P$data)),] # trim object, because rest of data is not needed anymore

--- a/R/g.getmeta.R
+++ b/R/g.getmeta.R
@@ -315,9 +315,12 @@ g.getmeta = function(datafile, params_metrics = c(), params_rawdata = c(),
           if (P$header$hardwareType == "AX6") { # cwa AX6
             # GGIR now ignores the AX6 gyroscope signals until added value has robustly been demonstrated
             data = P$data[,-c(2:4)]
+            P$data = P$data[1:min(100,nrow(P$data)),-c(2:4)] # trim object, because rest of data is not needed anymore
+            gyro_available = FALSE
+          } else {
+            data = P$data
+            P$data = P$data[1:min(100,nrow(P$data)),] # trim object, because rest of data is not needed anymore
           }
-          data = P$data
-          P$data = P$data[1:min(100,nrow(P$data)),-c(2:4)] # trim object, because rest of data is not needed anymore
         } else if (dformat == 5) { # ad-hoc csv
           data = P$data
         } else if (mon == 5) { #movisense

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -1,6 +1,11 @@
 \name{NEWS}
 \title{News for Package \pkg{GGIR}}
 \newcommand{\cpkg}{\href{http://CRAN.R-project.org/package=#1}{\pkg{#1}}}
+\section{Changes in version 2.7-5 (GitHub-only-release date: ?-?-2022)}{
+\itemize{
+    \item Part 1: AX6 gyroscope data correctly ignored in g.getmeta.
+    }
+}
 \section{Changes in version 2.7-4 (GitHub-only-release date:17-08-2022)}{
 \itemize{
     \item Part 1: Arguments configtz and desiredtz now also used for .gt3x data.


### PR DESCRIPTION
<!-- Describe your PR here -->
Fixes #623 
Now g.getmeta removes the columns relative to the gyroscope data and set gyro_available to FALSE so that the column indices do not get messed in the next steps of the processing. I did it this way to facilitate recovering the gyro reading functionality in the future in case we need it.

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [x] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [x] Updated or expanded the documentation.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [x] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
