### PR TITLE
#673 deprecate activityCounts dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ URL: https://github.com/wadpac/GGIR/, https://groups.google.com/forum/#!forum/Rp
 BugReports: https://github.com/wadpac/GGIR/issues
 License: LGPL (>= 2.0, < 3) | file LICENSE
 Suggests: testthat, covr, knitr, rmarkdown, actilifecounts
-Imports: data.table, foreach, doParallel, signal, zoo, GENEAread, tuneR, unisensR, ineq, read.gt3x, activityCounts, ActCR, methods, GGIRread
+Imports: data.table, foreach, doParallel, signal, zoo, GENEAread, tuneR, unisensR, ineq, read.gt3x, ActCR, methods, GGIRread
 Depends: stats, utils, R (>= 3.5.0)
 VignetteBuilder: knitr
 

--- a/R/check_params.R
+++ b/R/check_params.R
@@ -131,13 +131,11 @@ check_params = function(params_sleep = c(), params_metrics = c(),
       " Note that this option will be deprecated in the next CRAN release."))
     }
   }
-  if (length(params_metrics) > 0 & length(params_sleep) > 0) {
-    if (length(params_sleep[["def.noc.sleep"]]) != 2) {
-      if (params_sleep[["HASPT.algo"]] != "HorAngle") {
-        params_sleep[["HASPT.algo"]] = "HDCZA"
-      }
-    } else if (length(params_sleep[["def.noc.sleep"]]) == 2) {
-      params_sleep[["HASPT.algo"]] = "notused"
+  if (length(params_metrics) > 0) {
+    if (params_metrics[["do.brondcounts"]] == TRUE) {
+      stop(paste0("\nThe brondcounts option has been deprecated following issues with the ",
+                  "following issues with the activityCounts package. We will reinsert brondcounts ",
+                  "once the issues are resolved."), call. = FALSE)
     }
     if (params_metrics[["do.neishabouricounts"]] == TRUE) {
       if ("actilifecounts" %in% rownames(utils::installed.packages()) == FALSE) {
@@ -147,6 +145,16 @@ check_params = function(params_sleep = c(), params_metrics = c(),
           stop("\nPlease update R package actilifecounts to version 1.1.0 or higher", call. = FALSE)
         }
       }
+    }
+  }
+  
+  if (length(params_metrics) > 0 & length(params_sleep) > 0) {
+    if (length(params_sleep[["def.noc.sleep"]]) != 2) {
+      if (params_sleep[["HASPT.algo"]] != "HorAngle") {
+        params_sleep[["HASPT.algo"]] = "HDCZA"
+      }
+    } else if (length(params_sleep[["def.noc.sleep"]]) == 2) {
+      params_sleep[["HASPT.algo"]] = "notused"
     }
     if (params_general[["sensor.location"]] == "hip" &  params_sleep[["HASPT.algo"]] != "notused") {
       if (params_metrics[["do.anglex"]] == FALSE | params_metrics[["do.angley"]] == FALSE | params_metrics[["do.anglez"]] == FALSE) {

--- a/R/g.applymetrics.R
+++ b/R/g.applymetrics.R
@@ -322,18 +322,21 @@ g.applymetrics = function(data, sf, ws3, metrics2do,
   #================================================
   # Brond Counts)
   if (do.brondcounts == TRUE) {
-    if (ncol(data) > 3) data = data[,2:4]
-    mycounts = activityCounts::counts(data = data, hertz = sf, 
-                                      x_axis = 1, y_axis = 2, z_axis = 3,
-                                      start_time = Sys.time()) # ignoring timestamps, because GGIR has its own timestamps
-    if (sf < 30) {
-      warning("\nNote: activityCounts not designed for handling sample frequencies below 30 Hertz")
-    }
-    # activityCount output is per second
-    # aggregate to our epoch size:
-    allmetrics$BrondCount_x = sumPerEpoch(mycounts[, 2], sf = 1, epochsize)
-    allmetrics$BrondCount_y = sumPerEpoch(mycounts[, 3], sf = 1, epochsize)
-    allmetrics$BrondCount_z = sumPerEpoch(mycounts[, 4], sf = 1, epochsize)
+    stop(paste0("\nThe brondcounts option has been deprecated following issues with the ",
+                "following issues with the activityCounts package. We will reinsert brondcounts ",
+                "once the issues are resolved."), call. = FALSE)
+    # if (ncol(data) > 3) data = data[,2:4]
+    # mycounts = activityCounts::counts(data = data, hertz = sf, 
+    #                                   x_axis = 1, y_axis = 2, z_axis = 3,
+    #                                   start_time = Sys.time()) # ignoring timestamps, because GGIR has its own timestamps
+    # if (sf < 30) {
+    #   warning("\nNote: activityCounts not designed for handling sample frequencies below 30 Hertz")
+    # }
+    # # activityCount output is per second
+    # # aggregate to our epoch size:
+    # allmetrics$BrondCount_x = sumPerEpoch(mycounts[, 2], sf = 1, epochsize)
+    # allmetrics$BrondCount_y = sumPerEpoch(mycounts[, 3], sf = 1, epochsize)
+    # allmetrics$BrondCount_z = sumPerEpoch(mycounts[, 4], sf = 1, epochsize)
   }
   #================================================
   # Actilife Counts)

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -3,7 +3,8 @@
 \newcommand{\cpkg}{\href{http://CRAN.R-project.org/package=#1}{\pkg{#1}}}
 \section{Changes in version 2.8-2 (release date:03-10-2022)}{
   \itemize{
-    \item Part5: Fix #655 (unable to handle when M5HOUR falls on midnight exactly).
+    \item Part 5: Fix #655 (unable to handle when M5HOUR falls on midnight exactly).
+    \item Part 1: Deprecate brondcounts due to issues in activityCounts package
     }
 }
 \section{Changes in version 2.8-1 (release date:01-10-2022)}{

--- a/man/GGIR.Rd
+++ b/man/GGIR.Rd
@@ -616,6 +616,8 @@ GGIR(mode = \Sexpr{format(formals(GGIR::GGIR)[["mode"]])},
 
       \item{do.brondcounts}{
         Boolean (default = \Sexpr{format(GGIR::load_params()[["params_metrics"]][["do.brondcounts"]])}).
+        THIS OPTION HAS BEEN DEPRECATED (October2022) DUE TO ISSUES WITH THE ACTIVITYCOUNTS PACKAGE,
+        WE WILL ADD THIS BACK IN ONCE THE ISSUES WITH THE ACTIVITYCOUNTS PACKAGE ARE ADDRESSED.
         If TRUE, calculates the metric via R package activityCounts.
         We call them BrondCounts because there are large number of acitivty counts in
         the physical activity and sleep research field. By calling them _brondcounts_

--- a/tests/testthat/test_part1_with_allmetrics.R
+++ b/tests/testthat/test_part1_with_allmetrics.R
@@ -17,12 +17,12 @@ test_that("Part 1 can run with all metrics", {
           # We are not doing all the metrics, because Travis-CI cannot allocate enough memory
           do.enmo = TRUE,do.lfenmo = TRUE,
           do.bfen = TRUE, do.hfenplus = TRUE,
-          do.mad = TRUE, do.zcx = TRUE, do.brondcounts = TRUE,
+          do.mad = TRUE, do.zcx = TRUE, #do.brondcounts = TRUE,
    windowsizes = c(15,3600,3600), do.parallel = FALSE,
    minimumFileSizeMB = 0)
   rn = dir("output_test/meta/basic/",full.names = TRUE)
   load(rn[1])
-  expect_equal(ncol(M$metashort), 12)
+  expect_equal(ncol(M$metashort), 9)
   expect_equal(nrow(M$metashort), 11280)
   expect_equal(mean(M$metashort$BFEN),  0.0458, tolerance = 4)
   expect_equal(mean(M$metashort$LFENMO),  0.0447, tolerance = 4)
@@ -31,8 +31,8 @@ test_that("Part 1 can run with all metrics", {
   expect_equal(mean(M$metashort$anglex),  57.4683, tolerance = 4)
   expect_equal(mean(M$metashort$anglez),  0.3522, tolerance = 4)
   expect_equal(mean(M$metashort$ZCX),  14.94, tolerance = 2)
-  expect_equal(sum(M$metashort$BrondCount_x), 17690)
-  expect_equal(sum(M$metashort$BrondCount_y), 60971)
-  expect_equal(sum(M$metashort$BrondCount_z), 957584)
+  # expect_equal(sum(M$metashort$BrondCount_x), 17690)
+  # expect_equal(sum(M$metashort$BrondCount_y), 60971)
+  # expect_equal(sum(M$metashort$BrondCount_z), 957584)
   if (file.exists(fn)) file.remove(fn)
 })

--- a/vignettes/GGIR.Rmd
+++ b/vignettes/GGIR.Rmd
@@ -1298,7 +1298,9 @@ To aid research in exploring count type algorithms, we also implemented the
 `brondcounts` as proposed by Br&#248;nd and Brondeel and available via R package
 activityCounts, as well as the `neishabouricounts` that follows the algorithm implemented
 in the close-source software ActiLife by ActiGraph and is available in the R package
-actilifecounts. 
+actilifecounts. DISCLAIMER: the brondcounts option has been deprecated as of 
+October2022 due to issues with the activityCounts package it relies on. We will 
+reactivate brondcounts once the issues are resolved.
 To extract these metrics in addition to the zero crossing count,
 specify `do.brondcounts = TRUE` and/or `do.neishabouricounts = TRUE` which is used 
 in GGIR part 1 and uses R packages activityCounts and actilifecounts in the background. 


### PR DESCRIPTION
<!-- Describe your PR here -->

This PR deprecates activityCounts for a while:
- Produce error in g.applymetrics and in check_params when user tries to use the counts.
- Commented out calculation of brondcounts
- Updated vignette and GGIR.Rd to acknowledge that brondcounts has been temporarily deprecated
- Left all other references to brondcounts as they are to re-insterting brondcounts in a couple of months.

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [ ] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Updated or expanded the documentation.
- [ ] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
