### PR TITLE
Issue768 strategy3

### DIFF
--- a/R/check_params.R
+++ b/R/check_params.R
@@ -210,7 +210,14 @@ check_params = function(params_sleep = c(), params_metrics = c(),
       warning(paste0("\nSetting argument ndayswindow in combination with strategy = ", 
                      params_cleaning[["strategy"]]," is not meaningful, because this is only used when strategy = 3 or strategy = 5"), call. = FALSE)
     }
-    
+    if (params_cleaning[["strategy"]] == 5 &
+        params_cleaning[["ndayswindow"]] != round(params_cleaning[["ndayswindow"]])) {
+      newValue = round(params_cleaning[["ndayswindow"]])
+      warning(paste0("\nArgument ndayswindow has been rounded from ",
+                     params_cleaning[["ndayswindow"]], " to ", newValue, " days",
+                     "because when strategy == 5 we expect an integer value", call. = FALSE))
+      params_cleaning[["ndayswindow"]] = newValue
+    }
     
     if (length(params_cleaning[["data_cleaning_file"]]) > 0) {
       # Convert paths from Windows specific slashed to generic slashes

--- a/R/check_params.R
+++ b/R/check_params.R
@@ -206,9 +206,9 @@ check_params = function(params_sleep = c(), params_metrics = c(),
       warning(paste0("\nSetting argument hrs.del.end in combination with strategy = ",
                      params_cleaning[["strategy"]]," is not meaningful, because this is only used when straytegy = 1"), call. = FALSE)
     }
-    if (params_cleaning[["strategy"]] != 3 & params_cleaning[["ndayswindow"]] != 7) {
+    if (!(params_cleaning[["strategy"]] %in% c(3, 5)) & params_cleaning[["ndayswindow"]] != 7) {
       warning(paste0("\nSetting argument ndayswindow in combination with strategy = ", 
-                     params_cleaning[["strategy"]]," is not meaningful, because this is only used when straytegy = 3"), call. = FALSE)
+                     params_cleaning[["strategy"]]," is not meaningful, because this is only used when strategy = 3 or strategy = 5"), call. = FALSE)
     }
     
     

--- a/R/g.impute.R
+++ b/R/g.impute.R
@@ -1,5 +1,5 @@
-g.impute = function(M, I, acc.metric = "ENMO", params_cleaning = c(), desiredtz = "", 
-                    dayborder = 0, TimeSegments2Zero = c(), ...) {
+g.impute = function(M, I, params_cleaning = c(), desiredtz = "", 
+                    dayborder = 0, TimeSegments2Zero = c(), acc.metric = "ENMO", ...) {
   
   #get input variables
   input = list(...)

--- a/R/g.impute.R
+++ b/R/g.impute.R
@@ -172,7 +172,7 @@ g.impute = function(M, I, acc.metric = "ENMO", params_cleaning = c(), desiredtz 
         r4 = r4[1:floor(LD/(ws2/60))]
       }
     } else {
-      # Proposal 1 for strategy 3 (calendar days)
+      # Proposal 2 for strategy 3 (calendar days)
       atestlist = c()
       for (ati in 1:length(midnightsi)) {
         p0 = ((midnightsi[ati] * ws2/ws3) - ws2/ws3) + 1

--- a/R/g.part2.R
+++ b/R/g.part2.R
@@ -141,6 +141,7 @@ g.part2 = function(datadir = c(), metadatadir = c(), f0 = c(), f1 = c(),
           }
         }
         IMP = g.impute(M, I,
+                       acc.metric = params_general[["acc.metric"]],
                        params_cleaning = params_cleaning,
                        dayborder = params_general[["dayborder"]],
                        desiredtz = params_general[["desiredtz"]],

--- a/R/g.part2.R
+++ b/R/g.part2.R
@@ -141,11 +141,11 @@ g.part2 = function(datadir = c(), metadatadir = c(), f0 = c(), f1 = c(),
           }
         }
         IMP = g.impute(M, I,
-                       acc.metric = params_general[["acc.metric"]],
                        params_cleaning = params_cleaning,
                        dayborder = params_general[["dayborder"]],
                        desiredtz = params_general[["desiredtz"]],
-                       TimeSegments2Zero = TimeSegments2Zero)
+                       TimeSegments2Zero = TimeSegments2Zero,
+                       acc.metric = params_general[["acc.metric"]])
         
         if (params_cleaning[["do.imp"]] == FALSE) { #for those interested in sensisitivity analysis
           IMP$metashort = M$metashort

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -1,6 +1,12 @@
 \name{NEWS}
 \title{News for Package \pkg{GGIR}}
 \newcommand{\cpkg}{\href{http://CRAN.R-project.org/package=#1}{\pkg{#1}}}
+\section{Changes in version 2.9-1 (release date:?-?-2023)}{
+  \itemize{
+   \item Part 2: strategy = 5 implemented (allows to select most active X calendar days).
+   \item Part 2: fixed bug in strategy = 3 and now it selects the acc.metric of interest.
+  }
+}
 \section{Changes in version 2.9-0 (release date:24-03-2023)}{
   \itemize{
    \item Sleep log: fixed bug related to reading last day in advanced sleeplog.

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -3,7 +3,8 @@
 \newcommand{\cpkg}{\href{http://CRAN.R-project.org/package=#1}{\pkg{#1}}}
 \section{Changes in version 2.9-1 (release date:?-?-2023)}{
   \itemize{
-   \item Part 2: strategy = 5 implemented (allows to select most active X calendar days).
+   \item Part 2: strategy = 5 implemented as a variation of strategy 3 (it allows to select 
+   most active X calendar days).
    \item Part 2: fixed bug in strategy = 3 and now it selects the acc.metric of interest.
    \item Part 5: intensity gradient is now also calculated for full window in part 5 and column names now indicate the window over the intensity gradient is calculated (i.e., "_day_" or "_day_spt_").
   }

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -4,9 +4,9 @@
 \section{Changes in version 2.9-1 (release date:?-?-2023)}{
   \itemize{
    \item Part 2: strategy = 5 implemented as a variation of strategy 3 (it allows to select 
-   most active X calendar days).
-   \item Part 2: fixed bug in strategy = 3 and now it selects the acc.metric of interest.
-   \item Part 5: intensity gradient is now also calculated for full window in part 5 and column names now indicate the window over the intensity gradient is calculated (i.e., "_day_" or "_day_spt_").
+   most active X calendar days) #768.
+   \item Part 2: fixed bug in strategy = 3 and now it selects the acc.metric of interest #768.
+   \item Part 5: intensity gradient is now also calculated for full window in part 5 and column names now indicate the window over the intensity gradient is calculated (i.e., "_day_" or "_day_spt_") #763.
   }
 }
 \section{Changes in version 2.9-0 (release date:24-03-2023)}{

--- a/man/GGIR.Rd
+++ b/man/GGIR.Rd
@@ -756,8 +756,8 @@ GGIR(mode = \Sexpr{format(formals(GGIR::GGIR)[["mode"]])},
         strategy = 2 makes that only the data between the first
         midnight and the last midnight is used.
         strategy = 3 only selects the most active X days in the file where X is
-        specified by argument \code{ndayswindow}, where a day is a 24-h block starting 
-        any time in the day.
+        specified by argument \code{ndayswindow}, where the days are a series of 24-h blocks 
+        starting any time in the day.
         strategy = 4 to only use the data after the first midnight.
         strategy = 5 is similar to \code{strategy = 3}, but it selects X complete 
         calendar days where X is specified by argument \code{ndayswindow}.}

--- a/man/GGIR.Rd
+++ b/man/GGIR.Rd
@@ -780,7 +780,8 @@ GGIR(mode = \Sexpr{format(formals(GGIR::GGIR)[["mode"]])},
       \item{ndayswindow}{
         Numeric (default = \Sexpr{GGIR::load_params()[["params_cleaning"]][["ndayswindow"]]}).
         If \code{strategy} is set to 3 or 5, then this is the size of the window as a 
-        number of days.}
+        number of days. For strategy 3 value can be fractional, e.g. 7.5, 
+        while for strategy 5 it needs to be an integer.}
 
       \item{includedaycrit.part5}{
         Numeric (default = \Sexpr{round(GGIR::load_params()[["params_cleaning"]][["includedaycrit.part5"]], 3)}).

--- a/man/GGIR.Rd
+++ b/man/GGIR.Rd
@@ -756,8 +756,11 @@ GGIR(mode = \Sexpr{format(formals(GGIR::GGIR)[["mode"]])},
         strategy = 2 makes that only the data between the first
         midnight and the last midnight is used.
         strategy = 3 only selects the most active X days in the file where X is
-        specified by argument \code{ndayswindow}.
-        strategy = 4 to only use the data after the first midnight.}
+        specified by argument \code{ndayswindow}, where a day is a 24-h block starting 
+        any time in the day.
+        strategy = 4 to only use the data after the first midnight.
+        strategy = 5 is similar to \code{strategy = 3}, but it selects X complete 
+        calendar days where X is specified by argument \code{ndayswindow}.}
 
       \item{hrs.del.start}{
         Numeric (default = \Sexpr{GGIR::load_params()[["params_cleaning"]][["hrs.del.start"]]}).
@@ -776,7 +779,8 @@ GGIR(mode = \Sexpr{format(formals(GGIR::GGIR)[["mode"]])},
 
       \item{ndayswindow}{
         Numeric (default = \Sexpr{GGIR::load_params()[["params_cleaning"]][["ndayswindow"]]}).
-        If \code{strategy} is set to 3 then this is the size of the window as a number of days.}
+        If \code{strategy} is set to 3 or 5, then this is the size of the window as a 
+        number of days.}
 
       \item{includedaycrit.part5}{
         Numeric (default = \Sexpr{round(GGIR::load_params()[["params_cleaning"]][["includedaycrit.part5"]], 3)}).
@@ -1279,31 +1283,31 @@ GGIR(mode = \Sexpr{format(formals(GGIR::GGIR)[["mode"]])},
   GGIR(#-------------------------------
        # General parameters
        #-------------------------------
-       mode=mode,
-       datadir=datadir,
-       outputdir=outputdir,
-       studyname=studyname,
-       f0=f0,
-       f1=f1,
+       mode = mode,
+       datadir = datadir,
+       outputdir = outputdir,
+       studyname = studyname,
+       f0 = f0,
+       f1 = f1,
        overwrite = FALSE,
-       do.imp=TRUE,
-       idloc=1,
-       print.filename=FALSE,
+       do.imp = TRUE,
+       idloc = 1,
+       print.filename = FALSE,
        storefolderstructure = FALSE,
        #-------------------------------
        # Part 1 parameters:
        #-------------------------------
        windowsizes = c(5,900,3600),
-       do.cal=TRUE,
+       do.cal = TRUE,
        do.enmo = TRUE,
-       do.anglez=TRUE,
-       chunksize=1,
-       printsummary=TRUE,
+       do.anglez = TRUE,
+       chunksize = 1,
+       printsummary = TRUE,
        #-------------------------------
        # Part 2 parameters:
        #-------------------------------
        strategy = 1,
-       ndayswindow=7,
+       ndayswindow = 7,
        hrs.del.start = 1,
        hrs.del.end = 1,
        maxdur = 9,
@@ -1312,14 +1316,14 @@ GGIR(mode = \Sexpr{format(formals(GGIR::GGIR)[["mode"]])},
        M5L5res = 10,
        winhr = c(5,10),
        qlevels = c(c(1380/1440),c(1410/1440)),
-       qwindow=c(0,24),
+       qwindow = c(0,24),
        ilevels = c(seq(0,400,by=50),8000),
-       mvpathreshold =c(100,120),
+       mvpathreshold = c(100,120),
        #-------------------------------
        # Part 3 parameters:
        #-------------------------------
-       timethreshold= c(5,10),
-       anglethreshold=5,
+       timethreshold = c(5,10),
+       anglethreshold = 5,
        ignorenonwear = TRUE,
        #-------------------------------
        # Part 4 parameters:
@@ -1327,12 +1331,12 @@ GGIR(mode = \Sexpr{format(formals(GGIR::GGIR)[["mode"]])},
        excludefirstlast = FALSE,
        includenightcrit = 16,
        def.noc.sleep = 1,
-       loglocation= "D:/sleeplog.csv",
+       loglocation = "D:/sleeplog.csv",
        outliers.only = FALSE,
        criterror = 4,
        relyonguider = FALSE,
-       colid=1,
-       coln1=2,
+       colid = 1,
+       coln1 = 2,
        do.visual = TRUE,
        nnights = 9,
        #-------------------------------
@@ -1354,7 +1358,7 @@ GGIR(mode = \Sexpr{format(formals(GGIR::GGIR)[["mode"]])},
        #-----------------------------------
        # Report generation
        #-------------------------------
-       do.report=c(2,4,5))
+       do.report = c(2,4,5))
   }
 }
 \author{

--- a/man/g.impute.Rd
+++ b/man/g.impute.Rd
@@ -10,7 +10,7 @@
   protocol to label impute invalid time segments in the data.
 }
 \usage{
-  g.impute(M, I, params_cleaning = c(),
+  g.impute(M, I, acc.metric = "ENMO", params_cleaning = c(),
   desiredtz="", dayborder= 0, TimeSegments2Zero =c(), ...)
 }
 %- maybe also 'usage' for other objects documented here.
@@ -20,6 +20,14 @@
   }
   \item{I}{
     output from \link{g.inspectfile}
+  }
+  \item{acc.metric}{
+    Character (default = ENMO). Which one of the acceleration metrics do you want 
+    to use for all acceleration magnitude analyses in GGIR part 5 and the visual 
+    report? For example: "ENMO", "LFENMO", "MAD", "NeishabouriCount_y", or 
+    "NeishabouriCount_vm". Only one acceleration metric can be specified and the 
+    selected metric needs to have been calculated in part 1 (see g.part1) via 
+    arguments such as do.enmo = TRUE or do.mad = TRUE.
   }
   \item{params_cleaning}{
     See \link{g.part1}

--- a/man/g.impute.Rd
+++ b/man/g.impute.Rd
@@ -10,8 +10,8 @@
   protocol to label impute invalid time segments in the data.
 }
 \usage{
-  g.impute(M, I, acc.metric = "ENMO", params_cleaning = c(),
-  desiredtz="", dayborder= 0, TimeSegments2Zero =c(), ...)
+  g.impute(M, I, params_cleaning = c(),
+  desiredtz="", dayborder= 0, TimeSegments2Zero =c(), acc.metric = "ENMO", ...)
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
@@ -20,14 +20,6 @@
   }
   \item{I}{
     output from \link{g.inspectfile}
-  }
-  \item{acc.metric}{
-    Character (default = ENMO). Which one of the acceleration metrics do you want 
-    to use for all acceleration magnitude analyses in GGIR part 5 and the visual 
-    report? For example: "ENMO", "LFENMO", "MAD", "NeishabouriCount_y", or 
-    "NeishabouriCount_vm". Only one acceleration metric can be specified and the 
-    selected metric needs to have been calculated in part 1 (see g.part1) via 
-    arguments such as do.enmo = TRUE or do.mad = TRUE.
   }
   \item{params_cleaning}{
     See \link{g.part1}
@@ -43,6 +35,9 @@
     and acceleration metrics to be imputed by zeros. The data.frame is expected
     to contain two columns named windowstart and windowend, with the start- and end
     time of the time segment in POSIXlt class.
+  }
+  \item{acc.metric}{
+    See \link{GGIR}
   }
   \item{...}{
      Any argument used in the previous version of g.impute, which will now

--- a/tests/testthat/test_chainof5parts.R
+++ b/tests/testthat/test_chainof5parts.R
@@ -44,7 +44,21 @@ test_that("chainof5parts", {
   load(rn[1])
   expect_equal(nrow(IMP$metashort), 11280)
   expect_equal(round(mean(IMP$metashort$ENMO), digits = 5), 0.00802, tolerance = 3)
-  expect_equal(round(as.numeric(SUM$summary$meas_dur_def_proto_day), digits = 3), 0.417)
+  expect_equal(round(as.numeric(SUM$summary$meas_dur_def_proto_day), digits = 3), 1)
+  expect_equal(SUM$summary$`N valid WEdays`, "1")
+  expect_equal(SUM$summary$`N valid WKdays`, "2")
+  
+  # part 2 with strategy = 5
+  g.part2(datadir = fn, metadatadir = metadatadir, f0 = 1, f1 = 1,
+          idloc = 2, desiredtz = desiredtz, ndayswindow = 1,
+          strategy = 5, overwrite = TRUE, hrs.del.start = 0, hrs.del.end = 0,
+          maxdur = Ndays, includedaycrit = 0, do.parallel = do.parallel, myfun = c())
+  dirname = "output_test/meta/ms2.out/"
+  rn = dir(dirname,full.names = TRUE)
+  load(rn[1])
+  expect_equal(nrow(IMP$metashort), 11280)
+  expect_equal(round(mean(IMP$metashort$ENMO), digits = 5), 0.03398, tolerance = 3)
+  expect_equal(round(as.numeric(SUM$summary$meas_dur_def_proto_day), digits = 3), 1)
   expect_equal(SUM$summary$`N valid WEdays`, "1")
   expect_equal(SUM$summary$`N valid WKdays`, "2")
   

--- a/tests/testthat/test_chainof5parts.R
+++ b/tests/testthat/test_chainof5parts.R
@@ -36,7 +36,7 @@ test_that("chainof5parts", {
   #-------------------------
   # part 2 with strategy = 3
   g.part2(datadir = fn, metadatadir = metadatadir, f0 = 1, f1 = 1,
-          idloc = 2, desiredtz = desiredtz,
+          idloc = 2, desiredtz = desiredtz, ndayswindow = 1,
           strategy = 3, overwrite = TRUE, hrs.del.start = 0, hrs.del.end = 0,
           maxdur = Ndays, includedaycrit = 0, do.parallel = do.parallel, myfun = c())
   dirname = "output_test/meta/ms2.out/"

--- a/vignettes/GGIR.Rmd
+++ b/vignettes/GGIR.Rmd
@@ -293,7 +293,7 @@ for that.
     experiment.
     -   If `strategy` is set to value 1, then check out arguments
         `hrs.del.start` and `hrs.del.end`.
-    -   If `strategy` is set to value 3, then check out arguments
+    -   If `strategy` is set to value 3 or 5, then check out arguments
         `ndayswindow`.
 -   `maxdur` - maximum number of days you expect in a data file based on
     the study protocol.


### PR DESCRIPTION
<!-- Describe your PR here -->
Fixes #768 => Now strategy 3 and 5 uses `acc.metric` to look for the most active `ndayswindow`. Strategy 3 would look for X 24-h blocks, and strategy 5 would look for X complete calendar days.

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [x] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [x] Updated or expanded the documentation.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
