### PR TITLE
Issue651 activitylog

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Description: A tool to process and analyse data collected with wearable raw acce
 URL: https://github.com/wadpac/GGIR/, https://groups.google.com/forum/#!forum/RpackageGGIR
 BugReports: https://github.com/wadpac/GGIR/issues
 License: LGPL (>= 2.0, < 3) | file LICENSE
-Suggests: testthat, covr, knitr, rmarkdown
+Suggests: testthat, covr, knitr, rmarkdown, actilifecounts
 Imports: data.table, foreach, doParallel, signal, zoo, GENEAread, tuneR, unisensR, ineq, read.gt3x, activityCounts, ActCR, methods, GGIRread
 Depends: stats, utils, R (>= 3.5.0)
 VignetteBuilder: knitr

--- a/R/g.analyse.perday.R
+++ b/R/g.analyse.perday.R
@@ -342,12 +342,13 @@ g.analyse.perday = function(ndays, firstmidnighti, time, nfeatures,
                   varnum = c()
                 }
               }
-              gUnitMetric = length(grep(x = colnames(metashort)[mi], pattern = "BrondCounts|ZCX|ZCY", invert = TRUE)) > 0
+              gUnitMetric = length(grep(x = colnames(metashort)[mi], pattern = "BrondCount|ZCX|ZCY|ZCZ|NeishabouriCount", invert = TRUE)) > 0
               UnitReScale = ifelse(test = gUnitMetric, yes = 1000, no = 1)
               # Starting filling output matrix daysummary with variables per day segment and full day.
               if (minames[mi] %in% c("ENMO","LFENMO", "BFEN", "EN", "HFEN", "HFENplus", "MAD", "ENMOa",
-                                     "ZCX", "ZCY", "ZCZ", "BrondCounts_x", "BrondCounts_y",
-                                     "BrondCounts_z")) {
+                                     "ZCX", "ZCY", "ZCZ", "BrondCount_x", "BrondCount_y",
+                                     "BrondCount_z", "NeishabouriCount_x", "NeishabouriCount_y", 
+                                     "NeishabouriCount_z", "NeishabouriCount_vm")) {
                 collectfi = c()
                 for (winhr_value in params_247[["winhr"]]) { # Variable (column) names
                   # We are first defining location of variable names, before calculating

--- a/R/g.analyse.perday.R
+++ b/R/g.analyse.perday.R
@@ -163,7 +163,7 @@ g.analyse.perday = function(ndays, firstmidnighti, time, nfeatures,
         for (qwi in 1:(length(qwindowindices) - 1)) { #
           startindex = qwindowindices[qwi] * 60 * (60/ws3)
           endindex = qwindowindices[qwi + 1] * 60 * (60/ws3)
-          if(startindex <= length(val) & endindex <= length(val)) {
+          if (startindex <= length(val) & endindex <= length(val)) {
             valq = val[(startindex + 1):endindex]
           } else if (startindex <= length(val) & endindex >= length(val)) {
             valq = val[(startindex + 1):length(val)]
@@ -326,6 +326,13 @@ g.analyse.perday = function(ndays, firstmidnighti, time, nfeatures,
                 difference = NRV - length(averageday[, (mi - 1)])
                 if (di == 1) {
                   varnum = c(averageday[1:abs(difference), (mi - 1)], varnum)
+                  # readjust anwi indices in case that varnum has been imputed
+                  if (max(anwi_t1) < length(varnum)) { # since GGIR always calculates full window, max(anwi_t1) should always equals length(varnum)
+                    anwi_t0 = anwi_t0 + abs(difference)
+                    anwi_t1 = anwi_t1 + abs(difference)
+                    # then, we reset the minimum anwi_t0 to 1 to consider the imputed varnum
+                    anwi_t0[which(anwi_t0 == min(anwi_t0))] = 1
+                  }
                 } else {
                   a56 = length(averageday[,(mi - 1)]) - abs(difference)
                   a57 = length(averageday[, (mi - 1)])

--- a/R/g.analyse.perfile.R
+++ b/R/g.analyse.perfile.R
@@ -11,7 +11,7 @@ g.analyse.perfile = function(ID, fname, deviceSerialNumber, sensor.location, sta
   # Person identification number
   filesummary[vi] = ID
   # Identify which of the metrics are in g-units to aid deciding whether to multiply by 1000
-  g_variables_lookat = lookat[grep(x = colnames_to_lookat, pattern = "BrondCounts|ZCX|ZCY", invert = TRUE)]
+  g_variables_lookat = lookat[grep(x = colnames_to_lookat, pattern = "BrondCount|ZCX|ZCY|NeishabouriCount", invert = TRUE)]
   
   # Serial number
   if (snloc == 1) {

--- a/R/g.applymetrics.R
+++ b/R/g.applymetrics.R
@@ -1,7 +1,8 @@
 g.applymetrics = function(data, sf, ws3, metrics2do,
                           n = 4, lb = 0.2, hb = 15,
                           zc.lb = 0.25, zc.hb = 3, zc.sb = 0.01,
-                          zc.order = 2){
+                          zc.order = 2, 
+                          actilife_LFE = FALSE){
   epochsize = ws3 #epochsize in seconds
   # data is a 3 column matrix with the x, y, and z acceleration
   do.bfen = metrics2do$do.bfen
@@ -35,6 +36,7 @@ g.applymetrics = function(data, sf, ws3, metrics2do,
   do.zcy = metrics2do$do.zcy
   do.zcz = metrics2do$do.zcz
   do.brondcounts = metrics2do$do.brondcounts
+  do.neishabouricounts = metrics2do$do.neishabouricounts
   allmetrics = c()
   averagePerEpoch = function(x,sf,epochsize) {
     x2 = cumsum(c(0,x))
@@ -210,7 +212,7 @@ g.applymetrics = function(data, sf, ws3, metrics2do,
         allmetrics$ZCZ = sumPerEpoch(zerocross(data_processed[,zi], Ndat), sf, epochsize)
       }
     }
-
+    
     # Note that this is per epoch, in GGIR part 3 we aggregate (sum) this per minute
     # to follow Sadeh. In Sadeh 1987 this resulted in values up to 280
     # 280 = 60 x 2 x frequency of movement which would mean near 2.33 Hertz average
@@ -332,6 +334,29 @@ g.applymetrics = function(data, sf, ws3, metrics2do,
     allmetrics$BrondCount_x = sumPerEpoch(mycounts[, 2], sf = 1, epochsize)
     allmetrics$BrondCount_y = sumPerEpoch(mycounts[, 3], sf = 1, epochsize)
     allmetrics$BrondCount_z = sumPerEpoch(mycounts[, 4], sf = 1, epochsize)
+  }
+  #================================================
+  # Actilife Counts)
+  if (do.neishabouricounts == TRUE) {
+    # I do not include actilifecounts as dependency to avoid overwritten methods
+    # message from package signal (this package has not well defined the source 
+    # package of their functions and we get an inoffensive but unwanted message 
+    # printed in the console).
+    # I followed suggestion in: https://bit.ly/3SaP69u
+    suppressMessages(requireNamespace("actilifecounts"))
+    if (ncol(data) > 3) data = data[,2:4]
+    mycounts = actilifecounts::get_counts(raw = data, sf = sf,
+                                          epoch = epochsize, lfe_select = actilife_LFE,
+                                          verbose = FALSE)
+    if (sf < 30) {
+      warning("\nNote: activityCounts not designed for handling sample frequencies below 30 Hertz")
+    }
+    # activityCount output is per second
+    # aggregate to our epoch size:
+    allmetrics$NeishabouriCount_x = mycounts[, 1]
+    allmetrics$NeishabouriCount_y = mycounts[, 2]
+    allmetrics$NeishabouriCount_z = mycounts[, 3]
+    allmetrics$NeishabouriCount_vm = mycounts[, 4]
   }
   return(allmetrics)
 } 

--- a/R/g.getmeta.R
+++ b/R/g.getmeta.R
@@ -67,6 +67,7 @@ g.getmeta = function(datafile, params_metrics = c(), params_rawdata = c(),
                           do.zcy = params_metrics[["do.zcy"]],
                           do.zcz = params_metrics[["do.zcz"]],
                           do.brondcounts = params_metrics[["do.brondcounts"]],
+                          do.neishabouricounts = params_metrics[["do.neishabouricounts"]],
                           stringsAsFactors = TRUE)
   if (length(params_rawdata[["chunksize"]]) == 0) params_rawdata[["chunksize"]] = 1
   if (params_rawdata[["chunksize"]] > 1.5) params_rawdata[["chunksize"]] = 1.5
@@ -88,7 +89,8 @@ g.getmeta = function(datafile, params_metrics = c(), params_rawdata = c(),
                    params_metrics[["do.bfx"]], params_metrics[["do.bfy"]],
                    params_metrics[["do.bfz"]],
                    params_metrics[["do.zcx"]], params_metrics[["do.zcy"]],
-                   params_metrics[["do.zcz"]], params_metrics[["do.brondcounts"]] * 3))
+                   params_metrics[["do.zcz"]], params_metrics[["do.brondcounts"]] * 3,
+                   params_metrics[["do.neishabouricounts"]] * 4))
   if (length(myfun) != 0) {
     nmetrics = nmetrics + length(myfun$colnames)
     # check myfun object already, because we do not want to discover
@@ -492,7 +494,8 @@ g.getmeta = function(datafile, params_metrics = c(), params_rawdata = c(),
                                     zc.lb = params_metrics[["zc.lb"]],
                                     zc.hb = params_metrics[["zc.hb"]],
                                     zc.sb = params_metrics[["zc.sb"]],
-                                    zc.order = params_metrics[["zc.order"]])
+                                    zc.order = params_metrics[["zc.order"]],
+                                    actilife_LFE = params_metrics[["actilife_LFE"]])
         # round decimal places, because due to averaging we get a lot of information
         # that only slows down computation and increases storage size
         accmetrics = lapply(accmetrics, round, n_decimal_places)
@@ -531,7 +534,7 @@ g.getmeta = function(datafile, params_metrics = c(), params_rawdata = c(),
         }
         col_msi = 2
         # Add metric time series to metashort object
-        metnames = grep(pattern = "BrondCount", x = names(accmetrics), invert = TRUE, value = TRUE)
+        metnames = grep(pattern = "BrondCount|NeishabouriCount", x = names(accmetrics), invert = TRUE, value = TRUE)
         for (metnam in metnames) {
           dovalue = paste0("do.",tolower(metnam))
           dovalue = gsub(pattern = "angle_", replacement = "angle", x = dovalue)
@@ -546,6 +549,14 @@ g.getmeta = function(datafile, params_metrics = c(), params_rawdata = c(),
           metashort[count:(count - 1 + length(accmetrics$BrondCount_z)), col_msi + 2] = accmetrics$BrondCount_z
           col_msi = col_msi + 3
           metnames = c(metnames, "BrondCount_x", "BrondCount_y", "BrondCount_z")
+        }
+        if (params_metrics[["do.neishabouricounts"]] == TRUE) {
+          metashort[count:(count - 1 + length(accmetrics$NeishabouriCount_x)), col_msi] = accmetrics$NeishabouriCount_x
+          metashort[count:(count - 1 + length(accmetrics$NeishabouriCount_y)), col_msi + 1] = accmetrics$NeishabouriCount_y
+          metashort[count:(count - 1 + length(accmetrics$NeishabouriCount_z)), col_msi + 2] = accmetrics$NeishabouriCount_z
+          metashort[count:(count - 1 + length(accmetrics$NeishabouriCount_vm)), col_msi + 3] = accmetrics$NeishabouriCount_vm
+          col_msi = col_msi + 3
+          metnames = c(metnames, "NeishabouriCount_x", "NeishabouriCount_y", "NeishabouriCount_z", "NeishabouriCount_vm")
         }
         metnames = gsub(pattern = "angle_", replacement = "angle", x = metnames)
         if (length(myfun) != 0) { # if an external function is applied.

--- a/R/g.part5.R
+++ b/R/g.part5.R
@@ -180,7 +180,8 @@ g.part5 = function(datadir = c(), metadatadir = c(), f0=c(), f1=c(),
         load(paste0(metadatadir, "/meta/ms3.out/", fnames.ms3[i]))
         # extract key variables from the mile-stone data: time, acceleration and elevation angle
         # note that this is imputed ACCELERATION because we use this for describing behaviour:
-        ts = data.frame(time = IMP$metashort[,1], ACC = IMP$metashort[,params_general[["acc.metric"]]] * 1000,
+        scale = ifelse(test = grepl("^Brond|^Neishabouri|^ZC", params_general[["acc.metric"]]), yes = 1, no = 1000)
+        ts = data.frame(time = IMP$metashort[,1], ACC = IMP$metashort[,params_general[["acc.metric"]]] * scale,
                         guider = rep("unknown", nrow(IMP$metashort)),
                         angle = as.numeric(as.matrix(IMP$metashort[,which(names(IMP$metashort) == "anglez")])) )
         Nts = nrow(ts)

--- a/R/g.sib.det.R
+++ b/R/g.sib.det.R
@@ -131,9 +131,18 @@ g.sib.det = function(M, IMP, I, twd = c(-12, 12),
       } else {
         BrondCount = c()
       }
+      # optionally add NeishabouriCounts for comparison
+      NeishabouriCount_colname = paste0("NeishabouriCount_", tolower(params_sleep[["Sadeh_axis"]]))
+      if (NeishabouriCount_colname %in% colnames(IMP$metashort)) {
+        NeishabouriCount =  IMP$metashort[, NeishabouriCount_colname]
+        NeishabouriCount = fix_NA_invector(NeishabouriCount)
+      } else {
+        NeishabouriCount = c()
+      }
     } else {
       zeroCrossingCount = c()
       BrondCount = c()
+      NeishabouriCount = c()
     }
     #==================================================================
     # 'sleep' detection if sleep is not provided by external function.
@@ -151,7 +160,8 @@ g.sib.det = function(M, IMP, I, twd = c(-12, 12),
                     anglethreshold = params_sleep[["anglethreshold"]], 
                     time = time, anglez = anglez, ws3 = ws3,
                     zeroCrossingCount = zeroCrossingCount,
-                    BrondCount = BrondCount)
+                    BrondCount = BrondCount,
+                    NeishabouriCount = NeishabouriCount)
     } else { # getSleepFromExternalFunction == TRUE
       # Code now uses the sleep estimates from the external function
       # So, the assumption is that the external function provides a 

--- a/R/load_params.R
+++ b/R/load_params.R
@@ -41,8 +41,10 @@ load_params = function(group = c("sleep", "metrics", "rawdata",
                           do.hfx = FALSE, do.hfy = FALSE, do.hfz = FALSE,
                           do.bfx = FALSE, do.bfy = FALSE, do.bfz = FALSE,
                           do.brondcounts = FALSE,
+                          do.neishabouricounts = FALSE,
                           hb = 15, lb = 0.2, n = 4,
-                          zc.lb = 0.25, zc.hb = 3, zc.sb = 0.01, zc.order = 2, zc.scale = 1)
+                          zc.lb = 0.25, zc.hb = 3, zc.sb = 0.01, zc.order = 2, zc.scale = 1,
+                          actilife_LFE = FALSE)
   }
   if ("rawdata" %in% group) {
     params_rawdata = list(

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -6,16 +6,17 @@
     \item Changed POSIXlt to character conversion to be compatible with R-devel update svn revision r82904 (2022-09-24 19:32:52)
     \item Part 1: Added neishabouricounts metrics and dependency to actilifecounts package
     \item Documentation: minor fix in ShellDoc2Vignette that affected the parameters vignette
+    \item Fixed time mismatch between metashort and activity log when the first day does not start at midnight
     \item Documentation: Added information on Neishabouri counts in help files and main vignette
-   }
+    }
 }
 \section{Changes in version 2.8-0 (release date:19-09-2022)}{
   \itemize{
     \item Documentation: New package vignette added for cut-points.
     \item Documentation: New package vignette added for arguments
-    \item Documentation: GGIR function manual and parameter/argument vignette 
+    \item Documentation: GGIR function manual and parameter/argument vignette
     auto-integrate default values to avoid inconsistencies.
-    \item Documentation: Main vignette sections on cut-points and input argument 
+    \item Documentation: Main vignette sections on cut-points and input argument
     shortened with reference to the new vignettes.
     \item Documentation: Paragraph added on processing time.
     }
@@ -35,7 +36,7 @@
     \item Part 1: Deprecated g.cwaread and internally replaced by GGIRread::readAxivity.
     \item Part 1: Deprecated g.binread and internally replaced by GGIRread::readGenea.
     \item Part 1: Deprecated resample and internally replaced by GGIRread::resample.
-    \item Part 1: Added temporary option to choose between using GENEAread or 
+    \item Part 1: Added temporary option to choose between using GENEAread or
       GGIRread::readGENEActiv for reading GENEActiv .bin files.
     \item Part 1 + 2: Deprecated selectdaysfile functionality.
     \item Deprecated function g.getidfromheaderobject, and functionality merged with g.extractheadervars

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -4,8 +4,10 @@
 \section{Changes in version 2.8-1 (release date:29-09-2022)}{
   \itemize{
     \item Changed POSIXlt to character conversion to be compatible with R-devel update svn revision r82904 (2022-09-24 19:32:52)
+    \item Part 1: Added neishabouricounts metrics and dependency to actilifecounts package
     \item Documentation: minor fix in ShellDoc2Vignette that affected the parameters vignette
-    }
+    \item Documentation: Added information on Neishabouri counts in help files and main vignette
+   }
 }
 \section{Changes in version 2.8-0 (release date:19-09-2022)}{
   \itemize{

--- a/man/GGIR.Rd
+++ b/man/GGIR.Rd
@@ -622,6 +622,14 @@ GGIR(mode = \Sexpr{format(formals(GGIR::GGIR)[["mode"]])},
         we clarify that these are the counts proposed by Jan Br&#248;nd and implemented
         in R by Ruben Brondeel. The _brondcounts_ are intended to be an imitation of
         the counts produced by one of the closed source ActiLife software by ActiGraph.}
+        
+      \item{do.neishabouricounts}{
+        Boolean (default = \Sexpr{format(GGIR::load_params()[["params_metrics"]][["do.neishabouricounts"]])}).
+        If TRUE, calculates the metric via R package actilifecounts, which is an implementation
+        of the algorithm used in the closed-source software ActiLife by ActiGraph (methods published in doi: 
+        10.1038/s41598-022-16003-x). We use the name of the first author (instead of ActiLifeCounts) of the paper and
+        call them NeishabouriCount under the uncertainty that ActiLife will implement this same
+        algorithm over time.}
 
       \item{lb}{
         Numeric (default = \Sexpr{format(GGIR::load_params()[["params_metrics"]][["lb"]])}).
@@ -652,7 +660,11 @@ GGIR(mode = \Sexpr{format(formals(GGIR::GGIR)[["mode"]])},
         Used for zero-crossing counts only. Scaling factor to be applied after
         counts are calculated (GGIR part 3).}
         
-        
+      \item{actilife_LFE}{
+        Boolean (default = \Sexpr{format(GGIR::load_params()[["params_metrics"]][["actilife_LFE"]])}).
+        If TRUE, calculates the NeishabouriCount metric with the low-frequency extension filter
+        as proposed in the closed source ActiLife software by ActiGraph. Only applicable to 
+        the metric NeishabouriCount.}
     }
   }
 

--- a/man/HASIB.Rd
+++ b/man/HASIB.Rd
@@ -9,7 +9,8 @@
 }
 \usage{
   HASIB(HASIB.algo = "vanHees2015", timethreshold=c(), anglethreshold=c(), 
-                 time=c(), anglez=c(), ws3=c(), zeroCrossingCount=c(), BrondCount = c())
+                 time=c(), anglez=c(), ws3=c(), zeroCrossingCount=c(), BrondCount = c(),
+                 NeishabouriCount = c())
 }
 \arguments{
   \item{HASIB.algo}{
@@ -32,10 +33,13 @@
     See \link{g.getmeta}
   }
   \item{zeroCrossingCount}{
-    Vector with zero crossing counts per epoch as required for Sadeh algortihm
+    Vector with zero crossing counts per epoch as required for count-based algorithms
   }
   \item{BrondCount}{
-    Vector with Brond counts per epoch to be used by the Sadeh algortihm
+    Vector with Brond counts per epoch to be used by the count-based algorithms
+  }
+  \item{NeishabouriCount}{
+    Vector with Neishabouri counts per epoch to be used by the count-based algorithms
   }
 }
 \value{

--- a/man/g.applymetrics.Rd
+++ b/man/g.applymetrics.Rd
@@ -11,7 +11,8 @@
   g.applymetrics(data, sf, ws3, metrics2do,
                           n = 4, lb = 0.2, hb = 15,
                           zc.lb = 0.25, zc.hb = 3, 
-                          zc.sb = 0.01, zc.order = 2)
+                          zc.sb = 0.01, zc.order = 2,
+                          actilife_LFE = FALSE)
 }
 \arguments{
   \item{data}{
@@ -50,6 +51,9 @@
   \item{zc.order}{
     See \link{GGIR}
   }
+  \item{actilife_LFE}{
+    See \link{GGIR}
+  }
 }
 \value{
   Dataframe with metric values in columns average per epoch (ws3)
@@ -69,7 +73,8 @@
   do.lfx=FALSE, do.lfy=FALSE, do.lfz=FALSE, 
   do.hfx=FALSE, do.hfy=FALSE, do.hfz=FALSE, 
   do.bfx=FALSE, do.bfy=FALSE, do.bfz=FALSE,
-  do.zcx=FALSE, do.zcy=FALSE, do.zcz=FALSE, do.brondcounts=FALSE)
+  do.zcx=FALSE, do.zcy=FALSE, do.zcz=FALSE, 
+  do.brondcounts=FALSE, do.neishabouricounts=FALSE)
   
   extractedmetrics = g.applymetrics(data,n=4,sf=40,ws3=5,metrics2do)
 }

--- a/tests/testthat/test_load_check_params.R
+++ b/tests/testthat/test_load_check_params.R
@@ -10,7 +10,7 @@ test_that("load_params can load parameters", {
   # Test length of objects
   expect_equal(length(params), 8)
   expect_equal(length(params$params_sleep), 21)
-  expect_equal(length(params$params_metrics), 39)
+  expect_equal(length(params$params_metrics), 41)
   expect_equal(length(params$params_rawdata), 36)
   expect_equal(length(params$params_247), 20)
   expect_equal(length(params$params_cleaning), 17)

--- a/vignettes/GGIR.Rmd
+++ b/vignettes/GGIR.Rmd
@@ -1296,13 +1296,19 @@ try to optimise the zero crossing count parameters as discussed below.
 
 To aid research in exploring count type algorithms, we also implemented the
 `brondcounts` as proposed by Br&#248;nd and Brondeel and available via R package
-activityCounts. To extract this metric in addition to the zero crossing count,
-specify `do.brondcounts = TRUE` which is used in GGIR part 1 and uses R package
-activityCounts in the background. As a result, sleep estimates for Sadeh, Cole-Kripke
-or Galland will be derived based on both the zero crossing algorithm and
-the `brondcounts` algorithms. Further, we have added parameters to help modify
+activityCounts, as well as the `neishabouricounts` that follows the algorithm implemented
+in the close-source software ActiLife by ActiGraph and is available in the R package
+actilifecounts. 
+To extract these metrics in addition to the zero crossing count,
+specify `do.brondcounts = TRUE` and/or `do.neishabouricounts = TRUE` which is used 
+in GGIR part 1 and uses R packages activityCounts and actilifecounts in the background. 
+As a result, sleep estimates for Sadeh, Cole-Kripke
+or Galland will be derived based on the zero crossing algorithm and additionally on
+the `brondcounts` or/and `actilifecounts` algorithms if requested by the user. 
+Further, we have added parameters to help modify
 the configuration of the zero-crossing count calculation, see arguments:
-`zc.lb`, `zc.hb`, `zc.sb`, `zc/order`, and `zc.scale`.
+`zc.lb`, `zc.hb`, `zc.sb`, `zc/order`, and `zc.scale`. As well as one parameter to modify the
+neishabouricounts calculation, see argument: `actilife_LFE`.
 
 ### Guiders
 


### PR DESCRIPTION
<!-- Describe your PR here -->
Fixes #651 

When the first day does not start at midnight, time from midnight to the first recording is imputed with the averageday data. So, the numeric vector containing the acc metric data is larger than metashort and the corresponding time gets lagged. The indices from qwindow to analyse specific segments did not consider this lag in time and the windows in the reports did not match with the expected windows as defined by the user in qwindow.

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Updated or expanded the documentation.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
