### PR TITLE
adding names of objects to export #909

### DIFF
--- a/R/g.part1.R
+++ b/R/g.part1.R
@@ -360,7 +360,8 @@ g.part1 = function(datadir = c(), metadatadir = c(), f0 = 1, f1 = c(), myfun = c
       if (Ncores2use > 1) {
         cl <- parallel::makeCluster(Ncores2use) # not to overload your computer
         parallel::clusterExport(cl = cl, 
-                                unclass(lsf.str(envir = asNamespace("GGIR"), all = T)),
+                                varlist = c(unclass(lsf.str(envir = asNamespace("GGIR"), all = T)),
+                                            "MONITOR", "FORMAT"),
                                 envir = as.environment(asNamespace("GGIR"))
         )
         doParallel::registerDoParallel(cl)


### PR DESCRIPTION
<!-- Describe your PR here -->

@l-k- this is an minor edit to your PR #908 

I am managed to reproduce the error locally when using the combination of do.parallel = TRUE and sourcing each of the the function files in the R folder directly via source() rather than loading the entire package via library(GGIR).

I am not sure whether this relates to the issue that was encountered on the cluster, but if I add the object names explicitly to the call as in this PR then all goes well locally.

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [ ] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Updated or expanded the documentation.
- [ ] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
