### PR TITLE
fixed issue676 on nonwear storage in part 4 reports

### DIFF
--- a/R/g.report.part4.R
+++ b/R/g.report.part4.R
@@ -112,6 +112,7 @@ g.report.part4 = function(datadir = c(), metadatadir = c(), loglocation = c(), f
         }
       }
       # merge in variable
+      nightsummary2$night = gsub(" ", "", nightsummary2$night)
       nightsummary2 = base::merge(nightsummary2, outputp5, by = c("ID", "night"), all.x = TRUE)
       if (remove_oldID == TRUE) {
         nightsummary2$ID = nightsummary2$ID_old

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -1,6 +1,11 @@
 \name{NEWS}
 \title{News for Package \pkg{GGIR}}
 \newcommand{\cpkg}{\href{http://CRAN.R-project.org/package=#1}{\pkg{#1}}}
+\section{Changes in version 2.8-3 (release date:?-?-2022)}{
+  \itemize{
+    \item Reports: storing nonwear in part4 reports fixed when number of nights >= 10.
+  }
+}
 \section{Changes in version 2.8-2 (release date:06-10-2022)}{
   \itemize{
     \item Timestamp conversion functions tidied up #661.


### PR DESCRIPTION
<!-- Describe your PR here -->
Fixes #676. Nonwear information is now correctly stored in part 4 reports when the number of nights is >= 10 nights. 

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Updated or expanded the documentation.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
