### PR TITLE
fix minor bug in ismovisens

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# CHANGES IN GGIR VERSION 2.10-3
+
+- Part 1: Fixed minor bug in ismovisens that failed when datadir started with "./" #897
+
 # CHANGES IN GGIR VERSION 2.10-2
 
 - Part 1: Revision to readability of code (credits: Lena Kushleyeva)

--- a/R/ismovisens.R
+++ b/R/ismovisens.R
@@ -3,8 +3,10 @@ ismovisens = function(data){
         # Is data a directory? Then use the first file to test if recorded with movisens
         directory = dir(data, recursive = T, full.names = T)[1]
         isdir = !is.na(directory)
-        if(isdir == TRUE) data = directory
+        if (isdir == TRUE) data = directory
         # ---------------------------
+        # remove problematic dot at the beginning
+        data = gsub("^./", "", data)
         # Now, I focus on the participant directory
         p_dir = strsplit(data, ".", fixed = T)
         data_tmp = strsplit(p_dir[[1]], "/")


### PR DESCRIPTION
<!-- Describe your PR here -->
Fixes #897 => Fixes minor bug in `ismovisens`. It failed when datadir started with "./", now these two characters are removed if provided, which does not affect the directory definition.

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Updated or expanded the documentation.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
