### PR TITLE
making sure remaining_epochs column in S is also passed on

### DIFF
--- a/R/g.getmeta.R
+++ b/R/g.getmeta.R
@@ -347,10 +347,11 @@ g.getmeta = function(datafile, params_metrics = c(), params_rawdata = c(),
                 S = cbind(S, 1)
                 colnames(S)[4] = "remaining_epochs"
               }
-            } else {
+            } else if ("remaining_epochs" %in% colnames(S) == TRUE) {
               if ((ncol(S) - 1) == ncol(data)) {
                 # this block does not have time gaps while the previous blog did
-                S = S[, 1:(ncol(S) - 1)]
+                data = cbind(data, 1)
+                colnames(data)[4] = "remaining_epochs"
               }
             }
           }


### PR DESCRIPTION
Fixes #622:

The issue was that time gaps calculated for the remainder of the previous data chunk stored in object `S` were ignored.

I have tested this by creating a dummy file, which I created with:

```
now = as.numeric(as.POSIXlt("2022-09-09 16:30:00", tz = "Europe/Amsterdam"))
time = seq(now, (now + (48*3600)) , by = 1/10)
x = y = z = rnorm(n = length(time), mean = 0, sd = 0.5)
A = data.frame(time = time, x = x, y = y, z = z)
A = A[-c(500001:600000),] # remove artificial data
write.csv(x = A, file = "~/testfile/test.csv", row.names = FALSE)
```

Next, I processed it with GGIR:

```
datadir = "~/testfile"
outputdir = "~/tesresults"
GGIR(datadir = datadir,
     rmc.firstrow.acc = 1,
     rmc.col.acc = 2:4, rmc.col.time = 1,
     rmc.unit.time = "UNIXsec",
     imputeTimegaps = TRUE,
     rmc.sf = 10,
     idloc = 2,
     do.cal = FALSE,
     outputdir = outputdir,
     overwrite = TRUE,
     mode = 1,
     do.report = NULL,
     visualreport = TRUE,
     printsummary = TRUE)
```

The dimensions of M$metalong and M$metashort match the 24 hours you would expected from the original data before the timegap was created.

Note: If the dummy recording starts a few minutes before a round clock time then GGIR will (as it has always done) ignores the start of the recording until the first round clock time (integer numbers of long epoch size).


<!-- Describe your PR here -->

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [ ] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Updated or expanded the documentation.
- [ ] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
