### PR TITLE
Issue927 g.sib.det

### DIFF
--- a/R/create_test_acc_csv.R
+++ b/R/create_test_acc_csv.R
@@ -1,5 +1,5 @@
 create_test_acc_csv = function(sf = 3, Nmin = 2000, storagelocation = c(),
-                               starts_at_midnight = FALSE) {
+                               start_time = NULL, starts_at_midnight = FALSE) {
   # function to create a test Actigraph csv file needed for testing GGIR
   # adds variation in angle to enable autocalibration
   # adds some activity periods
@@ -25,7 +25,9 @@ create_test_acc_csv = function(sf = 3, Nmin = 2000, storagelocation = c(),
   
   generate_repeated_timestamp_blocks = function(first_onset, block_duration, period_length, sf, max_timestamp) {
     # Generate a series of timestamp blocks: the first one at first_onset, then one more each period. 
-    
+    if (max_timestamp <= first_onset) {
+      return(c())
+    }
     block_onsets = seq(first_onset + 1, max_timestamp, by = period_length) # one block onset for each period
     block_timestamps = rep(block_onsets, each = block_duration)
     block_timestamps = block_timestamps + rep(0:(block_duration - 1), times = length(block_onsets))
@@ -47,11 +49,17 @@ create_test_acc_csv = function(sf = 3, Nmin = 2000, storagelocation = c(),
   #==================================
   
   if (length(storagelocation) == 0) storagelocation = getwd()
-  if (Nmin < 1000) Nmin = 1000 # only make this file for tests with at least 1k minutes of data
-  if (starts_at_midnight) {
-    start_time = "00:00:00"
+  if (Nmin < 720) Nmin = 720 # only make this file for tests with at least 12 hours of data
+  if (length(start_time) == 0 || start_time == "") {
+    if (starts_at_midnight) {
+      start_time = "00:00:00"
+    } else {
+      start_time = "08:55:30"
+    }
   } else {
-    start_time = "08:55:30"
+    if (is.na(as.POSIXct(start_time, format = "%H:%M:%S"))) {
+      stop(paste0("start_time \"", start_time, "\" not in the right format, should be \"%H:%M:%S\", ex. \"08:55:30\""))
+    }
   }
   header = c(paste0("------------ Data File Created By ActiGraph GT3X+ ActiLife v6.13.3 Firmware v1.8.0 date format M/d/yyyy at ",sf," Hz  Filter Normal -----------"),
              "Serial Number: MOS2D12345678",

--- a/R/g.sib.det.R
+++ b/R/g.sib.det.R
@@ -203,7 +203,9 @@ g.sib.det = function(M, IMP, I, twd = c(-12, 12),
           midn_start = 1
         }
       } else {
-        midn_start = 0
+        # since there's no 4am in the recording, then even if there is a midnight, skip this midnight. 
+        # (basically treat this midnight like any other midnight without a preceding 4am)
+        midn_start = countmidn
       }
       sptei = 0
       for (j in midn_start:(countmidn)) { #Looping over the midnight

--- a/man/create_test_acc_csv.Rd
+++ b/man/create_test_acc_csv.Rd
@@ -11,23 +11,26 @@ in a range of accelerometer positions to allow for testing the
 auto-calibration functionality.}
 \usage{
   create_test_acc_csv(sf=3,Nmin=2000,storagelocation=c(),
-                      starts_at_midnight = FALSE)
+                      start_time = NULL, starts_at_midnight = FALSE)
 }
 \arguments{
   \item{sf}{
     Sample frequency in Hertz, the default here is low to minimize file size
   }
   \item{Nmin}{
-    Number of minutes (minimum is 2000)
+    Number of minutes (minimum is 720)
   }
   \item{storagelocation}{
     Location where the test file named testfile.csv will be stored
     If no value is provided then the function uses the current 
     working directory
   }
+  \item{start_time}{
+    Start time of the recording, in the hh:mm:ss format.
+  }
   \item{starts_at_midnight}{
     Boolean indicating whether the recording should start at 
-    midnight.
+    midnight. Ignored if start_time is specified.
   }
 }
 \value{

--- a/tests/testthat/test_part3_no4am.R
+++ b/tests/testthat/test_part3_no4am.R
@@ -1,18 +1,30 @@
 library(GGIR)
 context("g.part3")
-test_that("Part 3 runs fine on a short file not containing a night", {
+test_that("Part 3 runs fine on a short file not containing a full night", {
   skip_on_cran()
   #=======================
-  # Create a test file that doesn't contain a night.
-  # More specifically, it should not contan a 4am, since it's a magic time used in g.sib.det
-  create_test_acc_csv(Nmin=1000, starts_at_midnight = FALSE)
   fn = "123A_testaccfile.csv"
   dn = "output_test"
   if (file.exists(dn)) unlink(dn, recursive = TRUE)
 
+  # Create a test file that doesn't contain a 4am but does contain a noon and a midnight
+  # (4am, noon and midnight all carry significance in the internal logic of g.sib.det)
+  create_test_acc_csv(Nmin=1000, starts_at_midnight = FALSE)
   GGIR(mode = c(1:3), datadir = fn, outputdir = getwd(), studyname = "test", f0 = 1, f1 = 1,
        do.report = c(), visualreport = FALSE, viewingwindow = 1,
-       overwrite = TRUE, do.parallel = FALSE, minimumFileSizeMB = 0)
+       do.parallel = FALSE, minimumFileSizeMB = 0)
+  
+  out.file.path = paste0(dn, "/meta/ms3.out/", fn, ".RData")
+  expect_true(file.exists(out.file.path))
+
+  if (file.exists(dn)) unlink(dn, recursive = TRUE)
+
+  # Create a test file that doesn't contain a 4am or a noon, but does have a midnight
+  # (4am, noon and midnight all carry significance in the internal logic of g.sib.det)
+  create_test_acc_csv(Nmin=720, start_time = "13:00:00")
+  GGIR(mode = c(1:3), datadir = fn, outputdir = getwd(), studyname = "test", f0 = 1, f1 = 1,
+       do.report = c(), visualreport = FALSE, viewingwindow = 1,
+       do.parallel = FALSE, minimumFileSizeMB = 0)
   
   out.file.path = paste0(dn, "/meta/ms3.out/", fn, ".RData")
   expect_true(file.exists(out.file.path))


### PR DESCRIPTION
<!-- Describe your PR here -->
This addresses #927

g.sib.det was throwing an error on a short recording that contains a midnight but no 4am or noon.

<img width="754" alt="image" src="https://github.com/wadpac/GGIR/assets/6386739/4000aebf-b29f-4a34-91be-e72cabcd7068">

This happened because the a midnight without a preceding 4am should be skipped, but in the case where there is no 4am at all this only midnight was still being processed.

The proposed fix makes sure this only midnight without a preceding 4am is skipped.

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [X] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [X] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Updated or expanded the documentation.
- [ ] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
