### PR TITLE
Issue869 id loading external epoch

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # CHANGES IN GGIR VERSION 2.9-7
 
+- Part 1: Fix ID extraction for externally generated epoch files #869
+
 - Sleep log: Argument nnigths is now deprecated and number of nights are detected automatically in sleep logs #856
 
 - Sleep log: Minor fixed related to misplaced parenthesis in g.loadlog and automatic extension of sleeplog matrix if needed to avoid error #867

--- a/R/convertEpochData.R
+++ b/R/convertEpochData.R
@@ -173,8 +173,8 @@ convertEpochData = function(datadir = c(), studyname = c(), outputdir = c(),
       }
     }
     if (skip == FALSE) {
+      I = I_bu
       I$filename = filename_dir = fname
-      
       if (params_general[["dataFormat"]] == "ukbiobank_csv") {
         # read data
         D = data.table::fread(input = fnames[i],
@@ -263,7 +263,7 @@ convertEpochData = function(datadir = c(), studyname = c(), outputdir = c(),
         }
         
         # extract information from header
-        I = I_bu
+        
         if (header_test == TRUE) {
           I$deviceSerialNumber = AGh$value[grep(pattern = "serialnumber", x = AGh$variable)]
           # Add serial number to header object because g.extractheadersvars for Actigraph uses this

--- a/R/extract_params.R
+++ b/R/extract_params.R
@@ -22,10 +22,6 @@ extract_params = function(params_sleep = c(), params_metrics = c(),
     params = load_params(group = "rawdata")
     params_rawdata = params$params_rawdata
   }
-  if (length(params_rawdata) == 0) {
-    params = load_params(group = "rawdata")
-    params_rawdata = params$params_rawdata
-  }
   if (length(params_247) == 0) {
     params = load_params(group = "247")
     params_247 = params$params_247


### PR DESCRIPTION
<!-- Describe your PR here -->

Fixes #869 Minor bug fix in keep the extracted filename when working with externally derived epoch data.

Also I noticed a duplication of code in extract_code that has no side effect other than wasting time.

@jhmigueles I will just merge this now without review as the changes are very small and specific to only one functionality.

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Updated or expanded the documentation.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
