### PR TITLE
Issue804 thigh cutoffs to vignette

### DIFF
--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -4,6 +4,7 @@
   \section{Changes in version 2.9-5 (GitHub-only-release date: ??-??-2023)}{
     \itemize{
     \item Part 4: Now able to handle first night without any sustained inactivity bout detected #812
+    \item Vignettes: Buchan et al. 2023 cut-points for adults included in the cut-points vignette #804
     }
   }
   

--- a/vignettes/CutPoints.Rmd
+++ b/vignettes/CutPoints.Rmd
@@ -214,10 +214,9 @@ activity intensity classification with cut-points.
 | Hildebrand 2016   | Hip                |               | **`do.enmo = TRUE`\               | Moderate: 68.7\  |
 |                   |                    |               | `acc.metric = "ENMO"`             | Vigorous: 266.8  |
 +-------------------+--------------------+---------------+-----------------------------------+------------------+
-| Vähä-Ypyä 2015    | Hookie AM20\       | 35 (SD=11) yr | **Default values\                 | Light: N/A\      |
-|                   | Hip                |               | **`do.mad = TRUE`\                | Moderate: 91\    |
-|                   |                    |               | `do.enmo = FALSE`\                | Vigorous: 414    |
-|                   |                    |               | `acc.metric = "MAD"`              |                  |
+| Vähä-Ypyä 2015    | Hookie AM20\       | 35 (SD=11) yr | `do.mad = TRUE`\                  | Light: N/A\      |
+|                   | Hip                |               | `do.enmo = FALSE`\                | Moderate: 91\    |
+|                   |                    |               | `acc.metric = "MAD"`              | Vigorous: 414    |
 +-------------------+--------------------+---------------+-----------------------------------+------------------+
 | Dillon 2016\*^,†^ | GENEActiv\         | 50-69 yr      | `do.enmoa = TRUE`\                | Light: 105.6\    |
 |                   | Non-dominant wrist |               | `do.enmo = FALSE`\                | Moderate: 174.2\ |
@@ -226,6 +225,14 @@ activity intensity classification with cut-points.
 | Dillon 2016\*^,†^ | GENEActiv\         | 50-69 yr      | `do.enmoa = TRUE`\                | Light: 127.8\    |
 |                   | Dominant wrist     |               | `do.enmo = FALSE`\                | Moderate: 187.6\ |
 |                   |                    |               | `acc.metric = "ENMOa"`            | Vigorous: 396.4  |
++-------------------+--------------------+---------------+-----------------------------------+------------------+
+| Buchan 2023\*^,†^ | activPAL\          | 23 (SD=4) yr  | **Default values\                 | Light: 26.4\     |
+|                   | Right thigh        |               | `do.enmo = TRUE`\                 | Moderate: N/A\   |
+|                   |                    |               | `acc.metric = "ENMO"`             | Vigorous: N/A    |
++-------------------+--------------------+---------------+-----------------------------------+------------------+
+| Buchan 2023\*^,†^ | activPAL\          | 23 (SD=4) yr  | `do.mad = TRUE`\                  | Light: 30.1\     |
+|                   | Right thigh        |               | `do.enmo = FALSE`\                | Moderate: N/A\   |
+|                   |                    |               | `acc.metric = "MAD"`              | Vigorous: N/A    |
 +-------------------+--------------------+---------------+-----------------------------------+------------------+
 
 \*These publications used acceleration metrics that sum their values per epoch rather than average them per epoch like GGIR does. So, to use their cut-point in GGIR, we provide a scaled version of the cut-points presented in the paper as: `(CutPointFromPaper_in_gmins/(sampleRateFromPaper * EpochLengthInSecondsPaper)) * 1000`


### PR DESCRIPTION
<!-- Describe your PR here -->
Fixes #804 => Thigh cut-points for inactivity/light proposed by Buchan et al. (2023) in adults are now included in the cut-point vignette. 

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Updated or expanded the documentation.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
