### PR TITLE
Issue #918 don't confuse Actigraph csv files for axivity csv

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 - Part 1: Fixed issue #914 relating to specifying timezone for processing ad-hoc csv format raw data.
 
+- Part 1: Improved recognition of ActiGraph csv that occassionally confused for Axivity csv #918
+
 # CHANGES IN GGIR VERSION 2.10-3
 
 - Part 1: Fixed minor bug in ismovisens that failed when datadir started with "./" #897

--- a/R/g.inspectfile.R
+++ b/R/g.inspectfile.R
@@ -52,18 +52,21 @@ g.inspectfile = function(datafile, desiredtz = "", params_rawdata = c(),
                  }
       },
       "csv" = { dformat = FORMAT$CSV
-
-                testcsv = read.csv(datafile, nrow = 10, skip = 10)
-                testcsvtopline = read.csv(datafile, nrow = 2,skip = 1)
-
-                if (ncol(testcsv) == 2 && ncol(testcsvtopline) < 4) {
-                  mon = MONITOR$GENEACTIV
-                } else if (ncol(testcsv) >= 3 && ncol(testcsvtopline) < 4) {
+                testheader = read.csv(datafile, nrow = 1, skip = 0, header = FALSE)
+                
+                if (grepl("ActiGraph", testheader[1], fixed=TRUE)) {
                   mon = MONITOR$ACTIGRAPH
-                } else if (ncol(testcsv) >= 4 && ncol(testcsvtopline) >= 4) {
-                  mon = MONITOR$AXIVITY
                 } else {
-                  stop(paste0("\nError processing ", filename, ": unrecognised csv file format.\n"))
+                  testcsv = read.csv(datafile, nrow = 10, skip = 10)
+                  testcsvtopline = read.csv(datafile, nrow = 2,skip = 1)
+
+                  if (ncol(testcsv) == 2 && ncol(testcsvtopline) < 4) {
+                    mon = MONITOR$GENEACTIV
+                  } else if (ncol(testcsv) >= 4 && ncol(testcsvtopline) >= 4) {
+                    mon = MONITOR$AXIVITY
+                  } else {
+                    stop(paste0("\nError processing ", filename, ": unrecognised csv file format.\n"))
+                  }
                 }
       },
       "wav" = { stop(paste0("\nError processing ", filename, ": GENEA .wav file format is no longer supported.\n")) },

--- a/tests/testthat/test_greadaccfile.R
+++ b/tests/testthat/test_greadaccfile.R
@@ -1,8 +1,17 @@
 library(GGIR)
 context("g.readaccfile")
-test_that("g.readaccfile and g.inspectfile can read gt3x and cwa files correctly", {
+test_that("g.readaccfile and g.inspectfile can read gt3x, cwa, and actigraph csv files correctly", {
   skip_on_cran()
   
+  cat("\nActigraph .csv")
+  for (filename in c("ActiGraph13.csv", "ActiGraph61.csv")) {
+    csvfile = system.file(paste0("testfiles/", filename), package = "GGIR")[1]
+
+    Icsv = g.inspectfile(csvfile, desiredtz = "Europe/London")
+    expect_equal(Icsv$monc, MONITOR$ACTIGRAPH)
+    expect_equal(Icsv$dformc, FORMAT$CSV)
+  }
+
   cwafile  = system.file("testfiles/ax3_testfile.cwa", package = "GGIRread")[1]
   GAfile  = system.file("testfiles/GENEActiv_testfile.bin", package = "GGIRread")[1]
   gt3xfile  = system.file("testfiles/actigraph_testfile.gt3x", package = "GGIR")[1]


### PR DESCRIPTION
<!-- Describe your PR here -->
Addresses https://github.com/wadpac/GGIR/issues/918

(At least some) Actigraph csv files were getting mistakenly identified as Axivity csv, and then their processing was erroring out because the file format wasn't as expected for an Axivity csv.

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [X] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [X] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Updated or expanded the documentation.
- [ ] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
