### PR TITLE
Issue852 missing last day part5

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # CHANGES IN GGIR VERSION 2.9-6
 
+- Part 5: Now able to segment days based on qwindow #815
+
+- Part 5: Fix minor bug related to the definition of the MM window (it was biased by 1 epoch) #838
+
+- Part 5: Fix minor bug by which GGIR skipped the last day if measurement starts at midnight and timewindow = MM #852
+
+- Activity log: Fix minor bug that appeared when seconds in the activity log are not compatible with the epoch length used in GGIR #844
+
 - Config file: Fix minor bug by ignoring the local function getExt from the config file #846
 
 # CHANGES IN GGIR VERSION 2.9-5

--- a/R/g.part5.definedays.R
+++ b/R/g.part5.definedays.R
@@ -30,7 +30,7 @@ g.part5.definedays = function(nightsi, wi, indjump, nightsi_bu,
   # in the data for this day.
   if (timewindowi == "MM") {
     if (nightsi[1] == 1) wi = wi + 1 # if recording starts at midnight
-    if (length(nightsi) >= wi) {
+    if (Nwindows >= wi) {
       if (wi == 1) {
         qqq[1] = 1
         qqq[2] = nightsi[wi] - 1

--- a/R/g.part5.definedays.R
+++ b/R/g.part5.definedays.R
@@ -29,8 +29,13 @@ g.part5.definedays = function(nightsi, wi, indjump, nightsi_bu,
   # Check that it is possible to find both windows (WW and MM)
   # in the data for this day.
   if (timewindowi == "MM") {
-    if (nightsi[1] == 1) wi = wi + 1 # if recording starts at midnight
-    if (Nwindows >= wi) {
+    # if recording starts at midnight, adjust wi and nightsi
+    if (nightsi[1] == 1) {
+      wi = wi + 1
+      # add extra nightsi to get the last day processed (as wi has been increased by 1)
+      nightsi = c(nightsi, nightsi + (24*(60/ws3new) * 60) - 1)
+    }
+    if (length(nightsi) >= wi) {
       if (wi == 1) {
         qqq[1] = 1
         qqq[2] = nightsi[wi] - 1

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -5,6 +5,7 @@
     \itemize{
     \item Part 5: Now able to segment days based on qwindow #815
     \item Part 5: Fix minor bug related to the definition of the MM window (it was biased by 1 epoch) #838
+    \item Part 5: Fix minor bug by which GGIR skipped the last day if measurement starts at midnight and timewindow = MM #852
     \item Activity log: Fix minor bug that appeared when seconds in the activity log are not compatible with the epoch length used in GGIR #844
     \item Config file: Fix minor bug by ignoring the local function getExt from the config file #846
     }


### PR DESCRIPTION
<!-- Describe your PR here -->
Fixes #852 => Part 5 skipped last day if measurement starts at midnight and timewindow = "MM", now this has been addressed and the fix only affect in this scenario without affecting others (e.g., measurements not starting at midnight or timewindow = "WW")

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [ ] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Updated or expanded the documentation.
- [ ] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
