### PR TITLE
correctly check if params_[...] aren't specified

### DIFF
--- a/R/g.analyse.R
+++ b/R/g.analyse.R
@@ -4,12 +4,11 @@ g.analyse =  function(I, C, M, IMP, params_247 = c(), params_phyact = c(),
   
   #get input variables
   input = list(...)
-  expectedArgs = c("I", "C", "M", "IMP", "params_247", "params_phyact", 
-                   "params_general", "params_cleaning", "quantiletype",
-                    "myfun")
-  if ((length(input) > 0) ||
-      any(!unlist(lapply(expectedArgs, FUN = exists, where=environment())))) {
-    # Extract and check parameters if user provides more arguments than just the parameter arguments
+  if (length(input) > 0 ||
+      length(params_247) == 0 || length(params_phyact) == 0 ||
+      length(params_general) == 0 || length(params_cleaning) == 0) {
+    # Extract and check parameters if user provides more arguments than just the parameter arguments,
+    # or if params_[...] aren't specified (so need to be filled with defaults).
     # So, inside GGIR this will not be used, but it is used when g.analyse is used on its own
     # as if it was still the old g.analyse function
     params = extract_params(params_247 = params_247,

--- a/R/g.analyse.R
+++ b/R/g.analyse.R
@@ -7,8 +7,8 @@ g.analyse =  function(I, C, M, IMP, params_247 = c(), params_phyact = c(),
   expectedArgs = c("I", "C", "M", "IMP", "params_247", "params_phyact", 
                    "params_general", "params_cleaning", "quantiletype",
                     "myfun")
-  if (any(names(input) %in% expectedArgs == FALSE) |
-      any(!unlist(lapply(expectedArgs, FUN = exists)))) {
+  if ((length(input) > 0) ||
+      any(!unlist(lapply(expectedArgs, FUN = exists, where=environment())))) {
     # Extract and check parameters if user provides more arguments than just the parameter arguments
     # So, inside GGIR this will not be used, but it is used when g.analyse is used on its own
     # as if it was still the old g.analyse function

--- a/R/g.analyse.avday.R
+++ b/R/g.analyse.avday.R
@@ -3,12 +3,9 @@ g.analyse.avday = function(doquan, averageday, M, IMP, t_TWDI, quantiletype,
                            qcheck = c(), acc.metric = c(), ...) {
   #get input variables
   input = list(...)
-  expectedArgs = c("doquan", "averageday", "M", "IMP",
-                   "t_TWDI, quantiletype", "ws3", "ws2", 
-                   "doiglevels", "firstmidnighti", "midnightsi", "params_247", "qcheck", "acc.metric") 
-  if ((length(input) > 0) ||
-      any(!unlist(lapply(expectedArgs, FUN = exists, where=environment())))) {
-    # Extract and check parameters if user provides more arguments than just the parameter arguments
+  if (length(input) > 0 || length(params_247) == 0) {
+    # Extract and check parameters if user provides more arguments than just the parameter arguments,
+    # or if params_[...] aren't specified (so need to be filled with defaults).
     # So, inside GGIR this will not be used, but it is used when g.analyse is used on its own
     # as if it was still the old g.analyse function
     params = extract_params(params_247 = params_247,

--- a/R/g.analyse.avday.R
+++ b/R/g.analyse.avday.R
@@ -5,9 +5,9 @@ g.analyse.avday = function(doquan, averageday, M, IMP, t_TWDI, quantiletype,
   input = list(...)
   expectedArgs = c("doquan", "averageday", "M", "IMP",
                    "t_TWDI, quantiletype", "ws3", "ws2", 
-                   "doiglevels", "firstmidnighti", "midnightsi", "params_247", "qcheck") 
-  if (any(names(input) %in% expectedArgs == FALSE) |
-      any(!unlist(lapply(expectedArgs, FUN = exists)))) {
+                   "doiglevels", "firstmidnighti", "midnightsi", "params_247", "qcheck", "acc.metric") 
+  if ((length(input) > 0) ||
+      any(!unlist(lapply(expectedArgs, FUN = exists, where=environment())))) {
     # Extract and check parameters if user provides more arguments than just the parameter arguments
     # So, inside GGIR this will not be used, but it is used when g.analyse is used on its own
     # as if it was still the old g.analyse function

--- a/R/g.analyse.perday.R
+++ b/R/g.analyse.perday.R
@@ -18,8 +18,8 @@ g.analyse.perday = function(ndays, firstmidnighti, time, nfeatures,
                    "doquan", "quantiletype", "doilevels", "domvpa",
                    "mvpanames", "wdaycode", "ID",
                    "deviceSerialNumber", "ExtFunColsi", "myfun", "desiredtz") 
-  if (any(names(input) %in% expectedArgs == FALSE) |
-      any(!unlist(lapply(expectedArgs, FUN = exists)))) {
+  if ((length(input) > 0) ||
+      any(!unlist(lapply(expectedArgs, FUN = exists, where=environment())))) {
     # Extract and check parameters if user provides more arguments than just the parameter arguments
     # So, inside GGIR this will not be used, but it is used when g.analyse is used on its own
     # as if it was still the old g.analyse function

--- a/R/g.analyse.perday.R
+++ b/R/g.analyse.perday.R
@@ -10,17 +10,10 @@ g.analyse.perday = function(ndays, firstmidnighti, time, nfeatures,
   #get input variables
   input = list(...)
   
-  expectedArgs = c("params_247", "params_phyact", 
-                   "ndays", "firstmidnighti", "time", "nfeatures", 
-                   "midnightsi", "metashort", "averageday",
-                   "doiglevels", "nfulldays","lastmidnight", "ws3", "ws2", "qcheck",
-                   "fname", "idloc", "sensor.location", "wdayname", "tooshort", "includedaycrit",
-                   "doquan", "quantiletype", "doilevels", "domvpa",
-                   "mvpanames", "wdaycode", "ID",
-                   "deviceSerialNumber", "ExtFunColsi", "myfun", "desiredtz") 
-  if ((length(input) > 0) ||
-      any(!unlist(lapply(expectedArgs, FUN = exists, where=environment())))) {
-    # Extract and check parameters if user provides more arguments than just the parameter arguments
+  if (length(input) > 0 ||
+      length(params_247) == 0 || length(params_phyact) == 0) {
+    # Extract and check parameters if user provides more arguments than just the parameter arguments,
+    # or if params_[...] aren't specified (so need to be filled with defaults).
     # So, inside GGIR this will not be used, but it is used when g.analyse is used on its own
     # as if it was still the old g.analyse function
     params = extract_params(params_247 = params_247,

--- a/R/g.calibrate.R
+++ b/R/g.calibrate.R
@@ -7,10 +7,10 @@ g.calibrate = function(datafile, params_rawdata = c(),
 
   #get input variables
   input = list(...)
-  expectedArgs = c("datafile", "params_rawdata", "params_general", "params_cleaning", "inspectfileobject", "verbose")
-  if ((length(input) > 0) ||
-      any(!unlist(lapply(expectedArgs, FUN = exists, where=environment())))) {
-    # Extract and check parameters if user provides more arguments than just the parameter arguments
+  if (length(input) > 0 ||
+      length(params_rawdata) == 0 || length(params_general) == 0 || length(params_cleaning) == 0) {
+    # Extract and check parameters if user provides more arguments than just the parameter arguments,
+    # or if params_[...] aren't specified (so need to be filled with defaults).
     # So, inside GGIR this will not be used, but it is used when g.calibrate is used on its own
     # as if it was still the old g.calibrate function
     params = extract_params(params_rawdata = params_rawdata,

--- a/R/g.calibrate.R
+++ b/R/g.calibrate.R
@@ -7,9 +7,9 @@ g.calibrate = function(datafile, params_rawdata = c(),
 
   #get input variables
   input = list(...)
-  expectedArgs = c("datadir", "params_rawdata", "params_general", "params_cleaning")
-  if (any(names(input) %in% expectedArgs == FALSE) |
-      any(!unlist(lapply(expectedArgs, FUN = exists)))) {
+  expectedArgs = c("datafile", "params_rawdata", "params_general", "params_cleaning", "inspectfileobject", "verbose")
+  if ((length(input) > 0) ||
+      any(!unlist(lapply(expectedArgs, FUN = exists, where=environment())))) {
     # Extract and check parameters if user provides more arguments than just the parameter arguments
     # So, inside GGIR this will not be used, but it is used when g.calibrate is used on its own
     # as if it was still the old g.calibrate function

--- a/R/g.getmeta.R
+++ b/R/g.getmeta.R
@@ -7,24 +7,23 @@ g.getmeta = function(datafile, params_metrics = c(), params_rawdata = c(),
   
   #get input variables
   input = list(...)
-  expectedArgs = c("datafile", "params_metrics",
-                   "params_rawdata", "params_general", "params_cleaning",
-                   "daylimit", "offset",
-                   "scale", "tempoffset", "meantempcal",
-                   "myfun", "inspectfileobject", "verbose")
-  if ((length(input) > 0) ||
-      any(!unlist(lapply(expectedArgs, FUN = exists, where=environment())))) {
-    # Extract and check parameters if user provides more arguments than just the parameter arguments
+  if (length(input) > 0 ||
+      length(params_metrics) == 0 || length(params_rawdata) == 0 ||
+      length(params_general) == 0 || length(params_cleaning) == 0) {
+    # Extract and check parameters if user provides more arguments than just the parameter arguments,
+    # or if params_[...] aren't specified (so need to be filled with defaults).
     # So, inside GGIR this will not be used, but it is used when g.getmeta is used on its own
     # as if it was still the old g.getmeta function
     params = extract_params(params_metrics = params_metrics,
                             params_rawdata = params_rawdata,
                             params_general = params_general,
+                            params_cleaning = params_cleaning,
                             input = input,
-                            params2check = c("metrics", "rawdata", "general")) # load default parameters
+                            params2check = c("metrics", "rawdata", "general", "cleaning")) # load default parameters
     params_metrics = params$params_metrics
     params_rawdata = params$params_rawdata
     params_general = params$params_general
+    params_cleaning = params$params_cleaning
   }
   #get input variables
   if (length(input) > 0) {

--- a/R/g.getmeta.R
+++ b/R/g.getmeta.R
@@ -8,12 +8,12 @@ g.getmeta = function(datafile, params_metrics = c(), params_rawdata = c(),
   #get input variables
   input = list(...)
   expectedArgs = c("datafile", "params_metrics",
-                   "params_rawdata", "params_general",
+                   "params_rawdata", "params_general", "params_cleaning",
                    "daylimit", "offset",
                    "scale", "tempoffset", "meantempcal",
-                   "myfun")
-  if (any(names(input) %in% expectedArgs == FALSE) |
-      any(!unlist(lapply(expectedArgs, FUN = exists)))) {
+                   "myfun", "inspectfileobject", "verbose")
+  if ((length(input) > 0) ||
+      any(!unlist(lapply(expectedArgs, FUN = exists, where=environment())))) {
     # Extract and check parameters if user provides more arguments than just the parameter arguments
     # So, inside GGIR this will not be used, but it is used when g.getmeta is used on its own
     # as if it was still the old g.getmeta function

--- a/R/g.impute.R
+++ b/R/g.impute.R
@@ -3,11 +3,9 @@ g.impute = function(M, I, params_cleaning = c(), desiredtz = "",
   
   #get input variables
   input = list(...)
-  expectedArgs = c("M", "I", "params_cleaning", "desiredtz",
-                   "dayborder", "TimeSegments2Zero", "acc.metric")
-  if ((length(input) > 0) ||
-      any(!unlist(lapply(expectedArgs, FUN = exists, where=environment())))) {
-    # Extract and check parameters if user provides more arguments than just the parameter arguments
+  if (length(input) > 0 || length(params_cleaning) == 0) {
+    # Extract and check parameters if user provides more arguments than just the parameter arguments,
+    # or if params_[...] aren't specified (so need to be filled with defaults).
     # So, inside GGIR this will not be used, but it is used when g.impute is used on its own
     # as if it was still the old g.impute function
     params = extract_params(params_cleaning = params_cleaning,

--- a/R/g.impute.R
+++ b/R/g.impute.R
@@ -4,9 +4,9 @@ g.impute = function(M, I, params_cleaning = c(), desiredtz = "",
   #get input variables
   input = list(...)
   expectedArgs = c("M", "I", "params_cleaning", "desiredtz",
-                   "dayborder", "TimeSegments2Zero")
-  if (any(names(input) %in% expectedArgs == FALSE) |
-      any(!unlist(lapply(expectedArgs, FUN = exists)))) {
+                   "dayborder", "TimeSegments2Zero", "acc.metric")
+  if ((length(input) > 0) ||
+      any(!unlist(lapply(expectedArgs, FUN = exists, where=environment())))) {
     # Extract and check parameters if user provides more arguments than just the parameter arguments
     # So, inside GGIR this will not be used, but it is used when g.impute is used on its own
     # as if it was still the old g.impute function

--- a/R/g.inspectfile.R
+++ b/R/g.inspectfile.R
@@ -2,8 +2,8 @@ g.inspectfile = function(datafile, desiredtz = "", params_rawdata = c(),
                          configtz = c(), ...) {
   #get input variables
   input = list(...)
-  if (any(names(input) %in% c("datafile", "desiredtz", "params_rawdata", "configtz")) == FALSE) {
-    # Extract and check parameters if user provides more arguments than just the parameter arguments
+  if (length(input) > 0 || length(params_rawdata) == 0) {
+    # or if params_[...] aren't specified (so need to be filled with defaults).
     # So, inside GGIR this will not be used, but it is used when g.inspectfile is used on its own
     # as if it was still the old g.inspectfile function
     params = extract_params(params_rawdata = params_rawdata,
@@ -14,7 +14,6 @@ g.inspectfile = function(datafile, desiredtz = "", params_rawdata = c(),
   }
   
   #get input variables (relevant when read.myacc.csv is used
-  input = list(...)
   if (length(input) > 0) {
     for (i in 1:length(names(input))) {
       txt = paste0(names(input)[i], "=", input[i])

--- a/R/g.readaccfile.R
+++ b/R/g.readaccfile.R
@@ -4,8 +4,10 @@ g.readaccfile = function(filename, blocksize, blocknumber, filequality,
                          params_rawdata = c(), params_general = c(), ...) {
   #get input variables
   input = list(...)
-  if (length(input) > 0) {
-    # Extract and check parameters if user provides more arguments than just the parameter arguments
+  if (length(input) > 0 ||
+      length(params_rawdata) == 0 || length(params_general) == 0) {
+    # Extract and check parameters if user provides more arguments than just the parameter arguments,
+    # or if params_[...] aren't specified (so need to be filled with defaults).
     # So, inside GGIR this will not be used, but it is used when g.getmeta is used on its own
     # as if it was still the old g.getmeta function
     params = extract_params(params_rawdata = params_rawdata,

--- a/R/g.readaccfile.R
+++ b/R/g.readaccfile.R
@@ -4,11 +4,7 @@ g.readaccfile = function(filename, blocksize, blocknumber, filequality,
                          params_rawdata = c(), params_general = c(), ...) {
   #get input variables
   input = list(...)
-  if (any(names(input) %in% c("filename", "blocksize", "blocknumber",
-                              "filequality",
-                              "decn", "ws", "PreviousEndPage",
-                              "inspectfileobject", "params_rawdata",
-                              "params_general")) == FALSE) {
+  if (length(input) > 0) {
     # Extract and check parameters if user provides more arguments than just the parameter arguments
     # So, inside GGIR this will not be used, but it is used when g.getmeta is used on its own
     # as if it was still the old g.getmeta function

--- a/R/g.sib.det.R
+++ b/R/g.sib.det.R
@@ -4,12 +4,9 @@ g.sib.det = function(M, IMP, I, twd = c(-12, 12),
   
   #get input variables
   input = list(...)
-  expectedArgs = c("params_sleep", "M", "IMP",
-                   "I", "twd", "acc.metric", "desiredtz",
-                   "myfun", "sensor.location", "zc.scale")
-  if ((length(input) > 0) ||
-      any(!unlist(lapply(expectedArgs, FUN = exists, where=environment())))) {
-    # Extract and check parameters if user provides more arguments than just the parameter arguments
+  if (length(input) > 0 || length(params_sleep) == 0) {
+    # Extract and check parameters if user provides more arguments than just the parameter arguments,
+    # or if params_[...] aren't specified (so need to be filled with defaults).
     # So, inside GGIR this will not be used, but it is used when g.sleep is used on its own
     # as if it was still the old g.sleep function
     params = extract_params(params_sleep = params_sleep,

--- a/R/g.sib.det.R
+++ b/R/g.sib.det.R
@@ -6,9 +6,9 @@ g.sib.det = function(M, IMP, I, twd = c(-12, 12),
   input = list(...)
   expectedArgs = c("params_sleep", "M", "IMP",
                    "I", "twd", "acc.metric", "desiredtz",
-                   "myfun", "sensor.location")
-  if (any(names(input) %in% expectedArgs == FALSE) |
-      any(!unlist(lapply(expectedArgs, FUN = exists)))) {
+                   "myfun", "sensor.location", "zc.scale")
+  if ((length(input) > 0) ||
+      any(!unlist(lapply(expectedArgs, FUN = exists, where=environment())))) {
     # Extract and check parameters if user provides more arguments than just the parameter arguments
     # So, inside GGIR this will not be used, but it is used when g.sleep is used on its own
     # as if it was still the old g.sleep function

--- a/R/identify_level.R
+++ b/R/identify_level.R
@@ -2,8 +2,8 @@ identify_levels = function(ts, TRLi, TRMi, TRVi, ws3, params_phyact = c(), ...) 
   #get input variables
   input = list(...)
   expectedArgs = c("ts", "TRLi", "TRMi", "TRVi", "ws3", "params_phyact")
-  if (any(names(input) %in% expectedArgs == FALSE) |
-      any(!unlist(lapply(expectedArgs, FUN = exists)))) {
+  if ((length(input) > 0) ||
+      any(!unlist(lapply(expectedArgs, FUN = exists, where=environment())))) {
     # Extract and check parameters if user provides more arguments than just the parameter arguments
     # So, inside GGIR this will not be used, but it is used when identify_level is used on its own
     # as if it was still the old identify_level function

--- a/R/identify_level.R
+++ b/R/identify_level.R
@@ -1,10 +1,9 @@
 identify_levels = function(ts, TRLi, TRMi, TRVi, ws3, params_phyact = c(), ...) {
   #get input variables
   input = list(...)
-  expectedArgs = c("ts", "TRLi", "TRMi", "TRVi", "ws3", "params_phyact")
-  if ((length(input) > 0) ||
-      any(!unlist(lapply(expectedArgs, FUN = exists, where=environment())))) {
-    # Extract and check parameters if user provides more arguments than just the parameter arguments
+  if (length(input) > 0 || length(params_phyact) == 0) {
+    # Extract and check parameters if user provides more arguments than just the parameter arguments,
+    # or if params_[...] aren't specified (so need to be filled with defaults).
     # So, inside GGIR this will not be used, but it is used when identify_level is used on its own
     # as if it was still the old identify_level function
     params = extract_params(params_phyact = params_phyact,


### PR DESCRIPTION
<!-- Describe your PR here -->
Several functions in part 1 use the following condition to check whether all the expected parameters were supplied, and if not, to call extract_params() :
`if (... || any(!unlist(lapply(expectedArgs, FUN = exists))))`

Unfortunately this doesn't work as expected. R uses lexical scoping, not dynamic scoping. So when it creates a new environment to call the function exists(), by default this environment is a child of the base environment. The base env doesn't have any of the variables in expectedArgs defined, so lapply(expectedArgs, FUN = exists) will always return a list of FALSEs, unless we explicitly specify the environment we want for function exists().

Because of this,  extract_params() was called all the time, unnecessarily.

This doesn't cause any errors, just unnecessary extra calls to extract_params(). To reproduce this issue, you need to set a breakpoint in any of the affected functions and step through it to see that extract_params() gets called when it shouldn't have been.

Contributes to https://github.com/wadpac/GGIR/issues/883

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [X] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Updated or expanded the documentation.
- [ ] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
