### PR TITLE
Added extra checks to handle the zeros in g.imputeTimegaps

### DIFF
--- a/R/g.imputeTimegaps.R
+++ b/R/g.imputeTimegaps.R
@@ -34,11 +34,14 @@ g.imputeTimegaps = function(x, xyzCol, timeCol = c(), sf, k=0.25, impute = TRUE,
     }
     # if last value is a zero, we should not remove it (to keep track of the time)
     # This last row of zeros will be imputed afterwards (i.e., imputelast = TRUE)
-    if (zeros[length(zeros)] == nrow(x)) {
-      zeros = zeros[-length(zeros)]
-      imputelast = TRUE
+    if (length(zeros) > 0) { # safe check just in case that removing zeros[1] have made length(zeros) == 0
+      if (zeros[length(zeros)] == nrow(x)) {
+        zeros = zeros[-length(zeros)]
+        imputelast = TRUE
+      }
     }
-    x = x[-zeros,]
+    # Again, check that length(zeros) is still > 0 
+    if (length(zeros) > 0) x = x[-zeros,]
   }
   # find missing timestamps (timegaps)
   if (isTRUE(impute)) { # this is default, in g.calibrate this is set to FALSE


### PR DESCRIPTION
<!-- Describe your PR here -->
Minor fix in the long time gap imputation to make sure that the lack of zeros in hte signal do not produce an error and stops the processing.

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [x] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [x] Updated or expanded the documentation.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
