### PR TITLE
Issue689 tail expansion edits vincent

### DIFF
--- a/R/check_params.R
+++ b/R/check_params.R
@@ -235,22 +235,29 @@ check_params = function(params_sleep = c(), params_metrics = c(),
   }
   if (!is.null(params_general[["expand_tail_max_hours"]])) {
     if (is.null(params_general[["recordingEndSleepHour"]])) {
+      
       params_general[["recordingEndSleepHour"]] = params_general[["expand_tail_max_hours"]] # redefine the argument
       params_general[["expand_tail_max_hours"]] = NULL # set to null so that it keeps this configuration in the config file for the next run of the script.
-      # stop if expand_tail_max_hours was defined before 7pm
-      if (params_general[["recordingEndSleepHour"]] < 19) {
-        stop("\nThe argument expand_tail_max_hours has been replaced for recordingEndSleepHour. Please, see the documentation and replace this argument in your function call.")    
-      } 
+      stop("\nThe argument expand_tail_max_hours has been replaced for",
+           " recordingEndSleepHour. Please, see the documentation and replace",
+           " this argument in your function call.")
     } else {
       # If both are defined, this is probably because expand_tail_max_hours is 
       # in the config file from a previous run
       params_general[["expand_tail_max_hours"]] = NULL # set to null so that it keeps this configuration in the config file for the next run of the script.
-      warning("\nBoth expand_tail_max_hours and recordingEndSleepHour are defined. GGIR will only use recordingEndSleepHour.")
+      warning("\nBoth expand_tail_max_hours and recordingEndSleepHour",
+              " are defined. GGIR will only use recordingEndSleepHour.")
     }
   }
   if (!is.null(params_general[["recordingEndSleepHour"]])) {
+    # stop if expand_tail_max_hours was defined before 7pm
     if (params_general[["recordingEndSleepHour"]] < 19) {
-      warning(paste0("\nrecordingEndSleepHour expects the earliest time at which the participant is expected to fall asleep. recordingEndSleepHour has been defined as ", params_general[["recordingEndSleepHour"]], ", you might want to set this later in the day."))
+      stop(paste0("\nrecordingEndSleepHour expects the latest time at which",
+                     " the participant is expected to fall asleep. recordingEndSleepHour",
+                     " has been defined as ", params_general[["recordingEndSleepHour"]],
+                     ", which does not look plausible, please specify time at or later than 19:00",
+                  " . Please note that it is your responsibility as user to verify that the
+                  assumption is credible."))
     }
   }
   invisible(list(params_sleep = params_sleep,

--- a/man/GGIR.Rd
+++ b/man/GGIR.Rd
@@ -214,18 +214,22 @@ GGIR(mode = \Sexpr{format(formals(GGIR::GGIR)[["mode"]])},
         \link{g.part1} output with synthetic data to trigger sleep detection for last night.
         Using argument \code{recordingEndSleepHour} implies the assumption that the
         participant fell asleep at or before the end of the recording if the recording
-        ended less than \code{recordingEndSleepHour} before midnight. This assumption may not
+        ended at or after \code{recordingEndSleepHour} hour of the last day. This assumption may not
         always hold true and should be used with caution. 
         The synthetic data for metashort entails: timestamps continuing
         regularly, zeros for acceleration metrics other than EN, one for EN.
         Angle columns are created in a way that it triggers the sleep detection using
         the equation: \code{round(sin((1:length_expansion) / (900/epochsize))) * 15}.
         To keep track of the tail expansion \link{g.part1} stores the lenght of the expansion in
-        the RData files, which is then passed via \link{g.part2}, \link{g.part3}, and \link{g.part4} to \link{g.part5}.
-        In \link{g.part5} it is then included as an additional variable in the csv-reports.
-        In the \link{g.part4} report the last nigth is omitted, because we know that sleep
-        estimates from the last night will not be trustworthy. Similarly, the synthetic data are ignored
-        in the the rest of reports and visualizations to avoid biased output. 
+        the RData files, which is then passed via \link{g.part2}, \link{g.part3}, 
+        and \link{g.part4} to \link{g.part5}. In \link{g.part5} the tail expansion 
+        size is included as an additional variable in the csv-reports.
+        In the \link{g.part4} csv-report the last nigth is omitted, because we know
+        that sleep estimates from the last night will not be trustworthy. Similarly, 
+        in the \link{g.part5} output columns related to the sleep assessment will 
+        be omitted for the last window to avoid biassing the averages Further, 
+        the synthetic data are also ignored in the visualizations and time series 
+        output to avoid biased output.
       }
     }
   }

--- a/tests/testthat/test_recordingEndSleepHour.R
+++ b/tests/testthat/test_recordingEndSleepHour.R
@@ -31,8 +31,8 @@ test_that("recordingEndSleepHour works as expected", {
          visualreport = FALSE, do.report = c())
   )
   
-  expect_error( # warning from recordingEndSleepHour being too early
-    # this should trigger data expansion
+  expect_error( # error from recordingEndSleepHour being too early,
+    # this should not produce any output
     GGIR(datadir = fn, outputdir = getwd(),
          studyname = "test", overwrite = TRUE, 
          recordingEndSleepHour = 6,

--- a/tests/testthat/test_recordingEndSleepHour.R
+++ b/tests/testthat/test_recordingEndSleepHour.R
@@ -15,6 +15,7 @@ test_that("recordingEndSleepHour works as expected", {
   load(rn[1])
   nrow(M$metashort)
   expect_true(nrow(M$metashort) == 43020 )
+  expect_true(M$metashort$timestamp[nrow(M$metashort)] == "2016-06-25T20:44:55+0200")
   
   # errors and warnings work properly
   expect_error( # error from using expand_tail_max_hour instead of new argument
@@ -26,17 +27,24 @@ test_that("recordingEndSleepHour works as expected", {
   expect_warning( # warning from using both expand_tail_max_hour and recordingEndSleepHour
     GGIR(mode = 1, datadir = fn, outputdir = getwd(), 
          studyname = "test", overwrite = TRUE, 
-         expand_tail_max_hours = 5, recordingEndSleepHour = 8,
+         expand_tail_max_hours = 5, recordingEndSleepHour = 20,
          visualreport = FALSE, do.report = c())
   )
   
-  expect_warning( # warning from recordingEndSleepHour being too early
+  expect_error( # warning from recordingEndSleepHour being too early
     # this should trigger data expansion
     GGIR(datadir = fn, outputdir = getwd(),
          studyname = "test", overwrite = TRUE, 
          recordingEndSleepHour = 6,
          minimum_MM_length.part5 = 15)
   )
+  
+  
+  # No warning, this should work
+  GGIR(datadir = fn, outputdir = getwd(),
+         studyname = "test", overwrite = TRUE, 
+         recordingEndSleepHour = 20,
+         minimum_MM_length.part5 = 15)
   rn = dir("output_test/meta/basic/",full.names = TRUE)
   load(rn[1])
   expect_true(nrow(M$metashort) > 43020 ) # metashort is expanded
@@ -53,6 +61,7 @@ test_that("recordingEndSleepHour works as expected", {
   p5 = read.csv("output_test/results/part5_daysummary_MM_L40M100V400_T5A5.csv") 
   expect_equal(nrow(p5), 3) # expanded day appears in MM report
   expect_true(p5$dur_day_spt_min[nrow(p5)] < 23*60) # but expanded time is not accounted for in estimates
+  
   
   if (file.exists("output_test"))  unlink("output_test", recursive = TRUE)
   if (file.exists(fn)) file.remove(fn)


### PR DESCRIPTION
<!-- Describe your PR here -->

Hi @jhmigueles, in this PR I am proposing a couple of changes to PR https://github.com/wadpac/GGIR/pull/694. More specifically I:

1. Removed the first of the two `< 19` checks because it was inside the check for `expand_tail_max_hours` and `recordingEndSleepHour`. The second check a few lines lower should be sufficient and in this way we keep the code readable.
2. Replaced warning text "earliest time at which the participant is expected to fall asleep" to "latest time at which the participant is expected to fall asleep" because that is what `recordingEndSleepHour` does. This is why it is highly problematic if users would use this functionality for adult or elderly populations because it is questionable to assume that adults participants would fall asleep at or before 7pm.
3. Updated unit test based on new error/warning structure
4. Replaced warning by error when recordingEndSleepHour is below 7pm, because I cannot think of a population that can be assumed to fall asleep earlier in the day. Without this error I am worried that less critical researchers will abuse this functionality to boost sample size without realising how problematic their analyses are.
5. Correction to GGIR.Rd documentation on recordingEndSleepHour and reinserting the statement that sleep estimates for the last window for part 5 are omitted. This is important because the user will get day time variables for all days but not night time variables.
6. Updated unit test line 27 to only focus on the double argument situation, and not to also provide an invalid value for argument recordingEndSleepHour.

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [ ] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Updated or expanded the documentation.
- [ ] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
