### PR TITLE
Issue891 skip last day

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 - Part 2: Addresses confusing error message for some users #888
 
+- Part 5: Fix minor bug by which GGIR skipped the last day if measurement finishes before midnight and timewindow = MM #891
+
 # CHANGES IN GGIR VERSION 2.10-1
 
 - Part 1 + 2: File health log captured by dependency GGIRread::readAxivity 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# CHANGES IN GGIR VERSION 2.10-3
+
+- Part 5: Fix minor bug by which GGIR skipped the last day if measurement finishes before midnight and timewindow = MM #891
+
 # CHANGES IN GGIR VERSION 2.10-2
 
 - Part 1: Revision to readability of code (credits: Lena Kushleyeva)
@@ -7,8 +11,6 @@
 - Part 1 + 2: Bug fixed in logging file health of Axivity data
 
 - Part 2: Addresses confusing error message for some users #888
-
-- Part 5: Fix minor bug by which GGIR skipped the last day if measurement finishes before midnight and timewindow = MM #891
 
 # CHANGES IN GGIR VERSION 2.10-1
 

--- a/R/g.part5.definedays.R
+++ b/R/g.part5.definedays.R
@@ -74,7 +74,15 @@ g.part5.definedays = function(nightsi, wi, indjump, nightsi_bu,
         }
       }
     } else {
-      qqq = c(NA, NA)
+      if (length(qqq_backup) > 1) {
+        # if there is remaining time after previous day...
+        if (Nts > qqq_backup[2]) {
+          qqq = c(qqq_backup[2] + 1, Nts)
+        }
+      } else {
+        # else, do not analyse this day
+        qqq = c(NA, NA)
+      }
     }
     # in MM, also define segments of the day based on qwindow
     if (!is.na(qqq[1]) & !is.na(qqq[2])) {

--- a/tests/testthat/test_chainof5parts.R
+++ b/tests/testthat/test_chainof5parts.R
@@ -161,7 +161,7 @@ test_that("chainof5parts", {
   
   expect_true(dir.exists(dirname))
   expect_true(file.exists(rn[1]))
-  expect_that(nrow(output),equals(3)) # changed because part5 now gives also first and last day
+  expect_that(nrow(output),equals(4)) # 2023-09-04: changed because part5 now gives also first and last day
   expect_that(ncol(output),equals(160)) # changed because intensity gradient now included in the test
   expect_that(round(as.numeric(output$wakeup[2]), digits = 4), equals(36))
   dirname_raw = "output_test/meta/ms5.outraw/40_100_400"


### PR DESCRIPTION
<!-- Describe your PR here -->
Fixes #891 => Fixed minor bug by which GGIR skipped the last day if measurement finishes right before midnight and timewindow = MM #891

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [x] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [x] Updated or expanded the documentation.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
