### PR TITLE
Issue706 actlog seconds

### DIFF
--- a/R/g.part2.R
+++ b/R/g.part2.R
@@ -20,7 +20,7 @@ g.part2 = function(datadir = c(), metadatadir = c(), f0 = c(), f1 = c(),
   if (is.numeric(params_247[["qwindow"]])) {
     params_247[["qwindow"]] = params_247[["qwindow"]][order(params_247[["qwindow"]])]
   } else if (is.character(params_247[["qwindow"]])) {
-    params_247[["qwindow"]] = g.conv.actlog(params_247[["qwindow"]], params_247[["qwindow_dateformat"]])
+    params_247[["qwindow"]] = g.conv.actlog(params_247[["qwindow"]], params_247[["qwindow_dateformat"]], ws3 = params_general[["windowsizes"]][1])
     # This will be an object with numeric qwindow values for all individuals and days
   }
   #---------------------------------

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -5,7 +5,8 @@
   \itemize{
     \item Part 5: dayborder != 0 is now handled in g.part5.wakesleepwindow
     \item Part 5: excludefirstlast.part5 is now applied per window type in g.report.part5
-  }
+    \item Part 2: seconds in activitylog timestamps are now handled by g.conv.actlog
+ }
 }
 \section{Changes in version 2.8-3 (GitHub-only-release date:24-10-2022)}{
   \itemize{

--- a/man/GGIR.Rd
+++ b/man/GGIR.Rd
@@ -1077,7 +1077,9 @@ GGIR(mode = \Sexpr{format(formals(GGIR::GGIR)[["mode"]])},
         continuing with activity types for next day. Leave missing values empty. If an
         activitylog is used then individuals who do not appear in the activitylog will still
         be processed with value \code{qwindow = c(0, 24)}. Dates with no activiy log data can be skipped,
-        no need to have a column with the date followed by a column with the next date.}
+        no need to have a column with the date followed by a column with the next date. If times in the 
+        activity diary are not multiple of the short window size (epoch length), the next epoch is 
+        considered (e.g., with epoch of 5 seconds, 8:00:02 will be redefined as 8:00:05 in the activity log).}
 
       \item{qwindow_dateformat}{
         Character (default = "\Sexpr{GGIR::load_params()[["params_247"]][["qwindow_dateformat"]]}").

--- a/man/GGIR.Rd
+++ b/man/GGIR.Rd
@@ -463,20 +463,20 @@ GGIR(mode = \Sexpr{format(formals(GGIR::GGIR)[["mode"]])},
       \item{do.anglex}{
         Boolean (default = \Sexpr{format(GGIR::load_params()$params_metrics)[["do.anglex"]]}).
         If TRUE, calculates the angle of the X axis relative to the horizontal:
-        \deqn{angleX = (\tan{^{-1}\frac{acc_{rollmedian(x)}}{acc_{rollmedian(y)} +
-        acc_{rollmedian(z)}}}) * 180/\pi}}
+        \deqn{angleX = (\tan{^{-1}\frac{acc_{rollmedian(x)}}{(acc_{rollmedian(y)})^2 +
+        (acc_{rollmedian(z)})^2}}) * 180/\pi}}
 
       \item{do.angley}{
         Boolean (default = \Sexpr{format(GGIR::load_params()$params_metrics)[["do.angley"]]}).
         If TRUE, calculates the angle of the Y axis relative to the horizontal:
-        \deqn{angleY = (\tan{^{-1}\frac{acc_{rollmedian(y)}}{acc_{rollmedian(x)} +
-        acc_{rollmedian(z)}}}) * 180/\pi}}
+        \deqn{angleY = (\tan{^{-1}\frac{acc_{rollmedian(y)}}{(acc_{rollmedian(x)})^2 +
+        (acc_{rollmedian(z)})^2}}) * 180/\pi}}
 
       \item{do.anglez}{
         Boolean (default = \Sexpr{format(GGIR::load_params()$params_metrics)[["do.anglez"]]}).
         If TRUE, calculates the angle of the Z axis relative to the horizontal:
-        \deqn{angleZ = (\tan{^{-1}\frac{acc_{rollmedian(z)}}{acc_{rollmedian(x)} +
-        acc_{rollmedian(y)}}}) * 180/\pi}}
+        \deqn{angleZ = (\tan{^{-1}\frac{acc_{rollmedian(z)}}{(acc_{rollmedian(x)})^2 +
+        (acc_{rollmedian(y)})^2}}) * 180/\pi}}
 
       \item{do.zcx}{
         Boolean (default = \Sexpr{format(GGIR::load_params()$params_metrics)[["do.zcx"]]}).

--- a/man/g.conv.actlog.Rd
+++ b/man/g.conv.actlog.Rd
@@ -31,7 +31,7 @@
   \item{qwindow_dateformat}{
     Character specifying the date format used in the activity log.
   }
-  \item{ws3}{
+  \item{epochSize}{
     Short epoch size (first value of windowsizes in \link{g.getmeta}).
   }
 }

--- a/man/g.conv.actlog.Rd
+++ b/man/g.conv.actlog.Rd
@@ -5,11 +5,10 @@
 }
 \description{
  Function to read activity log and convert it into data.frame
- that has for each ID and date a different qwindow vector
-  
+ that has for each ID and date a different qwindow vector.
 }
 \usage{
-  g.conv.actlog(qwindow, qwindow_dateformat="\%d-\%m-\%Y")	
+  g.conv.actlog(qwindow, qwindow_dateformat="\%d-\%m-\%Y", ws3 = 5)	
 }
 \arguments{
   \item{qwindow}{
@@ -25,10 +24,15 @@
     Leave missing values empty. If an activitylog is used then individuals who do 
     not appear in the activitylog will still be processed with value c(0,24).
     Dates with no activiy log data can be skipped, no need to have a column with the 
-    date followed by a column with the next date.
+    date followed by a column with the next date. If times in the activitylog are not multiple 
+    of the short window size (epoch length), the next epoch is considered (e.g., with epoch of 5 seconds, 
+    8:00:02 will be redefined as 8:00:05 in the activity log).
   }
   \item{qwindow_dateformat}{
     Character specifying the date format used in the activity log.
+  }
+  \item{ws3}{
+    Short epoch size (first value of windowsizes in \link{g.getmeta}).
   }
 }
 \value{

--- a/tests/testthat/test_g_conv_actlog.R
+++ b/tests/testthat/test_g_conv_actlog.R
@@ -29,7 +29,7 @@ test_that("g.conv.actlog loads activity log and puts it in data.frame", {
   expect_equal(length(LOG$qwindow_names[[4]]), 7)
   expect_equal(LOG$qwindow_names[[3]], c("daystart", "work", "travelhome", "home", "dayend"))
   expect_equal(LOG$qwindow_values[[2]], c(0.00, 7.75, 17.00, 17.50, 24.00))
-  expect_equal(as.character(LOG$qwindow_times[[1]]), c("00:00", "7:45:00", "17:00:00", "17:30:00", "24:00"))
+  expect_equal(as.character(LOG$qwindow_times[[1]]), c("00:00", "7:45:00", "17:00:00", "17:30:00", "24:00:00"))
   
   expect_true(file.exists(fn))
   if (file.exists(fn)) file.remove(fn)
@@ -61,7 +61,7 @@ test_that("g.conv.actlog loads activity log and puts it in data.frame", {
   expect_equal(length(LOG$qwindow_names[[4]]), 7)
   expect_equal(LOG$qwindow_names[[3]], c("daystart", "work", "travelhome", "home", "dayend"))
   expect_equal(LOG$qwindow_values[[2]], c(0.00, 7.75, 17.00, 17.50, 24.00))
-  expect_equal(as.character(LOG$qwindow_times[[1]]), c("00:00", "7:45:00", "17:00:00", "17:30:00", "24:00"))
+  expect_equal(as.character(LOG$qwindow_times[[1]]), c("00:00", "7:45:00", "17:00:00", "17:30:00", "24:00:00"))
   
   expect_true(file.exists(fn))
   if (file.exists(fn)) file.remove(fn)

--- a/tests/testthat/test_g_conv_actlog.R
+++ b/tests/testthat/test_g_conv_actlog.R
@@ -5,11 +5,11 @@ test_that("g.conv.actlog loads activity log and puts it in data.frame", {
   # With slash as separator
   actlog = data.frame(id = c("1RAW", "2RAW"),
                       date = c("15/08/2022", "20/08/2022"),
-                      work = c("7:45:00", "7:45:00"),
+                      work = c("7:45:30", "7:45:00"),
                       travelhome = c("17:00:00", "17:00:00"),
                       home = c("17:30:00", "18:00:00"),
                       date = c("16/08/2022", "21/08/2022"),
-                      work = c("7:45:00", "7:45:00"),
+                      work = c("7:45:15", "7:45:00"),
                       travelhome = c("17:00:00", "17:00:00"),
                       home = c("17:30:00", "18:00:00"),
                       sport = c("", "19:00:00"),
@@ -28,8 +28,8 @@ test_that("g.conv.actlog loads activity log and puts it in data.frame", {
   expect_equal(length(LOG$qwindow_names[[3]]), 5)
   expect_equal(length(LOG$qwindow_names[[4]]), 7)
   expect_equal(LOG$qwindow_names[[3]], c("daystart", "work", "travelhome", "home", "dayend"))
-  expect_equal(LOG$qwindow_values[[2]], c(0.00, 7.75, 17.00, 17.50, 24.00))
-  expect_equal(as.character(LOG$qwindow_times[[1]]), c("00:00", "7:45:00", "17:00:00", "17:30:00", "24:00:00"))
+  expect_equal(LOG$qwindow_values[[2]], c(0.00, 7.754167, 17.00, 17.50, 24.00), tolerance = 3)
+  expect_equal(as.character(LOG$qwindow_times[[1]]), c("00:00", "7:45:30", "17:00:00", "17:30:00", "24:00:00"))
   
   expect_true(file.exists(fn))
   if (file.exists(fn)) file.remove(fn)


### PR DESCRIPTION
<!-- Describe your PR here -->
Fixes #706. `g.conv.actlog` now considers seconds in the activity log to define the `qwindows`.

This PR also fixes #701. Angle formulas are now revised in the documentation.

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [x] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [x] Updated or expanded the documentation.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
