### PR TITLE
Issue733 qwindow firstday

### DIFF
--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -4,6 +4,7 @@
 \section{Changes in version 2.8-5 (GitHub-only-release date:??-??-2022)}{
   \itemize{
     \item Part 2: seconds in activitylog timestamps are now handled by g.conv.actlog
+    \item Part 2: fixed bug related to qwindows in the first recording day
   }
 }
 \section{Changes in version 2.8-4 (GitHub-only-release date:20-12-2022)}{

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -3,8 +3,8 @@
 \newcommand{\cpkg}{\href{http://CRAN.R-project.org/package=#1}{\pkg{#1}}}
 \section{Changes in version 2.8-5 (GitHub-only-release date:??-??-2022)}{
   \itemize{
-    \item Part 2: seconds in activitylog timestamps are now handled by g.conv.actlog
-    \item Part 2: fixed bug related to qwindows in the first recording day
+    \item Part 2: Seconds in activitylog timestamps are now handled by g.conv.actlog
+    \item Part 2: Fixed #733 related to qwindows in the first recording day
   }
 }
 \section{Changes in version 2.8-4 (GitHub-only-release date:20-12-2022)}{


### PR DESCRIPTION
<!-- Describe your PR here -->
Fixes issue #733. When the first defined qwindows are not in the recorded data from the first day (e.g., qwindow = c(0, 7, 17, 24) and recording starts at 15:00), then there was a mismatch between the qwindow names and the definition to the windows to analyse. This is now fixed in this branch.

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Updated or expanded the documentation.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
