### PR TITLE
Issue760 last day sleeplog

### DIFF
--- a/R/g.loadlog.R
+++ b/R/g.loadlog.R
@@ -106,6 +106,7 @@ g.loadlog = function(loglocation = c(), coln1 = c(), colid = c(), nnights = c(),
               if (length(ind) > 0) {
                 curdatecol = datecols[ind]
                 nextdatecol =  datecols[which(datecols > curdatecol)[1]]
+                if (is.na(nextdatecol)) nextdatecol = ncol(S) + 1
                 onseti = onsetcols[which(onsetcols > curdatecol & onsetcols < nextdatecol)]
                 # if (ni < (length(expected_dates) - 1)) {
                 wakeupi = wakecols[which(wakecols > nextdatecol)[1]]

--- a/R/g.report.part4.R
+++ b/R/g.report.part4.R
@@ -122,7 +122,8 @@ g.report.part4 = function(datadir = c(), metadatadir = c(), loglocation = c(),
         }
       }
       # merge in variable
-      nightsummary2$night = gsub(" ", "", nightsummary2$night)
+      nightsummary2$night = as.numeric(gsub(" ", "", nightsummary2$night))
+      outputp5$night = as.numeric(outputp5$night)
       nightsummary2 = base::merge(nightsummary2, outputp5, by = c("ID", "night"), all.x = TRUE)
       if (remove_oldID == TRUE) {
         nightsummary2$ID = nightsummary2$ID_old

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -1,7 +1,13 @@
 \name{NEWS}
 \title{News for Package \pkg{GGIR}}
 \newcommand{\cpkg}{\href{http://CRAN.R-project.org/package=#1}{\pkg{#1}}}
-\section{Changes in version 2.8-7 (GitHub-only-release date:20-03-2022)}{
+\section{Changes in version 2.8-8 (GitHub-only-release date:??-??-2023)}{
+  \itemize{
+   \item Sleep log: fixed bug related to reading last day in advanced sleeplog.
+   \item Reports: nights in part 4 reports are now correctly ordered.
+  }
+}
+\section{Changes in version 2.8-7 (GitHub-only-release date:20-03-2023)}{
   \itemize{
    \item Part 1: Deprecating dependency on GENEAread package, from now onward only
    GGIRread is used for reading GENEActiv binary data #627


### PR DESCRIPTION
<!-- Describe your PR here -->
Fixes #760 -> last day in advanced sleeplog is now loaded in g.loadlog.
This also fixes the [ordering of nights](https://groups.google.com/g/RpackageGGIR/c/agPEBuiaMfA) in the nightsummary reports from part 4.

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Updated or expanded the documentation.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
