### PR TITLE
Utilise readAxivity() assessment of cwa-file health

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: GGIR
 Type: Package
 Title: Raw Accelerometer Data Analysis
-Version: 2.9-7
-Date: 2023-08-31
+Version: 2.10-0
+Date: 2023-08-09
 Authors@R: c(person("Vincent T","van Hees",role=c("aut","cre"),
                     email="v.vanhees@accelting.com"),
              person("Jairo H","Migueles",role="aut",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # CHANGES IN GGIR VERSION 2.9-7
 
+- Part 1 + 2: File health log captured by dependency GGIRread::readAxivity 
+incorporated in data_quality_report #866
+
 - Part 1: Fix ID extraction for externally generated epoch files #869
 
 - Sleep log: Argument nnigths is now deprecated and number of nights are detected automatically in sleep logs #856

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
-# CHANGES IN GGIR VERSION 2.9-7
+# CHANGES IN GGIR VERSION 2.10-0
 
 - Part 1 + 2: File health log captured by dependency GGIRread::readAxivity 
-incorporated in data_quality_report #866
+and incorporated in data_quality_report #866
 
 - Part 1: Fix ID extraction for externally generated epoch files #869
 
@@ -997,7 +997,7 @@ incorporated in data_quality_report #866
 
 # CHANGES IN GGIR VERSION 1.5-17
 
-- SPT-window detection now updated with a constrained threshold to make it more robust against between accelerometer brand differences. This is the approach used for our PSG in <https://www.biorxiv.org/content/early/2018/02/01/257972>
+- SPT-window detection now updated with a constrained threshold to make it more robust against between accelerometer brand differences. This is the approach used for our PSG in <https://www.biorxiv.org/content/10.1101/257972v1>
 
 # CHANGES IN GGIR VERSION 1.5-16
 

--- a/R/check_params.R
+++ b/R/check_params.R
@@ -57,7 +57,7 @@ check_params = function(params_sleep = c(), params_metrics = c(),
                        "rmc.col.acc", "interpolationType",
                        "rmc.firstrow.acc", "rmc.firstrow.header", "rmc.header.length",
                        "rmc.col.temp", "rmc.col.time", "rmc.bitrate", "rmc.dynamic_range",
-                       "rmc.sf", "rmc.col.wear", "rmc.noise")
+                       "rmc.sf", "rmc.col.wear", "rmc.noise", "frequency_tol")
     boolean_params = c("printsummary", "do.cal", "rmc.unsignedbit", "rmc.check4timegaps", "rmc.doresample",
                        "imputeTimegaps")
     character_params = c("backup.cal.coef", "rmc.dec", "rmc.unit.acc",
@@ -134,6 +134,13 @@ check_params = function(params_sleep = c(), params_metrics = c(),
                   "activityCounts package. We will reinsert brondcounts ",
                   "once the issues are resolved. Consider using argument do.neishabouricounts, ",
                   "for more information see package documentation."), call. = FALSE)
+    }
+  }
+  
+  if (length(params_rawdata) > 0) {
+    if (params_rawdata[["frequency_tol"]] < 0 | params_rawdata[["frequency_tol"]] > 1) {
+      stop(paste0("\nArgument frequency_tol is ", params_rawdata[["frequency_tol"]],
+                  " , please adjust such that it is a number between 0 and 1"))
     }
   }
   

--- a/R/g.analyse.R
+++ b/R/g.analyse.R
@@ -1,14 +1,12 @@
 g.analyse =  function(I, C, M, IMP, params_247 = c(), params_phyact = c(),
-                      quantiletype = 7, includedaycrit = 16, 
-                      idloc = 1, snloc = 1, dayborder = 0,  desiredtz = "", 
-                      myfun = c(), acc.metric = c(), ...) {
+                      params_general = c(), params_cleaning = c(),
+                      quantiletype = 7, myfun = c(), ...) {
   
   #get input variables
   input = list(...)
   expectedArgs = c("I", "C", "M", "IMP", "params_247", "params_phyact", 
-                   "quantiletype", "includedaycrit", 
-                   "idloc", "snloc", "dayborder", 
-                   "desiredtz", "myfun")
+                   "params_general", "params_cleaning", "quantiletype",
+                    "myfun")
   if (any(names(input) %in% expectedArgs == FALSE) |
       any(!unlist(lapply(expectedArgs, FUN = exists)))) {
     # Extract and check parameters if user provides more arguments than just the parameter arguments
@@ -16,13 +14,23 @@ g.analyse =  function(I, C, M, IMP, params_247 = c(), params_phyact = c(),
     # as if it was still the old g.analyse function
     params = extract_params(params_247 = params_247,
                             params_phyact = params_phyact,
+                            params_general = params_general,
+                            params_cleaning = params_cleaning,
                             input = input) # load default parameters
     params_247 = params$params_247
     params_phyact = params$params_phyact
+    params_general = params$params_general
+    params_cleaning = params$params_cleaning
   }
   params_247[["L5M5window"]] = c(0,24) # as of version 1.6-0 this is hardcoded because argument qwindow now
   # specifies the window over which L5M5 analysis is done. So, L5M5window is a depricated
   # argument and this is also clarified in the documentation
+  
+  desiredtz = params_general[["desiredtz"]]
+  idloc = params_general[["idloc"]]
+  includedaycrit = params_cleaning[["includedaycrit"]]
+  acc.metric = params_general[["acc.metric"]]
+  
   fname = I$filename
   averageday = IMP$averageday
   strategy = IMP$strategy
@@ -127,7 +135,9 @@ g.analyse =  function(I, C, M, IMP, params_247 = c(), params_phyact = c(),
   timeline = seq(0, ceiling(nrow(metalong)/n_ws2_perday), by = 1/n_ws2_perday)
   timeline = timeline[1:nrow(metalong)]
   tooshort = 0
-  dmidn = g.detecmidnight(time,desiredtz,dayborder) #ND,
+  dmidn = g.detecmidnight(time,
+                          desiredtz =  params_general[["desiredtz"]],
+                          dayborder = params_general[["dayborder"]]) #ND,
   firstmidnight = dmidn$firstmidnight;  firstmidnighti = dmidn$firstmidnighti
   lastmidnight = dmidn$lastmidnight;    lastmidnighti = dmidn$lastmidnighti
   midnights = dmidn$midnights;          midnightsi = dmidn$midnightsi
@@ -196,15 +206,6 @@ g.analyse =  function(I, C, M, IMP, params_247 = c(), params_phyact = c(),
                                  doiglevels = doiglevels, firstmidnighti = firstmidnighti, ws2 = ws2,
                                  midnightsi = midnightsi, params_247 = params_247, qcheck = qcheck,
                                  acc.metric = acc.metric)
-  InterdailyStability = output_avday$InterdailyStability
-  IntradailyVariability = output_avday$IntradailyVariability
-  igfullr_names = output_avday$igfullr_names
-  igfullr = output_avday$igfullr
-  QUAN = output_avday$QUAN
-  qlevels_names = output_avday$qlevels_names
-  ML5AD = output_avday$ML5AD
-  ML5AD_names = output_avday$ML5AD_names
-  
   cosinor_coef = output_avday$cosinor_coef
   
   #--------------------------------------------------------------
@@ -217,7 +218,8 @@ g.analyse =  function(I, C, M, IMP, params_247 = c(), params_phyact = c(),
                                      doiglevels = doiglevels, nfulldays = nfulldays,
                                      lastmidnight = lastmidnight,
                                      ws3 = ws3, ws2 = ws2, qcheck = qcheck, fname = fname,
-                                     idloc = idloc, sensor.location = sensor.location, wdayname = wdayname,
+                                     idloc = idloc, sensor.location = sensor.location,
+                                     wdayname = wdayname,
                                      tooshort = tooshort, includedaycrit = includedaycrit,
                                      quantiletype = quantiletype, doilevels = doilevels, 
                                      domvpa = domvpa,
@@ -226,10 +228,6 @@ g.analyse =  function(I, C, M, IMP, params_247 = c(), params_phyact = c(),
                                      doquan = doquan,  ExtFunColsi = ExtFunColsi,
                                      myfun = myfun, desiredtz = desiredtz,
                                      params_247 = params_247, params_phyact = params_phyact)
-    daysummary = output_perday$daysummary
-    ds_names = output_perday$ds_names
-    windowsummary = output_perday$windowsummary
-    ws_names = output_perday$ws_names
   }
   #metashort is shortened from midgnight to midnight if requested (strategy 2)
   if (strategy == 2) {
@@ -280,15 +278,31 @@ g.analyse =  function(I, C, M, IMP, params_247 = c(), params_phyact = c(),
     cat("file skipped for general average caculation because not enough data")
   }
   rm(metalong); rm(metashort)
-  
-  output_perfile = g.analyse.perfile(ID, fname, deviceSerialNumber, sensor.location, startt, I, LC2, LD, dcomplscore,
-                                     LMp, LWp, C, lookat, AveAccAve24hr, colnames_to_lookat, QUAN, ML5AD,
-                                     ML5AD_names, igfullr, igfullr_names,
-                                     daysummary, ds_names, includedaycrit, strategy, hrs.del.start,
-                                     hrs.del.end, maxdur, windowsizes, idloc, snloc, wdayname, doquan,
-                                     qlevels_names, doiglevels, tooshort, InterdailyStability, IntradailyVariability,
-                                     IVIS_windowsize_minutes = params_247[["IVIS_windowsize_minutes"]],
-                                     qwindow = params_247[["qwindow"]], longitudinal_axis_id, cosinor_coef)
+  dataqual_summary = data.frame(clipping_score = LC2  / ((LD/1440)*96),
+                                meas_dur_dys =  LD/1440,
+                                dcomplscore = dcomplscore,
+                                meas_dur_def_proto_day = LMp / 1440,
+                                wear_dur_def_proto_day = LWp / 1440)
+  file_summary = data.frame(wdayname = wdayname,
+                            deviceSerialNumber = deviceSerialNumber,
+                            sensor.location = sensor.location,
+                            ID = ID,
+                            fname = fname,
+                            startt = startt)
+  metrics_nav = list(lookat = lookat,
+                    colnames_to_lookat = colnames_to_lookat,
+                    longitudinal_axis_id = longitudinal_axis_id)
+  output_perfile = g.analyse.perfile(I, C, metrics_nav,
+                                     AveAccAve24hr, 
+                                     doquan, doiglevels, tooshort, 
+                                     params_247 = params_247, 
+                                     params_cleaning = params_cleaning,
+                                     params_general = params_general,
+                                     output_avday = output_avday,
+                                     output_perday = output_perday,
+                                     dataqual_summary = dataqual_summary,
+                                     file_summary = file_summary)
+
   filesummary = output_perfile$filesummary
   daysummary = output_perfile$daysummary
   
@@ -298,5 +312,4 @@ g.analyse =  function(I, C, M, IMP, params_247 = c(), params_phyact = c(),
     cosinor_ts = c()
   }
   invisible(list(summary = filesummary, daysummary = daysummary, cosinor_ts = cosinor_ts))
- 
 }

--- a/R/g.analyse.R
+++ b/R/g.analyse.R
@@ -289,6 +289,51 @@ g.analyse =  function(I, C, M, IMP, params_247 = c(), params_phyact = c(),
                             ID = ID,
                             fname = fname,
                             startt = startt)
+  
+  if (!is.null(M$QClog)) {
+    # Summarise the QC log (currently only expected from cwa Axivity files)
+    QCsummarise = function(QClog, wx) {
+      x = ifelse(test = length(wx) > 0,
+                 yes = sum(QClog$end[wx] - QClog$start[wx]) / 60,
+                 no = 0)
+      return(x)
+    }
+    # total imputation
+    impdone = which(M$QClog$imputed == TRUE)
+    file_summary$Dur_imputed = QCsummarise(M$QClog, impdone)
+    file_summary$Nblocks_imputed = length(impdone)
+    
+    # checksum
+    chsum_failed = which(M$QClog$checksum_pass == FALSE)
+    file_summary$Dur_chsum_failed = QCsummarise(M$QClog, chsum_failed)
+    file_summary$Nblocks_chsum_failed = length(chsum_failed)
+    
+    # nonincremental block ID
+    nonincremental = which(M$QClog$blockID_current - M$QClog$blockID_next != 1)
+    file_summary$Dur_nonincremental = QCsummarise(M$QClog, nonincremental)
+    file_summary$Nblocks_nonincremental = length(nonincremental)
+    
+    # sampling frequency issues
+    freqBlockHead = M$QClog$frequency_blockheader
+    frequency_bias = abs(M$QClog$frequency_observed - freqBlockHead) / freqBlockHead
+
+    freqissue = which(frequency_bias >= 0.05 & frequency_bias < 0.1)
+    file_summary$Dur_freqissue_5_10 = QCsummarise(M$QClog, freqissue)
+    file_summary$Nblock_freqissue_5_10 = length(freqissue)
+    
+    freqissue = which(frequency_bias >= 0.1 & frequency_bias < 0.2)
+    file_summary$Dur_freqissue_10_20 = QCsummarise(M$QClog, freqissue)
+    file_summary$Nblock_freqissue_10_20 = length(freqissue)
+    
+    freqissue = which(frequency_bias >= 0.2 & frequency_bias < 0.3)
+    file_summary$Dur_freqissue_20_30 = QCsummarise(M$QClog, freqissue)
+    file_summary$Nblock_freqissue_20_30 = length(freqissue)
+    
+    freqissue = which(frequency_bias >= 0.3)
+    file_summary$Dur_freqissue_30 = QCsummarise(M$QClog, freqissue)
+    file_summary$Nblock_freqissue_30 = length(freqissue)
+  }
+
   metrics_nav = list(lookat = lookat,
                     colnames_to_lookat = colnames_to_lookat,
                     longitudinal_axis_id = longitudinal_axis_id)

--- a/R/g.analyse.perfile.R
+++ b/R/g.analyse.perfile.R
@@ -67,9 +67,10 @@ g.analyse.perfile = function(I, C, metrics_nav,
   # readAxivity QClog summary
   if ("Dur_imputed" %in% names(file_summary)) {
     # These are summaries of the file health check by the GGIRread::readAxivity
-    # the function handles these issue by imputing data, and logging the information.
-    # Normally we do not expect issues with cwa files, but by logging the information
-    # we will facilitate better insight.
+    # the function handles data blocks (1-3 seconds) with faulty data by imputing 
+    # them and logging the information.
+    # Normally we do not expect issue with cwa files, but by logging the information
+    # we will facilitate better insight into when this happens.
     filesummary[vi:(vi + 6)] = c(file_summary$Dur_imputed, # total imputed
                                  file_summary$Dur_chsum_failed, # checksum
                                  file_summary$Dur_nonincremental, # nonincremental id between blocks

--- a/R/g.analyse.perfile.R
+++ b/R/g.analyse.perfile.R
@@ -64,6 +64,44 @@ g.analyse.perfile = function(I, C, metrics_nav,
   s_names[vi:(vi + q0)] = c("calib_err",
                             "calib_status", colnames_to_lookat)
   vi = vi + q0 + 2
+  # readAxivity QClog summary
+  if ("Dur_imputed" %in% names(file_summary)) {
+    # These are summaries of the file health check by the GGIRread::readAxivity
+    # the function handles these issue by imputing data, and logging the information.
+    # Normally we do not expect issues with cwa files, but by logging the information
+    # we will facilitate better insight.
+    filesummary[vi:(vi + 6)] = c(file_summary$Dur_imputed, # total imputed
+                                 file_summary$Dur_chsum_failed, # checksum
+                                 file_summary$Dur_nonincremental, # nonincremental id between blocks
+                                 file_summary$Dur_freqissue_5_10, # bias 5-10%
+                                 file_summary$Dur_freqissue_10_20, # bias 10-20%
+                                 file_summary$Dur_freqissue_20_30, # bias 20-30%
+                                 file_summary$Dur_freqissue_30) # bias >30%
+    s_names[vi:(vi + 6)] = c("filehealth_totimp_min",
+                             "filehealth_checksumfail_min",
+                             "filehealth_niblockid_min", # non incremental block id
+                             "filehealth_fbias0510_min", # frequency bias
+                             "filehealth_fbias1020_min", 
+                             "filehealth_fbias2030_min",
+                             "filehealth_fbias30_min")
+    vi = vi + 7
+    filesummary[vi:(vi + 6)] = c( file_summary$Nblocks_imputed,
+                                  file_summary$Nblocks_chsum_failed,
+                                  file_summary$Nblocks_nonincremental,
+                                  file_summary$Nblock_freqissue_5_10,
+                                  file_summary$Nblock_freqissue_10_20,
+                                  file_summary$Nblock_freqissue_20_30,
+                                  file_summary$Nblock_freqissue_30)
+    s_names[vi:(vi + 6)] = c("filehealth_totimp_N",
+                             "filehealth_checksumfail_N",
+                             "filehealth_niblockid_N",
+                             "filehealth_fbias0510_N",
+                             "filehealth_fbias1020_N",
+                             "filehealth_fbias2030_N",
+                             "filehealth_fbias30_N")
+    vi = vi + 7
+  }
+  
   #quantile, ML5, and intensity gradient variables
   if (doquan == TRUE) {
     q1 = length(output_avday$QUAN)

--- a/R/g.analyse.perfile.R
+++ b/R/g.analyse.perfile.R
@@ -1,10 +1,16 @@
-g.analyse.perfile = function(ID, fname, deviceSerialNumber, sensor.location, startt, I, LC2, LD, dcomplscore,
-                             LMp, LWp, C, lookat, AveAccAve24hr, colnames_to_lookat, QUAN, ML5AD,
-                             ML5AD_names, igfullr, igfullr_names,
-                             daysummary, ds_names, includedaycrit, strategy, hrs.del.start,
-                             hrs.del.end, maxdur, windowsizes, idloc, snloc, wdayname, doquan,
-                             qlevels_names, doiglevels, tooshort, InterdailyStability, IntradailyVariability,
-                             IVIS_windowsize_minutes, qwindow, longitudinal_axis_id, cosinor_coef) {
+g.analyse.perfile = function(I, C, metrics_nav,
+                             AveAccAve24hr, doquan, doiglevels, tooshort, 
+                             params_247, params_cleaning, params_general,
+                             output_avday, output_perday,
+                             dataqual_summary, file_summary) {
+  
+  # extract objects from lists in input:
+  cosinor_coef = output_avday$cosinor_coef
+  daysummary = output_perday$daysummary
+  ds_names = output_perday$ds_names
+  lookat = metrics_nav$lookat
+  colnames_to_lookat = metrics_nav$colnames_to_lookat
+  
   filesummary = matrix(" ", 1, 150) #matrix to be stored with summary per participant
   s_names = rep(" ", ncol(filesummary))
   vi = 1
@@ -15,42 +21,36 @@ g.analyse.perfile = function(ID, fname, deviceSerialNumber, sensor.location, sta
     daysummary = daysummary[,-cut]
   }
   # Person identification number
-  filesummary[vi] = ID
+  filesummary[vi] = file_summary$ID
   # Identify which of the metrics are in g-units to aid deciding whether to multiply by 1000
   g_variables_lookat = lookat[grep(x = colnames_to_lookat, pattern = "BrondCount|ZCX|ZCY|NeishabouriCount", invert = TRUE)]
   
   # Serial number
-  if (snloc == 1) {
-    filesummary[(vi + 1)] = deviceSerialNumber
-  } else if (snloc == 2) {
-    filesummary[(vi + 1)] = unlist(strsplit(fname, "_"))[2]
-  }
+  filesummary[(vi + 1)] = file_summary$deviceSerialNumber
   s_names[vi:(vi + 1)] = c("ID","device_sn")
   vi = vi + 2
   # starttime of measurement, body location, filename
-  filesummary[vi] = sensor.location
-  filesummary[(vi + 1)] = fname
-  filesummary[(vi + 2)] = startt # starttime of measurement
+  filesummary[vi] = file_summary$sensor.location
+  filesummary[(vi + 1)] = file_summary$fname
+  filesummary[(vi + 2)] = file_summary$startt # starttime of measurement
   s_names[vi:(vi + 2)] = c("bodylocation","filename","start_time")
   vi = vi + 3
   # weekday on which measurement started, sample frequency and device
-  filesummary[vi] = wdayname
+  filesummary[vi] = file_summary$wdayname
   filesummary[(vi + 1)] = I$sf
   filesummary[(vi + 2)] = I$monn
   s_names[vi:(vi + 2)] = c("startday", "samplefreq", "device")
   vi = vi + 3
   # clipsing score and measurement duration in days
-  filesummary[vi] = LC2  / ((LD/1440)*96)
-  filesummary[(vi + 1)] = LD/1440 #measurement duration in days
-  s_names[vi:(vi + 1)] = c("clipping_score", "meas_dur_dys")
-  vi = vi + 2
+  filesummary[vi] = dataqual_summary$clipping_score
+  filesummary[vi + 1] = dataqual_summary$meas_dur_dys #measurement duration in days
   # completeness core and measurement duration with different definitions
-  filesummary[vi] = dcomplscore #completeness of the day
-  filesummary[(vi + 1)] = LMp / 1440 #measurement duration according to protocol
-  filesummary[(vi + 2)] = LWp / 1440 #wear duration in days (out of measurement protocol)
-  s_names[vi:(vi + 2)] = c("complete_24hcycle", # day (fraction of 24 hours for which data is available at all)
+  filesummary[vi + 2] = dataqual_summary$dcomplscore #completeness of the day
+  filesummary[vi + 3] = dataqual_summary$meas_dur_def_proto_day #measurement duration according to protocol
+  filesummary[vi + 4] = dataqual_summary$wear_dur_def_proto_day #wear duration in days (out of measurement protocol)
+  s_names[vi:(vi + 4)] = c("clipping_score", "meas_dur_dys", "complete_24hcycle", 
                            "meas_dur_def_proto_day", "wear_dur_def_proto_day")
-  vi = vi + 3
+  vi = vi + 5
   # calibration error after auto-calibration
   if (length(C$cal.error.end) == 0)   C$cal.error.end = c(" ")
   filesummary[vi] = C$cal.error.end
@@ -66,21 +66,21 @@ g.analyse.perfile = function(ID, fname, deviceSerialNumber, sensor.location, sta
   vi = vi + q0 + 2
   #quantile, ML5, and intensity gradient variables
   if (doquan == TRUE) {
-    q1 = length(QUAN)
-    filesummary[vi:((vi - 1) + q1)] = QUAN * ifelse(test = lookat[la] %in% g_variables_lookat, yes = 1000, no = 1)
-    s_names[vi:((vi - 1) + q1)] = paste0(qlevels_names, "_fullRecording")
+    q1 = length(output_avday$QUAN)
+    filesummary[vi:((vi - 1) + q1)] = output_avday$QUAN * ifelse(test = lookat[la] %in% g_variables_lookat, yes = 1000, no = 1)
+    s_names[vi:((vi - 1) + q1)] = paste0(output_avday$qlevels_names, "_fullRecording")
     vi = vi + q1
-    q1 = length(ML5AD)
-    filesummary[vi:((vi - 1) + q1)] = as.numeric(ML5AD)
-    s_names[vi:((vi - 1) + q1)] = paste0(ML5AD_names, "_fullRecording")
+    q1 = length(output_avday$ML5AD)
+    filesummary[vi:((vi - 1) + q1)] = as.numeric(output_avday$ML5AD)
+    s_names[vi:((vi - 1) + q1)] = paste0(output_avday$ML5AD_names, "_fullRecording")
     vi = vi + q1
   }
   if (doiglevels == TRUE) {
     # intensity gradient (as described by Alex Rowlands 2018)
     # applied to the averageday per metric (except from angle metrics)
-    q1 = length(igfullr)
-    filesummary[vi:((vi - 1) + q1)] = igfullr
-    s_names[vi:((vi - 1) + q1)] = paste0(igfullr_names, "_fullRecording")
+    q1 = length(output_avday$igfullr)
+    filesummary[vi:((vi - 1) + q1)] = output_avday$igfullr
+    s_names[vi:((vi - 1) + q1)] = paste0(output_avday$output_avday$igfullr_names, "_fullRecording")
     vi = vi + q1
   }
   if (tooshort == 0) {
@@ -93,11 +93,11 @@ g.analyse.perfile = function(ID, fname, deviceSerialNumber, sensor.location, sta
     columnWithAlwaysData = which(ds_names == "N hours" | ds_names == "N_hours")
     NVHcolumn = which(ds_names == "N valid hours" | ds_names == "N_valid_hours" ) #only count in the days for which the inclusion criteria is met
     v1 = which(is.na(as.numeric(daysummary[wkend, columnWithAlwaysData])) == F &
-                 as.numeric(daysummary[wkend, NVHcolumn]) >= includedaycrit)
+                 as.numeric(daysummary[wkend, NVHcolumn]) >= params_cleaning[["includedaycrit"]])
     wkend = wkend[v1]
     wkday  = which(daysummary[,which(ds_names == "weekday")] != "Saturday" & daysummary[,which(ds_names == "weekday")] != "Sunday")
     v2 = which(is.na(as.numeric(daysummary[wkday, columnWithAlwaysData])) == F  &
-                 as.numeric(daysummary[wkday, NVHcolumn]) >= includedaycrit)
+                 as.numeric(daysummary[wkday, NVHcolumn]) >= params_cleaning[["includedaycrit"]])
     wkday = wkday[v2]
     # Add number of weekend and weekdays to filesummary
     filesummary[vi:(vi + 1)] = c(length(wkend),  length(wkday)) # number of weekend days & weekdays
@@ -106,8 +106,8 @@ g.analyse.perfile = function(ID, fname, deviceSerialNumber, sensor.location, sta
     s_names[vi:(vi + 1)] = c("N valid WEdays","N valid WKdays")
     vi = vi + 2
     # Add ISIV to filesummary
-    filesummary[vi:(vi + 2)] = c(InterdailyStability, IntradailyVariability,
-                                 IVIS_windowsize_minutes)
+    filesummary[vi:(vi + 2)] = c(output_avday$InterdailyStability, output_avday$IntradailyVariability,
+                                 params_247[["IVIS_windowsize_minutes"]])
     iNA = which(is.na(filesummary[vi:(vi + 3)]) == TRUE)
     if (length(iNA) > 0) filesummary[(vi:(vi + 3))[iNA]] = " "
     s_names[vi:(vi + 2)] = c("IS_interdailystability", "IV_intradailyvariability", "IVIS_windowsize_minutes")
@@ -157,7 +157,7 @@ g.analyse.perfile = function(ID, fname, deviceSerialNumber, sensor.location, sta
       for (dtwi in daytoweekvar) {
         #check whether columns is empty:
         uncona = unique(daysummary[,dtwi])
-        storevalue = !(length(uncona) == 1 & length(qwindow) > 2 & uncona[1] == "")
+        storevalue = !(length(uncona) == 1 & length(params_247[["qwindow"]]) > 2 & uncona[1] == "")
         if (is.na(storevalue) == TRUE) storevalue = FALSE
         # Only do next 15-isch lines of code if:
         # - there is more than 1 day of data
@@ -218,12 +218,12 @@ g.analyse.perfile = function(ID, fname, deviceSerialNumber, sensor.location, sta
       }
       vi = vi + 6 + ((dtwtel * sp) - 1)
     }
-    filesummary[vi] = strategy
-    filesummary[(vi + 1)] = hrs.del.start
-    filesummary[(vi + 2)] = hrs.del.end
-    filesummary[(vi + 3)] = maxdur
-    filesummary[(vi + 4)] = windowsizes[1]
-    filesummary[(vi + 5)] = longitudinal_axis_id
+    filesummary[vi] = params_cleaning[["strategy"]]
+    filesummary[(vi + 1)] = params_cleaning[["hrs.del.start"]]
+    filesummary[(vi + 2)] = params_cleaning[["hrs.del.end"]]
+    filesummary[(vi + 3)] = params_cleaning[["maxdur"]]
+    filesummary[(vi + 4)] = params_general[["windowsizes"]][1]
+    filesummary[(vi + 5)] = metrics_nav$longitudinal_axis_id
     #get GGIR version
     GGIRversion = "GGIR not used"
     if (is.element('GGIR', installed.packages()[,1])) {
@@ -241,7 +241,6 @@ g.analyse.perfile = function(ID, fname, deviceSerialNumber, sensor.location, sta
                                           "if_hip_long_axis_id", "GGIR version"))
     vi = vi + 6
   }
-  rm(LD); rm(ID)
   # tidy up daysummary object
   mw = which(is.na(daysummary) == T)
   mw = c(mw, grep(pattern = "NaN", x = daysummary))

--- a/R/g.detecmidnight.R
+++ b/R/g.detecmidnight.R
@@ -1,4 +1,4 @@
-g.detecmidnight = function(time,desiredtz,dayborder) {
+g.detecmidnight = function(time, desiredtz, dayborder) {
   # code in this function is able to deal with two types of timestamp format
   convert2clock = function(x) { #ISO format
     return(format(as.POSIXlt(x, format = "%Y-%m-%dT%H:%M:%S%z", tz = desiredtz), "%H:%M:%S"))

--- a/R/g.getmeta.R
+++ b/R/g.getmeta.R
@@ -201,6 +201,7 @@ g.getmeta = function(datafile, params_metrics = c(), params_rawdata = c(),
   } else if (mon == 2 | (mon == 4 & dformat == 4)  | mon == 5 | (mon == 0 & length(params_rawdata[["rmc.col.temp"]]) > 0)) {
     temp.available = TRUE
   }
+  QClog = NULL
   if (temp.available == FALSE) {
     metalong = matrix(" ", ((nev/(sf*ws2)) + 100), 4) #generating output matrix for 15 minutes summaries
   } else if (temp.available == TRUE & mon != 5) {
@@ -301,6 +302,7 @@ g.getmeta = function(datafile, params_metrics = c(), params_rawdata = c(),
           data = P$data
           P$data = P$data[1:min(100,nrow(P$data)),] # trim object, because rest of data is not needed anymore
         }
+        QClog = rbind(QClog, P$QClog)
       } else if (dformat == 5) { # ad-hoc csv
         data = P$data
       } else if (mon == 5) { #movisense
@@ -773,5 +775,5 @@ g.getmeta = function(datafile, params_metrics = c(), params_rawdata = c(),
   if (length(metashort) == 0 | filedoesnotholdday == TRUE) filetooshort = TRUE
   invisible(list(filecorrupt = filecorrupt, filetooshort = filetooshort, NFilePagesSkipped = NFilePagesSkipped,
                  metalong = metalong, metashort = metashort, wday = wday, wdayname = wdayname,
-                 windowsizes = params_general[["windowsizes"]], bsc_qc = bsc_qc))
+                 windowsizes = params_general[["windowsizes"]], bsc_qc = bsc_qc, QClog = QClog))
 }

--- a/R/g.part2.R
+++ b/R/g.part2.R
@@ -166,12 +166,9 @@ g.part2 = function(datadir = c(), metadatadir = c(), f0 = c(), f1 = c(),
         SUM = g.analyse(I, C, M, IMP,
                         params_247 = params_247,
                         params_phyact = params_phyact,
-                        dayborder = params_general[["dayborder"]],
-                        desiredtz = params_general[["desiredtz"]],
-                        idloc = params_general[["idloc"]],
-                        includedaycrit = params_cleaning[["includedaycrit"]],
-                        myfun = myfun,
-                        acc.metric = params_general[["acc.metric"]])
+                        params_general = params_general,
+                        params_cleaning = params_cleaning,
+                        myfun = myfun)
         RDname = as.character(unlist(strsplit(fnames[i], "eta_"))[2])
         # reset M and IMP so that they include the expanded time (needed for sleep detection in parts 3 and 4)
         if (length(tail_expansion_log) != 0) {

--- a/R/g.readaccfile.R
+++ b/R/g.readaccfile.R
@@ -172,8 +172,8 @@ g.readaccfile = function(filename, blocksize, blocknumber, filequality,
     try(expr = {P = GGIRread::readAxivity(filename = filename, start = startpage, # try to read block first time
                                           end = endpage, progressBar = FALSE, desiredtz = params_general[["desiredtz"]],
                                           configtz = params_general[["configtz"]],
-                                          interpolationType = params_rawdata[["interpolationType"]],
-                                          frequency_tol = params_rawdata[["frequency_tol"]])}, silent = TRUE)
+                                          interpolationType = params_rawdata[["interpolationType"]])}, silent = TRUE)
+    # frequency_tol = params_rawdata[["frequency_tol"]]
     if (length(P) > 1) { # data reading succesful
       if (length(P$data) == 0) { # too short?
         P = c() ; switchoffLD = 1
@@ -194,9 +194,8 @@ g.readaccfile = function(filename, blocksize, blocknumber, filequality,
                                                         end = endpage, progressBar = FALSE,
                                                         desiredtz = params_general[["desiredtz"]],
                                                         configtz = params_general[["configtz"]],
-                                                        interpolationType = params_rawdata[["interpolationType"]],
-                                                        frequency_tol = params_rawdata[["frequency_tol"]])}, silent = TRUE)
-      # 
+                                                        interpolationType = params_rawdata[["interpolationType"]])}, silent = TRUE)
+      # frequency_tol = params_rawdata[["frequency_tol"]]
       if (length(PtestLastPage$data) > 1) { # Last page exist, so there must be something wrong with the first page
         NFilePagesSkipped = 0
         while (length(PtestStartPage) == 0) { # Try loading the first page of the block by iteratively skipping a page
@@ -206,8 +205,8 @@ g.readaccfile = function(filename, blocksize, blocknumber, filequality,
                                                              end = startpage, progressBar = FALSE,
                                                              desiredtz = params_general[["desiredtz"]],
                                                              configtz = params_general[["configtz"]],
-                                                             interpolationType = params_rawdata[["interpolationType"]],
-                                                             frequency_tol = params_rawdata[["frequency_tol"]])}, silent = TRUE)
+                                                             interpolationType = params_rawdata[["interpolationType"]])}, silent = TRUE)
+          # frequency_tol = params_rawdata[["frequency_tol"]]
           if (NFilePagesSkipped == 10 & length(PtestStartPage) == 0) PtestStartPage = FALSE # stop after 10 attempts
         }
         warning(paste0("\n", NFilePagesSkipped," page(s) skipped in cwa file in ",
@@ -220,8 +219,8 @@ g.readaccfile = function(filename, blocksize, blocknumber, filequality,
                                               end = endpage, progressBar = FALSE,
                                               desiredtz = params_general[["desiredtz"]],
                                               configtz = params_general[["configtz"]],
-                                              interpolationType = params_rawdata[["interpolationType"]],
-                                              frequency_tol = params_rawdata[["frequency_tol"]])}, silent = TRUE)
+                                              interpolationType = params_rawdata[["interpolationType"]])}, silent = TRUE)
+        # frequency_tol = params_rawdata[["frequency_tol"]]
         if (length(P) > 1) { # data reading succesful
           if (length(P$data) == 0) { # if this still does not work then
             P = c() ; switchoffLD = 1

--- a/R/g.readaccfile.R
+++ b/R/g.readaccfile.R
@@ -192,7 +192,8 @@ g.readaccfile = function(filename, blocksize, blocknumber, filequality,
                                                         end = endpage, progressBar = FALSE, desiredtz = params_general[["desiredtz"]],
                                                         configtz = params_general[["configtz"]],
                                                         interpolationType = params_rawdata[["interpolationType"]])}, silent = TRUE)
-      if (length(PtestLastPage) > 1) { # Last page exist, so there must be something wrong with the first page
+      # 
+      if (length(PtestLastPage$data) > 1) { # Last page exist, so there must be something wrong with the first page
         NFilePagesSkipped = 0
         while (length(PtestStartPage) == 0) { # Try loading the first page of the block by iteratively skipping a page
           NFilePagesSkipped = NFilePagesSkipped + 1
@@ -206,7 +207,7 @@ g.readaccfile = function(filename, blocksize, blocknumber, filequality,
         }
         cat(paste0("\nWarning (4): ",NFilePagesSkipped," page(s) skipped in cwa file in order to read data-block, this may indicate data corruption."))
       }
-      if (length(PtestStartPage) > 1) {
+      if (length(PtestStartPage$data) > 1) {
         # Now we know on which page we can start and end the block, we can try again to
         # read the entire block:
         try(expr = {P = GGIRread::readAxivity(filename = filename, start = startpage,

--- a/R/g.readaccfile.R
+++ b/R/g.readaccfile.R
@@ -171,7 +171,9 @@ g.readaccfile = function(filename, blocksize, blocknumber, filequality,
     startpage = UPI$startpage;    endpage = UPI$endpage
     try(expr = {P = GGIRread::readAxivity(filename = filename, start = startpage, # try to read block first time
                                           end = endpage, progressBar = FALSE, desiredtz = params_general[["desiredtz"]],
-                                          configtz = params_general[["configtz"]], interpolationType = params_rawdata[["interpolationType"]])}, silent = TRUE)
+                                          configtz = params_general[["configtz"]],
+                                          interpolationType = params_rawdata[["interpolationType"]],
+                                          frequency_tol = params_rawdata[["frequency_tol"]])}, silent = TRUE)
     if (length(P) > 1) { # data reading succesful
       if (length(P$data) == 0) { # too short?
         P = c() ; switchoffLD = 1
@@ -189,9 +191,11 @@ g.readaccfile = function(filename, blocksize, blocknumber, filequality,
       PtestLastPage = PtestStartPage = c()
       # try to read the last page of the block, because if it exists then there might be something wrong with the first page(s).
       try(expr = {PtestLastPage = GGIRread::readAxivity(filename = filename, start = endpage, #note this is intentionally endpage
-                                                        end = endpage, progressBar = FALSE, desiredtz = params_general[["desiredtz"]],
+                                                        end = endpage, progressBar = FALSE,
+                                                        desiredtz = params_general[["desiredtz"]],
                                                         configtz = params_general[["configtz"]],
-                                                        interpolationType = params_rawdata[["interpolationType"]])}, silent = TRUE)
+                                                        interpolationType = params_rawdata[["interpolationType"]],
+                                                        frequency_tol = params_rawdata[["frequency_tol"]])}, silent = TRUE)
       # 
       if (length(PtestLastPage$data) > 1) { # Last page exist, so there must be something wrong with the first page
         NFilePagesSkipped = 0
@@ -202,10 +206,12 @@ g.readaccfile = function(filename, blocksize, blocknumber, filequality,
                                                              end = startpage, progressBar = FALSE,
                                                              desiredtz = params_general[["desiredtz"]],
                                                              configtz = params_general[["configtz"]],
-                                                             interpolationType = params_rawdata[["interpolationType"]])}, silent = TRUE)
+                                                             interpolationType = params_rawdata[["interpolationType"]],
+                                                             frequency_tol = params_rawdata[["frequency_tol"]])}, silent = TRUE)
           if (NFilePagesSkipped == 10 & length(PtestStartPage) == 0) PtestStartPage = FALSE # stop after 10 attempts
         }
-        cat(paste0("\nWarning (4): ",NFilePagesSkipped," page(s) skipped in cwa file in order to read data-block, this may indicate data corruption."))
+        warning(paste0("\n", NFilePagesSkipped," page(s) skipped in cwa file in ",
+                       "order to read data-block, this may indicate data corruption."), call. = FALSE)
       }
       if (length(PtestStartPage$data) > 1) {
         # Now we know on which page we can start and end the block, we can try again to
@@ -214,7 +220,8 @@ g.readaccfile = function(filename, blocksize, blocknumber, filequality,
                                               end = endpage, progressBar = FALSE,
                                               desiredtz = params_general[["desiredtz"]],
                                               configtz = params_general[["configtz"]],
-                                              interpolationType = params_rawdata[["interpolationType"]])}, silent = TRUE)
+                                              interpolationType = params_rawdata[["interpolationType"]],
+                                              frequency_tol = params_rawdata[["frequency_tol"]])}, silent = TRUE)
         if (length(P) > 1) { # data reading succesful
           if (length(P$data) == 0) { # if this still does not work then
             P = c() ; switchoffLD = 1

--- a/R/g.report.part2.R
+++ b/R/g.report.part2.R
@@ -156,7 +156,8 @@ g.report.part2 = function(metadatadir = c(), f0 = c(), f1 = c(), maxdur = 0,
       }
       if (length(M$NFilePagesSkipped) == 0) M$NFilePagesSkipped = 0 # to make the code work for historical part1 output.
       
-      QC = data.frame(filename = fnames[i],
+      fname2store = unlist(strsplit(fnames[i], "eta_|[.]RDat"))[2]
+      QC = data.frame(filename = fname2store,
                       file.corrupt = M$filecorrupt,
                       file.too.short = M$filetooshort,
                       use.temperature = C$use.temp,
@@ -171,21 +172,12 @@ g.report.part2 = function(metadatadir = c(), f0 = c(), f1 = c(), maxdur = 0,
                       device.serial.number = deviceSerialNumber,
                       NFilePagesSkipped = M$NFilePagesSkipped, stringsAsFactors = FALSE)
       
-      
-      QC = data.frame(filename = fnames[i],
-                      file.corrupt = M$filecorrupt,
-                      file.too.short = M$filetooshort,
-                      use.temperature = C$use.temp,
-                      scale.x = C$scale[1], scale.y = C$scale[2], scale.z = C$scale[3],
-                      offset.x = C$offset[1], offset.y = C$offset[2], offset.z = C$offset[3],
-                      temperature.offset.x = C$tempoffset[1],  temperature.offset.y = C$tempoffset[2],
-                      temperature.offset.z = C$tempoffset[3],
-                      cal.error.start = C$cal.error.start,
-                      cal.error.end = C$cal.error.end,
-                      n.10sec.windows = C$npoints,
-                      n.hours.considered = C$nhoursused, QCmessage = C$QCmessage, mean.temp = tmean,
-                      device.serial.number = deviceSerialNumber,
-                      stringsAsFactors = FALSE, NFilePagesSkipped = M$NFilePagesSkipped)
+      filehealth_cols = grep(pattern = "filehealth", x = names(SUMMARY), value = FALSE)
+      if (length(filehealth_cols) > 0) {
+        # migrate filehealth columns to QC report
+        QC = merge(x = QC, y = SUMMARY[, c(which(names(SUMMARY) == "filename"), filehealth_cols)], by = "filename")
+        SUMMARY = SUMMARY[, -filehealth_cols]
+      }
       if (i == 1 | i == f0) {
         QCout = QC
       } else {

--- a/R/load_params.R
+++ b/R/load_params.R
@@ -64,7 +64,7 @@ load_params = function(group = c("sleep", "metrics", "rawdata",
       rmc.check4timegaps = FALSE,  rmc.noise = 13,
       rmc.col.wear = c(), rmc.doresample = FALSE,
       interpolationType = 1,
-      imputeTimegaps = TRUE)
+      imputeTimegaps = TRUE, frequency_tol = 0.1)
   }
   if ("247" %in% group) {
     params_247 = list(qwindow = c(0,24), qlevels = c(),

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -33,7 +33,7 @@ bibentry(bibtype = "Article",
         number    =  7,
         pages     = "738--744",
         year      =  2014,
-        url       = "https://journals.physiology.org/doi/full/10.1152/japplphysiol.00421.2014")
+        url       = "https://doi.org/10.1152/japplphysiol.00421.2014")
         
         
 bibentry(bibtype = "Article",

--- a/man/GGIR-package.Rd
+++ b/man/GGIR-package.Rd
@@ -21,8 +21,8 @@
   \tabular{ll}{
   Package: \tab GGIR\cr
   Type: \tab Package\cr
-  Version: \tab 2.9-7\cr
-  Date: \tab 2023-08-31\cr
+  Version: \tab 2.10-0\cr
+  Date: \tab 2023-08-09\cr
   License: \tab Apache License (== 2.0)\cr
   Discussion group: \tab https://groups.google.com/forum/#!forum/rpackageggir\cr
   }

--- a/man/GGIR.Rd
+++ b/man/GGIR.Rd
@@ -485,6 +485,13 @@ GGIR(mode = 1:5,
         using \link{read.myacc.csv}. The \link{read.myacc.csv} does not take rmc.noise as argument,
         but when interacting with \link{GGIR} or \link{g.part1} rmc.noise is used.}
 
+      \item{frequency_tol}{
+        Number (default = 0.1) as passed on to readAxivity from the GGIRread package.
+        Represents the frequency tolerance as frequation between 0 and 1. When the bias
+        per data block is larger than this number then the data block will be imputed
+        by lack of movement with oriation guess from most recent valid data block.
+        Only relevant for Axivity .cwa data.
+      }
     }
   }
 

--- a/man/GGIR.Rd
+++ b/man/GGIR.Rd
@@ -487,10 +487,10 @@ GGIR(mode = 1:5,
 
       \item{frequency_tol}{
         Number (default = 0.1) as passed on to readAxivity from the GGIRread package.
-        Represents the frequency tolerance as frequation between 0 and 1. When the bias
-        per data block is larger than this number then the data block will be imputed
-        by lack of movement with oriation guess from most recent valid data block.
-        Only relevant for Axivity .cwa data.
+        Represents the frequency tolerance as fraction between 0 and 1. When the relative bias
+        per data block is larger than this fraction then the data block will be imputed
+        by lack of movement with gravitational oriationed guessed from most recent
+        valid data block. Only applicable to Axivity .cwa data.
       }
     }
   }

--- a/man/g.analyse.Rd
+++ b/man/g.analyse.Rd
@@ -16,9 +16,8 @@
 }
 \usage{
   g.analyse(I, C, M, IMP, params_247 = c(), params_phyact = c(),
-            quantiletype = 7, includedaycrit = 16, 
-            idloc = 1, snloc = 1, 
-            dayborder=0,  desiredtz = "", myfun=c(), acc.metric = c(), ...)
+                      params_general = c(), params_cleaning = c(),
+                      quantiletype = 7, myfun = c(), ...)
 }
 \arguments{
   \item{I}{
@@ -34,37 +33,23 @@
     the output from function \link{g.impute}
   }
   \item{params_247}{
-    See \link{g.part2}
+    See \link{GGIR}
   }
   \item{params_phyact}{
-    See \link{g.part2}
+    See \link{GGIR}
+  }
+  \item{params_general}{
+    See \link{GGIR}
+  }
+  \item{params_cleaning}{
+    See \link{GGIR}
   }
   \item{quantiletype}{
     type of quantile function to use (default recommended). For details, see 
     quantile function in STATS package
   }
-  \item{includedaycrit}{
-   See \link{g.part1}
-  }
-  \item{idloc}{
-   See \link{g.part1}
-  }
-  \item{snloc}{
-    If value = 1 (default) the code assumes that device serial number is stored in
-    the obvious header field. If value = 2 the code uses the character string between
-    the first and second character '_' in the filename as the serial number
-  }
-  \item{dayborder}{
-    See \link{g.part1}
-  }
-  \item{desiredtz}{
-    See \link{g.part1}
-  }
   \item{myfun}{
     External function object to be applied to raw data, see \link{g.getmeta}.
-  }
-  \item{acc.metric}{
-     Character, see \link{g.part1}.
   }
   \item{...}{
      Any argument used in the previous version of g.analyse, which will now

--- a/man/g.analyse.perfile.Rd
+++ b/man/g.analyse.perfile.Rd
@@ -8,66 +8,28 @@
   output matrix, \link{g.analyse}.
 }
 \usage{
-g.analyse.perfile(ID, fname, deviceSerialNumber,
-  sensor.location, startt, I, LC2, LD, dcomplscore,
-  LMp, LWp, C, lookat, AveAccAve24hr, 
-  colnames_to_lookat, QUAN,  ML5AD,
-  ML5AD_names, igfullr, igfullr_names,
-  daysummary, ds_names, includedaycrit, strategy, hrs.del.start,
-  hrs.del.end, maxdur, windowsizes, idloc, snloc, wdayname, doquan,
-  qlevels_names, doiglevels, tooshort, InterdailyStability, 
-  IntradailyVariability,
-  IVIS_windowsize_minutes, qwindow, longitudinal_axis_id, cosinor_coef)
+g.analyse.perfile(I, C, metrics_nav,
+                 AveAccAve24hr, doquan, doiglevels, tooshort,
+                 params_247, params_cleaning, params_general,
+                 output_avday, output_perday,
+                 dataqual_summary, file_summary)
 }
 
 \arguments{
-\item{ID}{Person Identification number, this can be numeric or character}
-\item{fname}{see \link{g.analyse.perday}}
-\item{deviceSerialNumber}{As produced by \link{g.extractheadervars}}
-\item{sensor.location}{as produced by \link{g.extractheadervars}}
-\item{startt}{First timestamp in metalong}
-\item{I}{output \link{g.inspectfile}}
-\item{LC2}{see \link{g.impute}}
-\item{LD}{length data in minutes}
-\item{dcomplscore}{see \link{g.impute}}
-\item{LMp}{length measurement based on study protocol (minutes)}
-\item{LWp}{length of sensor worn based on study protocol (minutes)}
-\item{C}{output \link{g.calibrate}}
-\item{lookat}{indices of metashort column to analyse}
-\item{AveAccAve24hr}{Average acceleration in an average 24 hour cycle}
-\item{colnames_to_lookat}{Names of columns to look at, corresponding 
-to argurment lookat}
-\item{QUAN}{Results quantile analysis on the average day produced by \link{g.analyse.avday}}
-\item{ML5AD}{Results ML5 analyses on the average day produced by \link{g.analyse.avday}}
-\item{ML5AD_names}{Columns names corresponding to ML5AD}
-\item{igfullr}{Results intensity gradient (ig) analysis on
-the average day produced by \link{g.analyse.avday}}
-\item{igfullr_names}{Columns names corresponding to igfullr}
-\item{daysummary}{object produced by \link{g.analyse.perday}}
-\item{ds_names}{column names corresponding to daysummary}
-\item{includedaycrit}{see \link{g.analyse}}
-\item{strategy}{see \link{g.analyse}}
-\item{hrs.del.start}{see \link{g.analyse}}
-\item{hrs.del.end}{see \link{g.analyse}}
-\item{maxdur}{see \link{g.analyse}}
-\item{windowsizes}{see \link{g.getmeta}}
-\item{idloc}{see \link{g.analyse}}
-\item{snloc}{see \link{g.analyse}}
-\item{wdayname}{character with weekdayname}
-\item{doquan}{Boolean whether quantile analysis should be done}
-\item{qlevels_names}{object produced by \link{g.analyse.avday}}
-\item{doiglevels}{Boolean to indicate whether iglevels should be calculated}
-\item{tooshort}{0 (file not too short) or 1 (file too short)}
-\item{InterdailyStability}{see \link{g.IVIS}}
-\item{IntradailyVariability}{see \link{g.IVIS}}
-\item{IVIS_windowsize_minutes}{see \link{g.IVIS}}
-\item{qwindow}{see \link{g.analyse}}
-\item{longitudinal_axis_id}{Index of axis for which the angle correlates most 
-  strongly across 24 hoursas calculated inside g.analyse. For hip worn 
-  accelerometer this helps to check which axis was the veritcal axis. 
-  The estimate may not be informative for other attachment locations.}
-\item{cosinor_coef}{output from cosinorAnlayses passed on to be included in
-  file summary}
+  \item{I}{output \link{g.inspectfile}}
+  \item{C}{output \link{g.calibrate}}
+  \item{metrics_nav}{List with three objects to help navigate the acceleration metrics}
+  \item{AveAccAve24hr}{Average acceleration in an average 24 hour cycle}
+  \item{doquan}{Boolean whether quantile analysis should be done}
+  \item{doiglevels}{Boolean to indicate whether iglevels should be calculated}
+  \item{tooshort}{0 (file not too short) or 1 (file too short)}
+  \item{params_247}{see \link{GGIR}}
+  \item{params_cleaning}{see \link{GGIR}}
+  \item{params_general}{see \link{GGIR}}
+  \item{output_avday}{Output from g.analyse.avday}
+  \item{output_perday}{Output from g.analyse.perday}
+  \item{dataqual_summary}{Data.frame with data quality summary indicators
+  produced in \link{g.analyse}}
 }
 \value{
   \item{\code{filesummary}}{summary for the file that was analysed}

--- a/tests/testthat/test_greadaccfile.R
+++ b/tests/testthat/test_greadaccfile.R
@@ -8,7 +8,8 @@ test_that("g.readaccfile and g.inspectfile can read gt3x and cwa files correctly
   gt3xfile  = system.file("testfiles/actigraph_testfile.gt3x", package = "GGIR")[1]
   
   desiredtz = "Europe/London"
-  
+  params_rawdata = list(frequency_tol = 0.1, interpolationType = 1,
+                        desiredtz = "Europe/London", configtz = "Europe/London")
   cat("\nActigraph .gt3x")
   # actigraph .gt3x
   Igt3x = g.inspectfile(gt3xfile, desiredtz = desiredtz)
@@ -22,7 +23,7 @@ test_that("g.readaccfile and g.inspectfile can read gt3x and cwa files correctly
   expect_false(Mgt3x$filecorrupt)
   cat("\nAxivity .cwa")
   # axivity .cwa
-  Icwa = g.inspectfile(cwafile, desiredtz = desiredtz)
+  Icwa = g.inspectfile(cwafile, desiredtz = desiredtz, params_rawdata = params_rawdata)
   expect_equal(Icwa$monc, 4)
   expect_equal(Icwa$dformc, 4)
   expect_equal(Icwa$sf, 100)
@@ -52,9 +53,11 @@ test_that("g.readaccfile and g.inspectfile can read gt3x and cwa files correctly
   expect_equal(decn,".")
   filequality = list(filecorrupt = FALSE, filetooshort = FALSE)
   dayborder = 0
+  
   cwa_read = g.readaccfile(cwafile, blocksize = 10, blocknumber = 1, filequality = filequality,
                            decn = ".", dayborder,ws = 3, desiredtz = desiredtz, 
-                           PreviousEndPage = 1, inspectfileobject = Icwa)
+                           PreviousEndPage = 1, inspectfileobject = Icwa,
+                           params_rawdata = params_rawdata)
   GA_read = g.readaccfile(GAfile, blocksize = 2, blocknumber = 1, filequality = filequality,
                                          decn = ".", dayborder = dayborder, ws = 3,
                                          desiredtz = desiredtz, PreviousEndPage = 1, inspectfileobject = IGA)

--- a/tests/testthat/test_load_check_params.R
+++ b/tests/testthat/test_load_check_params.R
@@ -12,7 +12,7 @@ test_that("load_params can load parameters", {
   expect_equal(length(params), 8)
   expect_equal(length(params$params_sleep), 20)
   expect_equal(length(params$params_metrics), 41)
-  expect_equal(length(params$params_rawdata), 36)
+  expect_equal(length(params$params_rawdata), 37)
   expect_equal(length(params$params_247), 20)
   expect_equal(length(params$params_cleaning), 21)
   expect_equal(length(params$params_phyact), 13)

--- a/vignettes/CutPoints.Rmd
+++ b/vignettes/CutPoints.Rmd
@@ -340,10 +340,10 @@ why cut-points still have value in GGIR see:
 # References
 
 -   Esliger 2011: <https://journals.lww.com/acsm-msse/Fulltext/2011/06000/Validation_of_the_GENEA_Accelerometer.22.aspx>
--   Phillips 2013: <https://www.jsams.org/article/S1440-2440(12)00112-0/fulltext>
+-   Phillips 2013: <https://doi.org/10.1016/j.jsams.2012.05.013>
 -   Schaefer 2014: <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3960318/>
 -   Hildebrand 2014: <https://journals.lww.com/acsm-msse/Fulltext/2014/09000/Age_Group_Comparability_of_Raw_Accelerometer.17.aspx>
--   Hildebrand 2016: <https://onlinelibrary.wiley.com/doi/10.1111/sms.12795>
+-   Hildebrand 2016: <https://doi.org/10.1111/sms.12795>
 -   Vähä-Ypyä 2015: <https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0134813>
 -   Aittasalo 2015: <https://bmcsportsscimedrehabil.biomedcentral.com/articles/10.1186/s13102-015-0010-0>
 -   Roscoe 2017: <https://link.springer.com/article/10.1007/s00431-017-2948-2>

--- a/vignettes/GGIR.Rmd
+++ b/vignettes/GGIR.Rmd
@@ -1078,7 +1078,7 @@ Reference:
     using local gravity and temperature: an evaluation on four
     continents. J Appl Physiol (1985). 2014 Oct 1;117(7):738-44. PMID:
     25103964
-    [link](https://journals.physiology.org/doi/full/10.1152/japplphysiol.00421.2014)
+    [link](https://doi.org/10.1152/japplphysiol.00421.2014)
 
 Key decisions to be made:
 
@@ -1673,7 +1673,7 @@ fragmentation metrics are applied in function `g.fragmentation`.
 
 -   Coefficient of Variance (`CoV`) is calculated according to [Blikman
     et al.
-    2014](https://www.archives-pmr.org/article/S0003-9993(14)01063-6/fulltext).
+    2014](https://doi.org/10.1016/j.apmr.2014.08.023).
 -   Transition probability (`TP`) from Inactivity (IN) to Physical
     activity (IN2PA) and from Physical activity to inactivity (PA2IN)
     are calculated as 1 divided by the mean fragment duration. The
@@ -2026,7 +2026,7 @@ If you used the **auto-calibration functionality** then also cite:
 4.  van Hees VT, Fang Z, et al. Auto-calibration of accelerometer data
     for free-living physical activity assessment using local gravity and
     temperature: an evaluation on four continents. J Appl Physiol 2014.
-    [link](https://journals.physiology.org/doi/full/10.1152/japplphysiol.00421.2014)
+    [link](https://doi.org/10.1152/japplphysiol.00421.2014)
 
 If you used the **sleep detection** then also cite:
 

--- a/vignettes/TutorialDaySegmentAnalyses.Rmd
+++ b/vignettes/TutorialDaySegmentAnalyses.Rmd
@@ -104,7 +104,7 @@ Both approaches are implemented in GGIR part 2 and part 5. Therefore the specifi
 output variables that are calculated both in part 2 and 5 are available per day,
 per person, and per segment of the day based on the argument `qwindow` Note that 
 `qwindow` is only used in **part 5** when `timewindow` includes `"MM"` (see specific
-documentation for `timewindow`} in the [parameters vignette](https://cran.r-project.org/web/packages/GGIR/vignettes/GGIRParameters.html))
+documentation for `timewindow`} in the [parameters vignette](https://CRAN.R-project.org/package=GGIR/vignettes/GGIRParameters.html))
 
 At the moment, specifying the argument `qwindow` triggers the calculation of the
 `qwindow` segments both in part 2 and part 5, which may result in a longer time
@@ -215,7 +215,7 @@ You will find these as variables such as `MVPA_E5S_T201_ENMO` or `MVPA_E5S_B1M80
 
 **Time spent in sleeping, in inactivity and physical activity intensities (part 5):**
 You will find these variables in the part 5 reports, in their bouted, unbouted, and
-total time version of the variables. See [description](https://cran.r-project.org/web/packages/GGIR/vignettes/GGIR.html#41_Output_part_5:~:text=as%3A%20sleeponset%20%2D%20guider_inbedStart-,4.3%20Output%20part%205,-The%20output%20of) of GGIR part 5 output in the main GGIR vignette for further details.
+total time version of the variables. See [description](https://cran.r-project.org/package=GGIR/vignettes/GGIR.html#41_Output_part_5) of GGIR part 5 output in the main GGIR vignette for further details.
 
 
 ```{r, echo=FALSE, out.width = "60%", out.extra='style="border: 0; padding:20px"'}


### PR DESCRIPTION
<!-- Describe your PR here -->

Fixes #866

- Code now takes `QClog` object with file health information from the `GGIRread::readAxivity` output per data chunk and reports a summary in the data_quality_report.
- I have added argument `frequency_tol` which is passed on to `GGIRread::readAxivity` to control the tolerance for sampling frequency.
- While adding this I noticed that function `g.analyse.perfile()` needed to be tidied up first in order to improve readability. I reduced the number of input arguments for it and removed some unnecessary object creation.

Additionally:
- Fixing URLs based on R package check
- Preparing for 2.10-0 release

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [ ] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Updated or expanded the documentation.
- [ ] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
