### PR TITLE
increased flexibility for other ActiLife-exported formats

### DIFF
--- a/R/GGIR.R
+++ b/R/GGIR.R
@@ -249,7 +249,8 @@ GGIR = function(mode = 1:5, datadir = c(), outputdir = c(),
       convertEpochData(datadir = datadir,
                        studyname = studyname,
                        outputdir = outputdir,
-                       params_general = params_general)
+                       params_general = params_general,
+                       verbose = verbose)
     }
     if (!is.null(params_general[["maxRecordingInterval"]])) {
       # Append recordings when ID and brand match and gap between

--- a/R/check_params.R
+++ b/R/check_params.R
@@ -121,7 +121,7 @@ check_params = function(params_sleep = c(), params_metrics = c(),
                        "expand_tail_max_hours", "maxRecordingInterval")
     boolean_params = c("overwrite", "print.filename", "do.parallel", "part5_agg2_60seconds")
     character_params = c("acc.metric", "desiredtz", "configtz", "sensor.location", 
-                         "dataFormat", "extEpochData_dateformat")
+                         "dataFormat", "extEpochData_timeformat")
     check_class("general", params = params_general, parnames = numeric_params, parclass = "numeric")
     check_class("general", params = params_general, parnames = boolean_params, parclass = "boolean")
     check_class("general", params = params_general, parnames = character_params, parclass = "character")

--- a/R/convertEpochData.R
+++ b/R/convertEpochData.R
@@ -280,7 +280,8 @@ convertEpochData = function(datadir = c(), studyname = c(), outputdir = c(),
           
           timestamp = paste0(startdate, " ", starttime)
           I$header[which(rownames(I$header) == "start"), 1] = timestamp
-          timestamp_POSIX = as.POSIXlt(timestamp, tz = tz, format = paste0(params_general[["extEpochData_dateformat"]], " %H:%M:%S"))
+          timestamp_POSIX = as.POSIXlt(timestamp, tz = tz,
+                                       format = params_general[["extEpochData_timeformat"]])
         } else if (header_test == FALSE) {
           # extract date/timestamp if included in the columns
           tmp = data.table::fread(input = fnames[i],
@@ -298,8 +299,7 @@ convertEpochData = function(datadir = c(), studyname = c(), outputdir = c(),
             starttime = date[1]
             timestamp = paste0(date, " ", time)
             I$header[which(rownames(I$header) == "start"), 1] = timestamp[1]
-            format = paste(params_general[["extEpochData_dateformat"]],
-                           params_general[["extEpochData_timeformat"]])
+            format = params_general[["extEpochData_timeformat"]]
             timestamp_POSIX = as.POSIXlt(timestamp, tz = tz, format = format)
             if (all(is.na(timestamp_POSIX))) {
               stop(paste0("\nTimestamps are not available in hte file, neither it has
@@ -315,9 +315,9 @@ convertEpochData = function(datadir = c(), studyname = c(), outputdir = c(),
         }
         # CHECKS
         if (all(is.na(timestamp_POSIX))) {
-          stop(paste0("\nDate format in data ", timestamp, " does not match with date format ",
-                      params_general[["extEpochData_dateformat"]],
-                      " as specified by argument extEpochData_dateformat, please correct.\n"))
+          stop(paste0("\nTime format in data ", timestamp, " does not match with time format ",
+                      params_general[["extEpochData_timeformat"]],
+                      " as specified by argument extEpochData_timeformat, please correct.\n"))
         }
         if (epSizeShort != params_general[["windowsizes"]][1]) {
           stop(paste0("\nThe short epoch size as specified by the user as the first value of argument windowsizes (",
@@ -378,12 +378,12 @@ convertEpochData = function(datadir = c(), studyname = c(), outputdir = c(),
           I$header[which(rownames(I$header) == "start"), 1] = paste(D$date[1], D$time[1], sep = " ")
           
           timestamp_POSIX = as.POSIXct(x = paste(D$date[1:4], D$time[1:4], sep = " "),
-                                       format = paste0(params_general[["extEpochData_dateformat"]], " %H:%M:%S"),
+                                       format = params_general[["extEpochData_timeformat"]],
                                        tz = tz)
           if (all(is.na(timestamp_POSIX))) {
-            stop(paste0("\nDate format in data ", D$date[1], " does not match with date format ",
-                        params_general[["extEpochData_dateformat"]],
-                        " as specified by argument extEpochData_dateformat, please correct.\n"))
+            stop(paste0("\nTime format in data ", D$date[1], " does not match with time format ",
+                        params_general[["extEpochData_timeformat"]],
+                        " as specified by argument extEpochData_timeformat, please correct.\n"))
           }
           epSizeShort = mean(diff(as.numeric(timestamp_POSIX)))
           if (epSizeShort != params_general[["windowsizes"]][1]) {
@@ -424,14 +424,14 @@ convertEpochData = function(datadir = c(), studyname = c(), outputdir = c(),
                                       size = c(15, 30, 60, 120, 300, 2, 5, 10))
           epSizeShort = optionalEpochs$size[which(optionalEpochs$code == as.character(header[4]))]
           # Get starttime 
-          timestampFormat = paste0(params_general[["extEpochData_dateformat"]], " %H:%M")
+          timestampFormat = paste0(unlist(strsplit(params_general[["extEpochData_timeformat"]], " "))[1], " %H:%M")
           I$header[which(rownames(I$header) == "start"), 1] =  paste(header[2], header[3], sep = " ")
           timestamp_POSIX = as.POSIXct(x = paste(header[2], header[3], sep = " "),
                                        format = timestampFormat, tz = tz)
           if (is.na(timestamp_POSIX)) {
-            stop(paste0("\nDate format in data ", header[2], " does not match with date format ",
-                        params_general[["extEpochData_dateformat"]],
-                        " as specified by argument extEpochData_dateformat, please correct.\n"))
+            stop(paste0("\nTime format in data ", header[2], " does not match with time format ",
+                        params_general[["extEpochData_timeformat"]],
+                        " as specified by argument extEpochData_timeformat, please correct.\n"))
           }
           if (epSizeShort != params_general[["windowsizes"]][1]) {
             stop(paste0("\nThe short epoch size as specified by the user as the first value of argument windowsizes (",

--- a/R/convertEpochData.R
+++ b/R/convertEpochData.R
@@ -301,6 +301,11 @@ convertEpochData = function(datadir = c(), studyname = c(), outputdir = c(),
             format = paste(params_general[["extEpochData_dateformat"]],
                            params_general[["extEpochData_timeformat"]])
             timestamp_POSIX = as.POSIXlt(timestamp, tz = tz, format = format)
+            if (all(is.na(timestamp_POSIX))) {
+              stop(paste0("\nTimestamps are not available in hte file, neither it has
+                          a header to extract the timestamps from. Therefore, the file
+                          cannot be processed.\n"))
+            }
             
             epochSize = difftime(timestamp_POSIX[2], timestamp_POSIX[1], 
                                  units = "secs")

--- a/R/load_params.R
+++ b/R/load_params.R
@@ -118,7 +118,8 @@ load_params = function(group = c("sleep", "metrics", "rawdata",
                           sensor.location = "wrist",
                           expand_tail_max_hours = NULL, recordingEndSleepHour = NULL,
                           dataFormat = "raw", maxRecordingInterval = NULL,
-                          extEpochData_dateformat = "%d-%m-%Y")
+                          extEpochData_dateformat = "%d-%m-%Y",
+                          extEpochData_timeformat = "%H:%M:%S")
   }
   # }
   invisible(list(params_sleep = params_sleep,

--- a/R/load_params.R
+++ b/R/load_params.R
@@ -118,8 +118,7 @@ load_params = function(group = c("sleep", "metrics", "rawdata",
                           sensor.location = "wrist",
                           expand_tail_max_hours = NULL, recordingEndSleepHour = NULL,
                           dataFormat = "raw", maxRecordingInterval = NULL,
-                          extEpochData_dateformat = "%d-%m-%Y",
-                          extEpochData_timeformat = "%H:%M:%S")
+                          extEpochData_timeformat = "%d-%m-%Y %H:%M:%S")
   }
   # }
   invisible(list(params_sleep = params_sleep,

--- a/man/GGIR.Rd
+++ b/man/GGIR.Rd
@@ -272,6 +272,12 @@ GGIR(mode = \Sexpr{format(formals(GGIR::GGIR)[["mode"]])},
         To specify the date format used in the external epoch level data when
         argument \code{dataFormat} is set to "actiwatch_csv" or "actiwatch_awd".
       }
+      \item{extEpochData_timeformat}{
+        Character (default =
+        \Sexpr{format(GGIR::load_params()[["params_general"]][["extEpochData_timeformat"]])}).
+        To specify the time format used in the external epoch level data when
+        argument \code{dataFormat} is set to "actiwatch_csv", "actiwatch_awd", or "actigraph_csv".
+      }
       }
     }
 

--- a/man/GGIR.Rd
+++ b/man/GGIR.Rd
@@ -266,17 +266,13 @@ GGIR(mode = \Sexpr{format(formals(GGIR::GGIR)[["mode"]])},
         will show number of appended recordings, sampling rate for each, time overlap or gap
         and the names of the filenames of the respective recording.
       }
-      \item{extEpochData_dateformat}{
-        Character (default =
-        \Sexpr{format(GGIR::load_params()[["params_general"]][["extEpochData_dateformat"]])}).
-        To specify the date format used in the external epoch level data when
-        argument \code{dataFormat} is set to "actiwatch_csv" or "actiwatch_awd".
-      }
       \item{extEpochData_timeformat}{
         Character (default =
         \Sexpr{format(GGIR::load_params()[["params_general"]][["extEpochData_timeformat"]])}).
         To specify the time format used in the external epoch level data when
         argument \code{dataFormat} is set to "actiwatch_csv", "actiwatch_awd", or "actigraph_csv".
+        For example "\%Y-\%m-\%d \%I:\%M:\%S \%p" for "2023-07-11 01:24:01 PM" or
+        "\%m/\%d/\%Y \%H:\%M:\%S" "2023-07-11 13:24:01"
       }
       }
     }
@@ -1444,7 +1440,7 @@ GGIR(mode = \Sexpr{format(formals(GGIR::GGIR)[["mode"]])},
        GGIR(datadir = "/media/actiwatch_awd", # folder with epoch level .AWD file
           outputdir = "/media/myoutput",
           dataFormat = "actiwatch_awd",
-          extEpochData_dateformat = "\%m/\%d/\%Y",
+          extEpochData_timeformat = "\%m/\%d/\%Y \%H:\%M:\%S",
           mode = 1:5,
           do.report = c(2, 4, 5),
           windowsizes = c(60, 900, 3600), # 60 is the expected epoch length
@@ -1458,7 +1454,7 @@ GGIR(mode = \Sexpr{format(formals(GGIR::GGIR)[["mode"]])},
        GGIR(datadir = "/media/actiwatch_csv", # folder with epoch level .AWD file
           outputdir = "/media/myoutput",
           dataFormat = "actiwatch_csv",
-          extEpochData_dateformat = "\%m/\%d/\%Y",
+          extEpochData_timeformat = "\%m/\%d/\%Y \%H:\%M:\%S",
           mode = 1:5,
           do.report = c(2, 4, 5),
           windowsizes = c(15, 900, 3600), # 15 is the expected epoch length
@@ -1471,7 +1467,7 @@ GGIR(mode = \Sexpr{format(formals(GGIR::GGIR)[["mode"]])},
        GGIR(datadir = "/media/ukbiobank",
            outputdir = "/media/myoutput",
            dataFormat = "ukbiobank_csv",
-           extEpochData_dateformat = "\%m/\%d/\%Y",
+           extEpochData_timeformat = "\%m/\%d/\%Y \%H:\%M:\%S",
            mode = c(1:2),
            do.report = c(2),
            windowsizes = c(5, 900, 3600), # We know that data was stored in 5 second epoch
@@ -1490,7 +1486,7 @@ GGIR(mode = \Sexpr{format(formals(GGIR::GGIR)[["mode"]])},
            threshold.in = round(100 * (5/60), digits = 2),
            threshold.mod = round(2500 * (5/60), digits = 2),
            threshold.vig = round(10000 * (5/60), digits = 2),
-           extEpochData_dateformat = "\%m/\%d/\%Y",
+           extEpochData_timeformat = "\%m/\%d/\%Y \%H:\%M:\%S",
            do.neishabouricounts = TRUE,
            acc.metric = "NeishabouriCount_x",
            HASPT.algo = "NotWorn",

--- a/man/convertEpochData.Rd
+++ b/man/convertEpochData.Rd
@@ -11,7 +11,7 @@
 }
 \usage{
    convertEpochData(datadir = c(), studyname = c(), outputdir = c(),
-                            params_general = c())
+                            params_general = c(), verbose = TRUE)
 }
 \arguments{
   \item{datadir}{

--- a/man/convertEpochData.Rd
+++ b/man/convertEpochData.Rd
@@ -26,6 +26,9 @@
   \item{params_general}{
     Parameters object see \link{GGIR}
   }
+  \item{verbose}{
+    See \link{GGIR}
+  }
 }
 \keyword{internal}
 \author{

--- a/tests/testthat/test_convertExtEpochData.R
+++ b/tests/testthat/test_convertExtEpochData.R
@@ -4,7 +4,7 @@ test_that("External epoch data is correctly converted", {
   skip_on_cran()
   params_general = load_params()$params_general
   params_general[["overwrite"]] = TRUE
-  params_general[["extEpochData_dateformat"]] = "%d/%m/%Y"
+  params_general[["extEpochData_timeformat"]] = "%d/%m/%Y %H:%M:%S"
   # Set smaller than usual windowsizes, because this test recordings are clipped short
   params_general[["windowsizes"]][2] = 60
   params_general[["windowsizes"]][3] = 120
@@ -31,7 +31,7 @@ test_that("External epoch data is correctly converted", {
   move2folder(system.file("testfiles/Actiwatch.AWD", package = "GGIR")[1], dn)
   params_general[["windowsizes"]][1] = 60
   params_general[["dataFormat"]] = "actiwatch_awd"
-  params_general[["extEpochData_dateformat"]] = "%d-%b-%Y"
+  params_general[["extEpochData_timeformat"]] = "%d-%b-%Y %H:%M:%S"
   convertEpochData(datadir = dn, studyname = "tmp_testdata", outputdir = ".",
                               params_general = params_general)
   
@@ -48,10 +48,10 @@ test_that("External epoch data is correctly converted", {
   move2folder(system.file("testfiles/Actiwatch.csv", package = "GGIR")[1], dn)
   params_general[["windowsizes"]][1] = 15
   params_general[["dataFormat"]] = "actiwatch_csv"
-  params_general[["extEpochData_dateformat"]] = "%d-%m-%Y"
+  params_general[["extEpochData_timeformat"]] = "%d-%m-%Y %H:%M:%S"
   expect_error(convertEpochData(datadir = dn, studyname = "tmp_testdata", outputdir = ".",
                    params_general = params_general))
-  params_general[["extEpochData_dateformat"]] = "%d/%m/%Y"
+  params_general[["extEpochData_timeformat"]] = "%d/%m/%Y %H:%M:%S"
   convertEpochData(datadir = dn, studyname = "tmp_testdata", outputdir = ".",
                    params_general = params_general)
   if (dir.exists(dn))  unlink(dn, recursive = TRUE)
@@ -82,7 +82,7 @@ test_that("External epoch data is correctly converted", {
   move2folder(system.file("testfiles/ActiGraph61.csv", package = "GGIR")[1], dn)
   params_general[["windowsizes"]][1] = 5
   params_general[["dataFormat"]] = "actigraph_csv"
-  params_general[["extEpochData_dateformat"]] = "%m/%d/%Y"
+  params_general[["extEpochData_timeformat"]] = "%m/%d/%Y %H:%M:%S"
   convertEpochData(datadir = dn, studyname = "tmp_testdata", outputdir = ".",
                    params_general = params_general)
   if (dir.exists(dn))  unlink(dn, recursive = TRUE)
@@ -99,7 +99,7 @@ test_that("External epoch data is correctly converted", {
   move2folder(system.file("testfiles/ActiGraph13.csv", package = "GGIR")[1], dn)
   params_general[["windowsizes"]][1] = 15
   params_general[["dataFormat"]] = "actigraph_csv"
-  params_general[["extEpochData_dateformat"]] = "%m/%d/%Y"
+  params_general[["extEpochData_timeformat"]] = "%m/%d/%Y %H:%M:%S"
   convertEpochData(datadir = dn, studyname = "tmp_testdata", outputdir = ".",
                    params_general = params_general)
   if (dir.exists(dn))  unlink(dn, recursive = TRUE)

--- a/tests/testthat/test_convertExtEpochData.R
+++ b/tests/testthat/test_convertExtEpochData.R
@@ -88,9 +88,9 @@ test_that("External epoch data is correctly converted", {
   if (dir.exists(dn))  unlink(dn, recursive = TRUE)
   load(paste0(QCbasis, "/meta_ActiGraph61.csv.RData"))
   expect_equal(nrow(M$metashort), 984)
-  expect_equal(ncol(M$metashort), 4)
-  expect_equal(colnames(M$metashort), c("timestamp", "NeishabouriCount_x",
-                                        "NeishabouriCount_y", "NeishabouriCount_z"))
+  expect_equal(ncol(M$metashort), 5)
+  expect_true(all(c("timestamp", "NeishabouriCount_x", "NeishabouriCount_y", 
+                    "NeishabouriCount_z") %in% colnames(M$metashort)))
   
   # Tidy up by deleting output folder
   if (file.exists(outputdir)) unlink(outputdir, recursive = TRUE)
@@ -105,9 +105,9 @@ test_that("External epoch data is correctly converted", {
   if (dir.exists(dn))  unlink(dn, recursive = TRUE)
   load(paste0(QCbasis, "/meta_ActiGraph13.csv.RData"))
   expect_equal(nrow(M$metashort), 988)
-  expect_equal(ncol(M$metashort), 4)
-  expect_equal(colnames(M$metashort), c("timestamp", "NeishabouriCount_x",
-                                        "NeishabouriCount_y", "NeishabouriCount_z"))
+  expect_equal(ncol(M$metashort), 5)
+  expect_true(all(c("timestamp", "NeishabouriCount_x", "NeishabouriCount_y", 
+                    "NeishabouriCount_z") %in% colnames(M$metashort)))
   
   # Tidy up by deleting output folder
   if (file.exists(outputdir)) unlink(outputdir, recursive = TRUE)

--- a/tests/testthat/test_load_check_params.R
+++ b/tests/testthat/test_load_check_params.R
@@ -17,7 +17,7 @@ test_that("load_params can load parameters", {
   expect_equal(length(params$params_cleaning), 19)
   expect_equal(length(params$params_phyact), 13)
   expect_equal(length(params$params_output), 19)
-  expect_equal(length(params$params_general), 17)
+  expect_equal(length(params$params_general), 18)
 
   params_sleep = params$params_sleep
   # Test that parameter check does not generate warnings:

--- a/tests/testthat/test_load_check_params.R
+++ b/tests/testthat/test_load_check_params.R
@@ -17,7 +17,7 @@ test_that("load_params can load parameters", {
   expect_equal(length(params$params_cleaning), 19)
   expect_equal(length(params$params_phyact), 13)
   expect_equal(length(params$params_output), 19)
-  expect_equal(length(params$params_general), 18)
+  expect_equal(length(params$params_general), 17)
 
   params_sleep = params$params_sleep
   # Test that parameter check does not generate warnings:


### PR DESCRIPTION
<!-- Describe your PR here -->
In this PR:
- Increased flexibility to read actilife-exported formats with and without header and/or column names.
- Now it is supported the possibility to define the time format (I got some files with time defined as "01:48:00 PM", which was problematic). New argument included for this: `extEpochData_timeformat`
- `Neishabouricount_vm` is now always calculated to be consistent with the pipeline when `do.neuishabouricounts = TRUE`
- Still area of improvement when column names are not provided. In this case, GGIR assumes first 3 columns correspond to acceleration values for axis 1, 2 and 3 if 3 or more columns are provided. If less than 3 columns are provided, then GGIR assumes the first column contains the vector magnitude. However, this is not always the case, users can define the columns to export in actilife.

It works for all the test files I have.

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [x] Updated or expanded the documentation.
- [ ] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
