### PR TITLE
ignore getExt function from the generation of the config file

### DIFF
--- a/R/GGIR.R
+++ b/R/GGIR.R
@@ -313,7 +313,7 @@ GGIR = function(mode = 1:5, datadir = c(), outputdir = c(),
                           "GGIRversion",  "dupArgValues", "verbose", "is_GGIRread_installed", 
                           "is_read.gt3x_installed", "is_ActCR_installed", 
                           "is_actilifecounts_installed", "rawaccfiles", 
-                          "checkFormat") == FALSE)]
+                          "checkFormat", "getExt") == FALSE)]
 
   config.parameters = mget(LS)
   config.matrix = as.data.frame(createConfigFile(config.parameters, GGIRversion))

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -1,6 +1,12 @@
 \name{NEWS}
 \title{News for Package \pkg{GGIR}}
 \newcommand{\cpkg}{\href{http://CRAN.R-project.org/package=#1}{\pkg{#1}}}
+
+  \section{Changes in version 2.9-6 (GitHub-only-release date: ?-?-2023)}{
+    \itemize{
+    \item Config file: Fix minor bug by ignoring the local function getExt from the config file #846
+    }
+  }
   \section{Changes in version 2.9-5 (GitHub-only-release date: 13-07-2023)}{
     \itemize{
     \item Part 4: Now able to handle first night without any sustained inactivity bout detected #812


### PR DESCRIPTION
<!-- Describe your PR here -->
Fixes #846 => When either GGIRread or read.gt3x packages are not installed (even if they are not needed), the object getExt (function) is generated locally and later on stored in teh config file. This generates an error. Now getExt function is within the objects in the environment that are ignored in the config file.

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Updated or expanded the documentation.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
