### PR TITLE
Issue763 gradient part5

### DIFF
--- a/R/g.part5.R
+++ b/R/g.part5.R
@@ -834,7 +834,17 @@ g.part5 = function(datadir = c(), metadatadir = c(), f0=c(), f1=c(),
                             x_ig = zoo::rollmean(params_247[["iglevels"]], k = 2)
                             y_ig = (as.numeric(table(q55)) * ws3new)/60 #converting to minutes
                             dsummary[di,fi:(fi + 2)] = as.numeric(g.intensitygradient(x_ig, y_ig))
-                            ds_names[fi:(fi + 2)] = c("ig_gradient", "ig_intercept", "ig_rsquared")
+                            ds_names[fi:(fi + 2)] = c("ig_day_gradient", "ig_day_intercept", "ig_day_rsquared")
+                            fi = fi + 3
+                          }
+                          #===========================
+                          # Intensity gradient over the full window (waking + spt)
+                          if (length(params_247[["iglevels"]]) > 0) {
+                            q55 = cut(ts$ACC[sse], breaks = params_247[["iglevels"]], right = FALSE)
+                            x_ig = zoo::rollmean(params_247[["iglevels"]], k = 2)
+                            y_ig = (as.numeric(table(q55)) * ws3new)/60 #converting to minutes
+                            dsummary[di,fi:(fi + 2)] = as.numeric(g.intensitygradient(x_ig, y_ig))
+                            ds_names[fi:(fi + 2)] = c("ig_day_spt_gradient", "ig_day_spt_intercept", "ig_day_spt_rsquared")
                             fi = fi + 3
                           }
                           #===============================================

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -1,6 +1,11 @@
 \name{NEWS}
 \title{News for Package \pkg{GGIR}}
 \newcommand{\cpkg}{\href{http://CRAN.R-project.org/package=#1}{\pkg{#1}}}
+\section{Changes in version 2.9-1 (release date:?-?-2023)}{
+  \itemize{
+   \item Part 5: intensity gradient is now also calculated for full window in part 5.
+  }
+}
 \section{Changes in version 2.9-0 (release date:24-03-2023)}{
   \itemize{
    \item Sleep log: fixed bug related to reading last day in advanced sleeplog.

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -3,7 +3,7 @@
 \newcommand{\cpkg}{\href{http://CRAN.R-project.org/package=#1}{\pkg{#1}}}
 \section{Changes in version 2.9-1 (release date:?-?-2023)}{
   \itemize{
-   \item Part 5: intensity gradient is now also calculated for full window in part 5.
+   \item Part 5: intensity gradient is now also calculated for full window in part 5 and column names now indicate the window over the intensity gradient is calculated (i.e., "_day_" or "_day_spt_").
   }
 }
 \section{Changes in version 2.9-0 (release date:24-03-2023)}{

--- a/vignettes/GGIR.Rmd
+++ b/vignettes/GGIR.Rmd
@@ -918,6 +918,10 @@ vigorous activity:
 | L5TIME_num, M5TIME_num  | Timing of least/most active 5hrs, expressed as hours in the day. Note that L5/M5 timing variables are difficult to average across days because 23:00 and 1:00 would average to noon and not to midnight. So, caution is needed when interpreting person averages.   |
 | L5VALUE     | Acceleration value for least active 5hrs       |
 | M5VALUE     | Acceleration value for most active 5hrs        |
+| `ig_`       | All variables related to intensity gradient analysis |
+| `_gradient`   | Gradient from intensity gradient analysis proposed by [Rowlands et al. 2018](https://journals.lww.com/acsm-msse/Fulltext/2018/06000/Beyond_Cut_%20Points__Accelerometer_Metrics_that.25.aspx) for the waking hours window (`_day_`) and for the full window (`_day_spt_`)      |
+| `_intercept`  | Intercept from intensity gradient analysis proposed by [Rowlands et al. 2018](https://journals.lww.com/acsm-msse/Fulltext/2018/06000/Beyond_Cut_%20Points__Accelerometer_Metrics_that.25.aspx) for the waking hours window (`_day_`) and for the full window (`_day_spt_`)      |
+| `_rsquared`   | r squared from intensity gradient analysis proposed by [Rowlands et al. 2018](https://journals.lww.com/acsm-msse/Fulltext/2018/06000/Beyond_Cut_%20Points__Accelerometer_Metrics_that.25.aspx) for the waking hours window (`_day_`) and for the full window (`_day_spt_`)      |
 | `FRAG_`     | All variables related to behavioural fragmentation analysis |
 | `TP_`       | Transition probability|
 | PA2IN       | Physical activity fragments followed by inactivity fragments|


### PR DESCRIPTION
<!-- Describe your PR here -->
Fixes #763 => Part 5 now calculates the intensity gradient both for the waking hours (ig_day_gradient,...) and for the full window (ig_day_spt_gradient,...), and names in the part 5 report are revised to indicate this.

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [x] Updated or expanded the documentation.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
