### PR TITLE
data_quality_report when rerunning parts 1 and 2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# CHANGES IN GGIR VERSION 2.10-3
+
+- Part 1: Fixed minor bug to keep calibration data in the data quality report after re-running parts 1 and 2 with overwrite = TRUE and backup.cal.coef = "retrieve" #896
+
 # CHANGES IN GGIR VERSION 2.10-2
 
 - Part 1: Revision to readability of code (credits: Lena Kushleyeva)

--- a/R/g.part1.R
+++ b/R/g.part1.R
@@ -215,9 +215,19 @@ g.part1 = function(datadir = c(), metadatadir = c(), f0 = 1, f1 = c(), myfun = c
         bcc.scalei = which(colnames(bcc.data) == "scale.x" | colnames(bcc.data) == "scale.y" | colnames(bcc.data) == "scale.z")
         bcc.offseti = which(colnames(bcc.data) == "offset.x" | colnames(bcc.data) == "offset.y" | colnames(bcc.data) == "offset.z")
         bcc.temp.offseti = which(colnames(bcc.data) == "temperature.offset.x" | colnames(bcc.data) == "temperature.offset.y" | colnames(bcc.data) == "temperature.offset.z")
+        bcc.QCmessagei = which(colnames(bcc.data) == "QCmessage")
+        bcc.npointsi = which(colnames(bcc.data) == "n.10sec.windows")
+        bcc.nhoursusedi = which(colnames(bcc.data) == "n.hours.considered")
+        bcc.use.tempi = which(colnames(bcc.data) == "use.temperature")
         C$scale = as.numeric(bcc.data[bcc.i[1],bcc.scalei])
         C$offset = as.numeric(bcc.data[bcc.i[1],bcc.offseti])
         C$tempoffset =  as.numeric(bcc.data[bcc.i[1],bcc.temp.offseti])
+        C$cal.error.start = as.numeric(bcc.data[bcc.i[1],bcc.cal.error.start])
+        C$cal.error.end = as.numeric(bcc.data[bcc.i[1],bcc.cal.error.end])
+        C$QCmessage = bcc.data[bcc.i[1],bcc.QCmessagei]
+        C$npoints = bcc.data[bcc.i[1], bcc.npointsi]
+        C$nhoursused = bcc.data[bcc.i[1], bcc.nhoursusedi]
+        C$use.temp = bcc.data[bcc.i[1], bcc.nhoursusedi]
         if (verbose == TRUE) {
           cat(paste0("\nRetrieved Calibration error (g) before: ",as.numeric(bcc.data[bcc.i[1],bcc.cal.error.start])))
           cat(paste0("\nRetrieved Callibration error (g) after: ",as.numeric(bcc.data[bcc.i[1],bcc.cal.error.end])))


### PR DESCRIPTION
<!-- Describe your PR here -->
Fixes #896 => After rerunning parts 1 and 2 with `overwrite = TRUE` and `backup.cal.coef = "retrieve"`, the QC message and the calibration errors were not stored appropriately. This has been fixed now.

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Updated or expanded the documentation.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
