### PR TITLE
Issue672 speedup reports

### DIFF
--- a/R/g.convert.part2.long.R
+++ b/R/g.convert.part2.long.R
@@ -49,10 +49,11 @@ g.convert.part2.long = function(daySUMMARY) {
     return(x4)
   }
   
-  getvar = function(x) {
-    tmp = unlist(strsplit(as.character(x),"_"))
-    return(paste0(tmp[1:(length(tmp)-1)],collapse="_"))
-  }
+  # getvar = function(x) {
+    # tmp = unlist(strsplit(as.character(x),"_"))
+    # return(paste0(tmp[1:(length(tmp)-1)],collapse="_"))
+  # }
+  
   gettimeseg = function(x) {
     tmp = unlist(strsplit(as.character(x),"_"))
     tmp2 = unlist(strsplit(tmp[length(tmp)],"[.]"))[1]
@@ -65,16 +66,18 @@ g.convert.part2.long = function(daySUMMARY) {
   cn = names(daySUMMARY)
   # extract windowsegment specification from variable name
   tt = sapply(cn, FUN = extractlastpart)
-  id.vars = colnames(tt[,which(tt[2,] == "")]) # identify other varibales, including ID
+  id.vars = colnames(tt[,which(tt[2,] == "")]) # identify other variables, including ID
   daySUMMARY = data.table::as.data.table(daySUMMARY)
   # turn into long format with melt, this will make it too long, so further
   # down we will move key variables to wide again
   daySUMMARY2 = data.table::melt(daySUMMARY, id.vars = id.vars, 
-                                 measure.vars = colnames(tt)[which(tt[2,]!= "")])
+                                 measure.vars = colnames(tt)[which(tt[2,] != "")])
   # extract variable names
-  daySUMMARY2$variable2 = sapply(daySUMMARY2$variable, FUN = getvar)
+  # daySUMMARY2$variable2 = sapply(daySUMMARY2$variable, FUN = getvar)
+  daySUMMARY2$variable2 = sub("_[^_]+$", "", daySUMMARY2$variable)
   # extract time segment names
-  daySUMMARY2$timesegment2 = sapply(daySUMMARY2$variable, FUN = gettimeseg)
+  # daySUMMARY2$timesegment2 = sapply(daySUMMARY2$variable, FUN = gettimeseg)
+  daySUMMARY2$timesegment2 = sub("^.*_", "", daySUMMARY2$variable)
   daySUMMARY2 = as.data.frame(daySUMMARY2)
   # tidy up
   rem = which(colnames(daySUMMARY2) == "variable")

--- a/R/g.report.part2.R
+++ b/R/g.report.part2.R
@@ -198,9 +198,9 @@ g.report.part2 = function(metadatadir = c(), f0 = c(), f1 = c(), maxdur = 0,
           SUMMARY_clean = tidyup_df(SUMMARY)
           daySUMMARY_clean = tidyup_df(daySUMMARY)
           #store matrix temporarily to keep track of process
-          write.csv(x = SUMMARY_clean, file = paste0(metadatadir, "/results/part2_summary.csv"), row.names = F)
-          write.csv(x = daySUMMARY_clean, file = paste0(metadatadir, "/results/part2_daysummary.csv"), row.names = F)
-          write.csv(x = QCout, file = paste0(metadatadir, "/results/QC/data_quality_report.csv"), row.names = F)
+          data.table::fwrite(x = SUMMARY_clean, file = paste0(metadatadir, "/results/part2_summary.csv"), row.names = F, na = "")
+          data.table::fwrite(x = daySUMMARY_clean, file = paste0(metadatadir, "/results/part2_daysummary.csv"), row.names = F, na = "")
+          data.table::fwrite(x = QCout, file = paste0(metadatadir, "/results/QC/data_quality_report.csv"), row.names = F, na = "")
         }
         pdfpagecount = pdfpagecount + 1
       }
@@ -216,14 +216,14 @@ g.report.part2 = function(metadatadir = c(), f0 = c(), f1 = c(), maxdur = 0,
       
       #===============================================================================
       # store final matrices again
-      write.csv(x = SUMMARY_clean, file = paste0(metadatadir, "/results/part2_summary.csv"), row.names = F)
-      write.csv(x = daySUMMARY_clean, paste0(metadatadir, "/results/part2_daysummary.csv"), row.names = F)
+      data.table::fwrite(x = SUMMARY_clean, file = paste0(metadatadir, "/results/part2_summary.csv"), row.names = F, na = "")
+      data.table::fwrite(x = daySUMMARY_clean, paste0(metadatadir, "/results/part2_daysummary.csv"), row.names = F, na = "")
       if (store.long == TRUE) { # Convert daySUMMARY to long format if there are multiple segments per day
         df = g.convert.part2.long(daySUMMARY)
         df_clean = tidyup_df(df)
-        write.csv(x = df_clean, file = paste0(metadatadir, "/results/part2_daysummary_longformat.csv"), row.names = F)
+        data.table::fwrite(x = df_clean, file = paste0(metadatadir, "/results/part2_daysummary_longformat.csv"), row.names = F, na = "")
       }
-      write.csv(x = QCout, file = paste0(metadatadir, "/results/QC/data_quality_report.csv"), row.names = F)
+      data.table::fwrite(x = QCout, file = paste0(metadatadir, "/results/QC/data_quality_report.csv"), row.names = F, na = "")
     }
   }
 }

--- a/R/g.report.part4.R
+++ b/R/g.report.part4.R
@@ -146,8 +146,8 @@ g.report.part4 = function(datadir = c(), metadatadir = c(), loglocation = c(), f
         print("report not stored, because no results available")
       } else {
         nightsummary_clean = tidyup_df(nightsummary)
-        write.csv(nightsummary_clean, file = paste(resultfolder, "/results/QC/part4_nightsummary_sleep_full.csv",
-                                                   sep = ""), row.names = FALSE)
+        data.table::fwrite(nightsummary_clean, file = paste(resultfolder, "/results/QC/part4_nightsummary_sleep_full.csv",
+                                                   sep = ""), row.names = FALSE, na = "")
         nightsummary_bu = nightsummary
       }
       ####
@@ -501,15 +501,15 @@ g.report.part4 = function(datadir = c(), metadatadir = c(), loglocation = c(), f
           nightsummary_clean = tidyup_df(nightsummary)
           personSummary_clean = tidyup_df(personSummary)
           if (dotwice == 1) {
-            write.csv(nightsummary_clean, file = paste(resultfolder, "/results/QC/part4_nightsummary_sleep_full.csv",
-                                                       sep = ""), row.names = FALSE)
-            write.csv(personSummary_clean, file = paste(resultfolder, "/results/QC/part4_summary_sleep_full.csv",
-                                                        sep = ""), row.names = FALSE)
+            data.table::fwrite(nightsummary_clean, file = paste(resultfolder, "/results/QC/part4_nightsummary_sleep_full.csv",
+                                                       sep = ""), row.names = FALSE, na = "")
+            data.table::fwrite(personSummary_clean, file = paste(resultfolder, "/results/QC/part4_summary_sleep_full.csv",
+                                                        sep = ""), row.names = FALSE, na = "")
           } else {
-            write.csv(nightsummary_clean, file = paste(resultfolder, "/results/part4_nightsummary_sleep_cleaned.csv",
-                                                       sep = ""), row.names = FALSE)
-            write.csv(personSummary_clean, file = paste(resultfolder, "/results/part4_summary_sleep_cleaned.csv",
-                                                        sep = ""), row.names = FALSE)
+            data.table::fwrite(nightsummary_clean, file = paste(resultfolder, "/results/part4_nightsummary_sleep_cleaned.csv",
+                                                       sep = ""), row.names = FALSE, na = "")
+            data.table::fwrite(personSummary_clean, file = paste(resultfolder, "/results/part4_summary_sleep_cleaned.csv",
+                                                        sep = ""), row.names = FALSE, na = "")
           }
         }
       }

--- a/R/g.report.part5.R
+++ b/R/g.report.part5.R
@@ -156,14 +156,14 @@ g.report.part5 = function(metadatadir = c(), f0 = c(), f1 = c(), loglocation = c
                 #-------------------------------------------------------------
                 # store all summaries in csv files without cleaning criteria
                 OF3_clean = tidyup_df(OF3)
-                write.csv(OF3_clean,paste(metadatadir,"/results/QC/part5_daysummary_full_",
+                data.table::fwrite(OF3_clean,paste(metadatadir,"/results/QC/part5_daysummary_full_",
                                     uwi[j],"_L",uTRLi[h1],"M",uTRMi[h2],"V",uTRVi[h3],
-                                    "_",usleepparam[h4],".csv",sep=""),row.names=FALSE)
+                                    "_",usleepparam[h4],".csv",sep=""),row.names=FALSE, na = "")
                 # store all summaries in csv files with cleaning criteria
                 validdaysi = getValidDayIndices(OF3,includedaycrit.part5, window = uwi[j])
-                write.csv(OF3_clean[validdaysi,],paste(metadatadir,"/results/part5_daysummary_",
+                data.table::fwrite(OF3_clean[validdaysi,],paste(metadatadir,"/results/part5_daysummary_",
                                                  uwi[j],"_L",uTRLi[h1],"M",uTRMi[h2],"V",
-                                                 uTRVi[h3],"_",usleepparam[h4],".csv",sep=""), row.names=FALSE)
+                                                 uTRVi[h3],"_",usleepparam[h4],".csv",sep=""), row.names=FALSE, na = "")
                 #------------------------------------------------------------------------------------
                 #also compute summary per person
                 agg_plainNweighted = function(df,filename="filename",daytype="daytype") {
@@ -370,8 +370,8 @@ g.report.part5 = function(metadatadir = c(), f0 = c(), f1 = c(), loglocation = c
                   #-------------------------------------------------------------
                   # store all summaries in csv files
                   OF4_clean = tidyup_df(OF4)
-                  write.csv(OF4_clean,paste(metadatadir,"/results/part5_personsummary_",
-                                      uwi[j],"_L",uTRLi[h1],"M",uTRMi[h2],"V",uTRVi[h3],"_",usleepparam[h4],".csv",sep=""),row.names=FALSE)
+                  data.table::fwrite(OF4_clean,paste(metadatadir,"/results/part5_personsummary_",
+                                      uwi[j],"_L",uTRLi[h1],"M", uTRMi[h2], "V", uTRVi[h3], "_", usleepparam[h4], ".csv", sep = ""), row.names = FALSE, na = "")
                 }
               }
             }

--- a/R/tidyup_df.R
+++ b/R/tidyup_df.R
@@ -1,19 +1,33 @@
 tidyup_df = function(df = c(), digits = 3) {
   df = df[rowSums(!is.na(df)) > 0, ]
   if (ncol(df) > 1) {
-    for (i in 1:ncol(df)) {
-      # convert to numeric if possible
-      df[,i] = tryCatch(as.numeric(as.character(df[, i])),
-                        error = function(cond) { return(df[, i]) },
-                        warning = function(cond) { return(df[, i]) } )
-
-      # if numeric, round to n digits
-      if (is.numeric(df[, i])) df[, i] = round(x = df[, i], digits = digits)
+    # browser()
+    # is.nan.data.frame <- function(x) {
+    #   do.call(cbind, lapply(x, is.nan))
+    # }
+    # df_bu = df
+    # t0 = Sys.time()
+    nums = vapply(df, is.numeric, FUN.VALUE = logical(1))
+    df[, nums] = round(df[, nums], digits = digits)
+    # df[is.na(df) | is.nan.data.frame(df)] = ""
+    # print(Sys.time() - t0)
+    # df_new = df
+    # df = df_bu
+    # t0 = Sys.time()
+    # for (i in 1:ncol(df)) {
+    #   # convert to numeric if possible
+    #   df[,i] = tryCatch(as.numeric(as.character(df[, i])),
+    #                     error = function(cond) { return(df[, i]) },
+    #                     warning = function(cond) { return(df[, i]) } )
+    # 
+    #   # if numeric, round to n digits
+    #   if (is.numeric(df[, i])) df[, i] = round(x = df[, i], digits = digits)
 
       # replace all NA and NaN values by blank
-      NA_NaN = which(is.na(df[, i]) | is.nan(df[, i]) | df[, i] == "NA" | df[, i] == "NaN")
-      df[NA_NaN, i] = ""
-    }
+      # NA_NaN = which(is.na(df[, i]) | is.nan(df[, i]) | df[, i] == "NA" | df[, i] == "NaN")
+      # df[NA_NaN, i] = ""
+    # }
+    # print(Sys.time() - t0)
   }
   return(df)
 }

--- a/R/tidyup_df.R
+++ b/R/tidyup_df.R
@@ -1,33 +1,12 @@
 tidyup_df = function(df = c(), digits = 3) {
   df = df[rowSums(!is.na(df)) > 0, ]
   if (ncol(df) > 1) {
-    # browser()
-    # is.nan.data.frame <- function(x) {
-    #   do.call(cbind, lapply(x, is.nan))
-    # }
-    # df_bu = df
-    # t0 = Sys.time()
-    nums = vapply(df, is.numeric, FUN.VALUE = logical(1))
-    df[, nums] = round(df[, nums], digits = digits)
-    # df[is.na(df) | is.nan.data.frame(df)] = ""
-    # print(Sys.time() - t0)
-    # df_new = df
-    # df = df_bu
-    # t0 = Sys.time()
-    # for (i in 1:ncol(df)) {
-    #   # convert to numeric if possible
-    #   df[,i] = tryCatch(as.numeric(as.character(df[, i])),
-    #                     error = function(cond) { return(df[, i]) },
-    #                     warning = function(cond) { return(df[, i]) } )
-    # 
-    #   # if numeric, round to n digits
-    #   if (is.numeric(df[, i])) df[, i] = round(x = df[, i], digits = digits)
-
-      # replace all NA and NaN values by blank
-      # NA_NaN = which(is.na(df[, i]) | is.nan(df[, i]) | df[, i] == "NA" | df[, i] == "NaN")
-      # df[NA_NaN, i] = ""
-    # }
-    # print(Sys.time() - t0)
+    # Round columns that can be coerced to numeric
+    df = lapply(df, function(x) tryCatch(round(as.numeric(as.character(x)), digits = digits), 
+                                         error = function(cond) return(x),
+                                         warning = function(cond) return(x)))
+    # list to data frame
+    df = as.data.frame(df)
   }
   return(df)
 }

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -4,7 +4,8 @@
 \section{Changes in version 2.8-2 (release date:03-10-2022)}{
   \itemize{
     \item Part5: Fix #655 (unable to handle when M5HOUR falls on midnight exactly).
-    }
+    \item Reports: Fix #672 (improved speed of reports generation).
+   }
 }
 \section{Changes in version 2.8-1 (release date:01-10-2022)}{
   \itemize{

--- a/tests/testthat/test_tidyup_df.R
+++ b/tests/testthat/test_tidyup_df.R
@@ -3,10 +3,9 @@ context("tidyup_df")
 test_that("tidyup_df returns a data frame with the numeric columns rounded", {
   # POSIXtime2iso8601
   df = data.frame(letters = c("a", "b"), nums = as.character(c(1.543218, 8.216856483)), 
-                  factor = factor(c("f1", "f2")), missing = c(NA, "NaN"))
+                  factor = factor(c("f1", "f2")))
   df_converted = tidyup_df(df = df, digits = 3)
   expect_equal(df_converted$letters, df$letters)
   expect_equal(df_converted$nums, c(1.543, 8.217))
   expect_equal(df_converted$factor, df$factor)
-  expect_equal(df_converted$missing, c("", ""))
 })


### PR DESCRIPTION
<!-- Describe your PR here -->
Fixes #672
`data.table::fwrite` function implemented instead of write.csv to save reports, and NA removal from data frames moved out from the `tidyup_df` function, now this is performed within the `fwrite` function with the argument `na = ""`.
This does not affect functionality, but speed of reports generation is improved.

I have tested this in a extensive dataset with several metrics calculated (ENMO, ZC metrics, and neishabouricounts), applying several ilevels and one mvpathreshold, and using an activity log with several windows defined in the day. Dataset of 302 files, here the performance results for the report generation of part 2:

**For one file:**
current master branch - 4.5 minutes
after skipping NA removal in tidyup_df - 36.5 seconds
after implementing data.table::fwrite - 1.3 seconds

**For the complete dataset**
current master branch - 1.05 hours
new approach - 7.5 minutes

All tests pass and the output is identical in all my tests.

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Updated or expanded the documentation.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
