### PR TITLE
Edits to PR 931 re. OO window

### DIFF
--- a/R/g.part5.R
+++ b/R/g.part5.R
@@ -276,7 +276,8 @@ g.part5 = function(datadir = c(), metadatadir = c(), f0=c(), f1=c(),
             # Add first waking up time, if it is missing:
             ts = g.part5.addfirstwake(ts, summarysleep = summarysleep_tmp2, nightsi, sleeplog, ID,
                                       Nepochsinhour, SPTE_end)
-            # Convert time column regardless of whether it is aggregated to secure standard time format
+            # Convert time column from iso8601 to POSIX regardless of whether it is aggregated
+            # to ensure the format is consistent
             ts$time = iso8601chartime2POSIX(ts$time,tz = params_general[["desiredtz"]])
             if (params_general[["part5_agg2_60seconds"]] == TRUE) { # Optionally aggregate to 1 minute epoch:
               ts$time_num = floor(as.numeric(ts$time) / 60) * 60

--- a/R/g.part5.R
+++ b/R/g.part5.R
@@ -276,8 +276,10 @@ g.part5 = function(datadir = c(), metadatadir = c(), f0=c(), f1=c(),
             # Add first waking up time, if it is missing:
             ts = g.part5.addfirstwake(ts, summarysleep = summarysleep_tmp2, nightsi, sleeplog, ID,
                                       Nepochsinhour, SPTE_end)
+            # Convert time column regardless of whether it is aggregated to secure standard time format
+            ts$time = iso8601chartime2POSIX(ts$time,tz = params_general[["desiredtz"]])
             if (params_general[["part5_agg2_60seconds"]] == TRUE) { # Optionally aggregate to 1 minute epoch:
-              ts$time_num = floor(as.numeric(iso8601chartime2POSIX(ts$time,tz = params_general[["desiredtz"]])) / 60) * 60
+              ts$time_num = floor(as.numeric(ts$time) / 60) * 60
               
               # only include angle if angle is present
               angleColName = ifelse("angle" %in% names(ts), yes = "angle", no = NULL)

--- a/R/g.part5.addfirstwake.R
+++ b/R/g.part5.addfirstwake.R
@@ -1,4 +1,4 @@
-g.part5.addfirstwake =function(ts, summarysleep, nightsi, sleeplog, ID, 
+g.part5.addfirstwake = function(ts, summarysleep, nightsi, sleeplog, ID, 
                                Nepochsinhour, SPTE_end) {
   # Note related to if first and last night were ignored in part 4:
   # - diur lacks the first and last night at this point in the code.
@@ -72,7 +72,7 @@ g.part5.addfirstwake =function(ts, summarysleep, nightsi, sleeplog, ID,
     }
     if (is.na(wake_night1_index)) wake_night1_index = 0
     if (wake_night1_index < firstwake & wake_night1_index > 1 & (wake_night1_index-1) > nightsi[1]) {
-      ts$diur[nightsi[1]:(wake_night1_index-1)] = 1
+      ts$diur[1:(wake_night1_index-1)] = 1
     } else {
       # Person slept only during the afternoon on day 2
       # And there is no sleep data available for the first night
@@ -82,8 +82,8 @@ g.part5.addfirstwake =function(ts, summarysleep, nightsi, sleeplog, ID,
       # and merging of the sleep variables is still consistent with
       # the other recording.
       dummywake = max(firstonset - round(Nepochsinhour/12), nightsi[1] + round(Nepochsinhour * 6))
-      ts$diur[nightsi[1]:dummywake] = 1 
-      ts$nonwear[nightsi[1]:firstonset] = 1
+      ts$diur[1:dummywake] = 1 
+      ts$nonwear[1:firstonset] = 1
     }
   }
   return(ts)

--- a/R/g.part5.definedays.R
+++ b/R/g.part5.definedays.R
@@ -77,7 +77,9 @@ g.part5.definedays = function(nightsi, wi, indjump, nightsi_bu,
       qqq = c(NA, NA)
       if (length(qqq_backup) > 1) {
         # if there is remaining time after previous day...
-        # and if this is less than 24 hours (necessary if sleep is ignored for last night
+        # but only do this if there is less than 24 hours
+        # this is necessary if sleep is ignored for last night as
+        # that would include the entire last day
         if (Nts - qqq_backup[2] < 24 * (60 / epochSize) * 60) {
           qqq = c(qqq_backup[2] + 1, Nts)
         }

--- a/R/g.part5.definedays.R
+++ b/R/g.part5.definedays.R
@@ -76,10 +76,11 @@ g.part5.definedays = function(nightsi, wi, indjump, nightsi_bu,
     } else {
       qqq = c(NA, NA)
       if (length(qqq_backup) > 1) {
-        # if there is remaining time after previous day...
-        # but only do this if there is less than 24 hours
-        # this is necessary if sleep is ignored for last night as
-        # that would include the entire last day
+        # If there is remaining time after previous day...
+        # but only do this if there is less than 24 hours.
+        # This is necessary if sleep is ignored for last night.
+        # In that case the last two calendar days should be ignored
+        # as no sleep onset will be available.
         if (Nts - qqq_backup[2] < 24 * (60 / epochSize) * 60) {
           qqq = c(qqq_backup[2] + 1, Nts)
         }

--- a/R/g.part5.definedays.R
+++ b/R/g.part5.definedays.R
@@ -74,14 +74,13 @@ g.part5.definedays = function(nightsi, wi, indjump, nightsi_bu,
         }
       }
     } else {
+      qqq = c(NA, NA)
       if (length(qqq_backup) > 1) {
         # if there is remaining time after previous day...
-        if (Nts > qqq_backup[2]) {
+        # and if this is less than 24 hours (necessary if sleep is ignored for last night
+        if (Nts - qqq_backup[2] < 24 * (60 / epochSize) * 60) {
           qqq = c(qqq_backup[2] + 1, Nts)
         }
-      } else {
-        # else, do not analyse this day
-        qqq = c(NA, NA)
       }
     }
     # in MM, also define segments of the day based on qwindow
@@ -154,7 +153,6 @@ g.part5.definedays = function(nightsi, wi, indjump, nightsi_bu,
       segments = list(qqq)
       start = format(ts$time[qqq[1]], "%H:%M:%S")
       end = format(ts$time[qqq[2]], "%H:%M:%S")
-      if (timewindowi == "OO") browser()
       names(segments) = paste(start, end, sep = "-")
       segments_names = timewindowi
     }

--- a/R/g.part5.definedays.R
+++ b/R/g.part5.definedays.R
@@ -87,7 +87,7 @@ g.part5.definedays = function(nightsi, wi, indjump, nightsi_bu,
     # in MM, also define segments of the day based on qwindow
     if (!is.na(qqq[1]) & !is.na(qqq[2])) {
       fullQqq = qqq[1]:qqq[2]
-      lastepoch = substr(ts$time[qqq[2]], 12, 19)
+      lastepoch = format(ts$time[qqq[2]],  "%H:%M:%S")
       qnames = NULL
       if (is.data.frame(qwindow)) {
         date_of_interest = substr(ts$time[qqq[1]], 1, 10)
@@ -137,13 +137,14 @@ g.part5.definedays = function(nightsi, wi, indjump, nightsi_bu,
       }
       names(segments) = segments_timing
     }
-  } else if (timewindowi == "WW") {
-    if (wi <= (Nwindows - 1)) { # all full wake to wake days
-      qqq[1] = which(diff(ts$diur) == -1)[wi] + 1
-      qqq[2] = which(diff(ts$diur) == -1)[wi + 1]
+  } else if (timewindowi == "WW" || timewindowi == "OO") {
+    windowEdge = ifelse(timewindowi == "WW", yes = -1, no = 1)
+    if (wi <= (Nwindows - 1)) { # all full windows
+      qqq[1] = which(diff(ts$diur) == windowEdge)[wi] + 1
+      qqq[2] = which(diff(ts$diur) == windowEdge)[wi + 1]
     } else {
-      # time after last reliable waking up (this can be more than 24 hours)
-      # ignore this day, because if the night was ignored for sleep analysis
+      # time after last reliable waking up or onset (this can be more than 24 hours)
+      # ignore this window, because if the night was ignored for sleep analysis
       # then the description of the day in part 5 including that night is
       # not informative.
       qqq = c(NA, NA)
@@ -151,30 +152,13 @@ g.part5.definedays = function(nightsi, wi, indjump, nightsi_bu,
     # build up segments
     if (!is.na(qqq[1]) & !is.na(qqq[2])) {
       segments = list(qqq)
-      start = substr(ts$time[qqq[1]], 12, 19)
-      end = substr(ts$time[qqq[2]], 12, 19)
+      start = format(ts$time[qqq[1]], "%H:%M:%S")
+      end = format(ts$time[qqq[2]], "%H:%M:%S")
+      if (timewindowi == "OO") browser()
       names(segments) = paste(start, end, sep = "-")
-      segments_names = "WW"
+      segments_names = timewindowi
     }
-  } else if (timewindowi == "OO") {
-    if (wi <= (Nwindows - 1)) { # all full wake to wake days
-      qqq[1] = which(diff(ts$diur) == 1)[wi] + 1
-      qqq[2] = which(diff(ts$diur) == 1)[wi + 1]
-    } else {
-      # time after last reliable waking up (this can be more than 24 hours)
-      # ignore this day, because if the night was ignored for sleep analysis
-      # then the description of the day in part 5 including that night is
-      # not informative.
-      qqq = c(NA, NA)
-    }
-    # build up segments
-    if (!is.na(qqq[1]) & !is.na(qqq[2])) {
-      segments = list(qqq)
-      start = substr(ts$time[qqq[1]], 12, 19)
-      end = substr(ts$time[qqq[2]], 12, 19)
-      names(segments) = paste(start, end, sep = "-")
-      segments_names = "OO"
-    }
+    
   }
   return(invisible(list(qqq = qqq, qqq_backup = qqq_backup, 
                         segments = segments, segments_names = segments_names)))

--- a/R/g.part5.onsetwaketiming.R
+++ b/R/g.part5.onsetwaketiming.R
@@ -4,10 +4,10 @@ g.part5.onsetwaketiming = function(qqq, ts, min, sec, hour, timewindowi) {
   # Onset index
   if (timewindowi == "OO") {
     # For OO onset is by definition the start and end of the window
-    onseti = qqq[2] + 1
+    onseti = qqq[1] + 1
   } else {
     # For WW and MM onset needs to be search in the window
-    onseti = c(qqq[1]:qqq[2])[which(diff(ts$diur[qqq[1]:(qqq[2] - 1)]) == 1) + 1]
+    onseti = c(qqq[1]:qqq[2])[which(diff(ts$diur[qqq[1]:(qqq[2] - 1)]) == 1)] + 1
     if (length(onseti) > 1) {
       onseti = onseti[length(onseti)] # in the case if MM use last onset
     }

--- a/R/g.part5.onsetwaketiming.R
+++ b/R/g.part5.onsetwaketiming.R
@@ -2,22 +2,23 @@ g.part5.onsetwaketiming = function(qqq, ts, min, sec, hour, timewindowi) {
   onset = wake = 0
   skiponset = TRUE; skipwake = TRUE
   # Onset index
-  if (timewindowi == "WW") {
-    onseti = c(qqq[1]:qqq[2])[which(diff(ts$diur[qqq[1]:(qqq[2]-1)]) == 1)+1]
-    if (length(onseti) > 1) {
-      onseti = onseti[length(onseti)] # in the case if MM use last onset
-    }
+  if (timewindowi == "OO") {
+    # For OO onset is by definition the start and end of the window
+    onseti = qqq[2] + 1
   } else {
-    onseti = c(qqq[1]:qqq[2])[which(diff(ts$diur[qqq[1]:(qqq[2]-1)]) == 1)+1]
+    # For WW and MM onset needs to be search in the window
+    onseti = c(qqq[1]:qqq[2])[which(diff(ts$diur[qqq[1]:(qqq[2] - 1)]) == 1) + 1]
     if (length(onseti) > 1) {
       onseti = onseti[length(onseti)] # in the case if MM use last onset
     }
   }
   # Wake index
   if (timewindowi == "WW") {
-    wakei = qqq[2]+1
+    # For WW wake is by definition the start and end of the window
+    wakei = qqq[2] + 1
   } else {
-    wakei = c(qqq[1]:qqq[2])[which(diff(ts$diur[qqq[1]:(qqq[2]-1)]) == -1)+1]
+    # For OO and MM wake needs to be search in the window
+    wakei = c(qqq[1]:qqq[2])[which(diff(ts$diur[qqq[1]:(qqq[2] - 1)]) == -1) + 1]
     if (length(wakei) > 1) wakei = wakei[1] # in the case if MM use first wake-up time
   }
   # Onset time

--- a/R/g.part5_analyseSegment.R
+++ b/R/g.part5_analyseSegment.R
@@ -48,7 +48,7 @@ g.part5_analyseSegment = function(indexlog, timeList, levelList,
   # The following is to avoid issue with merging sleep variables from part 4
   # This code extract them the time series (ts) object create in g.part5
   # Note that this means that for MM windows there can be multiple or no wake or onsets
-  date = as.Date(ts$time[segStart + 1])
+  date = as.Date(ts$time[segStart + 1], tz = params_general[["desiredtz"]])
   if (add_one_day_to_next_date == TRUE & timewindowi %in% c("WW", "OO")) { # see below for explanation
     date = date + 1
     add_one_day_to_next_date = FALSE
@@ -73,9 +73,9 @@ g.part5_analyseSegment = function(indexlog, timeList, levelList,
     # So, for next window we have to do date = date + 1
     add_one_day_to_next_date = TRUE
   }
-  if (onset < 24 & timewindowi == "OO") {
-    # onset before midnight means that next OO window
-    # will start a day before the day we refer to when discussing it's SPT
+  if (onset > 24 & timewindowi == "OO") {
+    # onset after midnight means that next OO window
+    # will start a day after the day we refer to when discussing it's SPT
     # So, for next window we have to do date = date + 1
     add_one_day_to_next_date = TRUE
   }
@@ -427,11 +427,15 @@ g.part5_analyseSegment = function(indexlog, timeList, levelList,
     # LIGHT, IF AVAILABLE
     if ("lightpeak" %in% colnames(ts) & length(params_247[["LUX_day_segments"]]) > 0) {
       # mean LUX
-      dsummary[si,fi] =  round(max(ts$lightpeak[sse[ts$diur[sse] == 0]], na.rm = TRUE), digits = 1)
-      dsummary[si,fi + 1] = round(mean(ts$lightpeak[sse[ts$diur[sse] == 0]], na.rm = TRUE), digits = 1)
-      dsummary[si,fi + 2] = round(mean(ts$lightpeak[sse[ts$diur[sse] == 1]], na.rm = TRUE), digits = 1)
-      dsummary[si,fi + 3] = round(mean(ts$lightpeak[sse[ts$diur[sse] == 0 & ts$ACC[sse] > TRMi]], na.rm = TRUE),
-                                  digits = 1)
+      if (length(which(ts$diur[sse] == 0)) > 0 & length(which(ts$diur[sse] == 1)) > 0) {
+        dsummary[si,fi] =  round(max(ts$lightpeak[sse[ts$diur[sse] == 0]], na.rm = TRUE), digits = 1)
+        dsummary[si,fi + 1] = round(mean(ts$lightpeak[sse[ts$diur[sse] == 0]], na.rm = TRUE), digits = 1)
+        dsummary[si,fi + 2] = round(mean(ts$lightpeak[sse[ts$diur[sse] == 1]], na.rm = TRUE), digits = 1)
+        dsummary[si,fi + 3] = round(mean(ts$lightpeak[sse[ts$diur[sse] == 0 & ts$ACC[sse] > TRMi]], na.rm = TRUE),
+                                    digits = 1)
+      } else {
+        dsummary[si,fi:(fi + 3)] = NA
+      }
       ds_names[fi:(fi + 3)] = c("LUX_max_day", "LUX_mean_day", "LUX_mean_spt", "LUX_mean_day_mvpa"); fi = fi + 4
       # time in LUX ranges
       Nluxt = length(params_247[["LUXthresholds"]])

--- a/R/g.part5_analyseSegment.R
+++ b/R/g.part5_analyseSegment.R
@@ -49,7 +49,7 @@ g.part5_analyseSegment = function(indexlog, timeList, levelList,
   # This code extract them the time series (ts) object create in g.part5
   # Note that this means that for MM windows there can be multiple or no wake or onsets
   date = as.Date(ts$time[segStart + 1])
-  if (add_one_day_to_next_date == TRUE & timewindowi == "WW") { # see below for explanation
+  if (add_one_day_to_next_date == TRUE & timewindowi %in% c("WW", "OO")) { # see below for explanation
     date = date + 1
     add_one_day_to_next_date = FALSE
   }
@@ -69,6 +69,12 @@ g.part5_analyseSegment = function(indexlog, timeList, levelList,
   skiponset = onsetwaketiming$skiponset; skipwake = onsetwaketiming$skipwake
   if (wake < 24 & timewindowi == "WW") {
     # waking up before midnight means that next WW window
+    # will start a day before the day we refer to when discussing it's SPT
+    # So, for next window we have to do date = date + 1
+    add_one_day_to_next_date = TRUE
+  }
+  if (onset < 24 & timewindowi == "OO") {
+    # onset before midnight means that next OO window
     # will start a day before the day we refer to when discussing it's SPT
     # So, for next window we have to do date = date + 1
     add_one_day_to_next_date = TRUE
@@ -440,7 +446,7 @@ g.part5_analyseSegment = function(indexlog, timeList, levelList,
         }
       }
       fi = fi + Nluxt
-      if (timewindowi == "WW") {
+      if (timewindowi %in% c("WW", "OO")) {
         # LUX per segment of the day
         luxperseg = g.part5.lux_persegment(ts, sse,
                                            LUX_day_segments = params_247[["LUX_day_segments"]],
@@ -487,7 +493,6 @@ g.part5_analyseSegment = function(indexlog, timeList, levelList,
                   columnIndex = fi)
   timeList = list(ts = ts,
                   epochSize = ws3new)
-  
   invisible(list(
     indexlog = indexlog,
     ds_names = ds_names,

--- a/R/g.part5_analyseSegment.R
+++ b/R/g.part5_analyseSegment.R
@@ -69,13 +69,13 @@ g.part5_analyseSegment = function(indexlog, timeList, levelList,
   skiponset = onsetwaketiming$skiponset; skipwake = onsetwaketiming$skipwake
   if (wake < 24 & timewindowi == "WW") {
     # waking up before midnight means that next WW window
-    # will start a day before the day we refer to when discussing it's SPT
+    # will start a day before the date we refer to when discussing it's SPT
     # So, for next window we have to do date = date + 1
     add_one_day_to_next_date = TRUE
   }
   if (onset > 24 & timewindowi == "OO") {
     # onset after midnight means that next OO window
-    # will start a day after the day we refer to when discussing it's SPT
+    # will start a date after the date we refer to when discussing it;s SPT
     # So, for next window we have to do date = date + 1
     add_one_day_to_next_date = TRUE
   }

--- a/R/g.report.part5.R
+++ b/R/g.report.part5.R
@@ -210,7 +210,7 @@ g.report.part5 = function(metadatadir = c(), f0 = c(), f1 = c(), loglocation = c
                 CN = colnames(outputfinal)
                 outputfinal2 = outputfinal
                 colnames(outputfinal2) = CN
-                delcol = grep(pattern = "window|TRLi|TRMi|TRVi|sleepparam",
+                delcol = grep(pattern = "TRLi|TRMi|TRVi|sleepparam",
                               x = colnames(outputfinal2))
                 if (uwi[j] != "Segments") {
                   delcol = c(delcol, which(colnames(outputfinal2) == "window"))

--- a/tests/testthat/test_part5_qwindow.R
+++ b/tests/testthat/test_part5_qwindow.R
@@ -6,10 +6,9 @@ test_that("g.part5.definedays considers qwindow to generate segments", {
   # set windows
   timestamp = seq.POSIXt(from = as.POSIXct("2022-01-01 00:00:00"), 
                          to = as.POSIXct("2022-01-04 23:59:00"), by = 60)
-  timestamp = POSIXtime2iso8601(timestamp, tz = "")
   ts = data.frame(timestamp = timestamp,
                   ACC = 0)
-  nightsi = grep("00:00:00", ts$timestamp)
+  nightsi = grep("00:00:00", format(ts$timestamp))
   qwindow = c(7, 18)
   
   definedays = g.part5.definedays(nightsi = nightsi, wi = 1, indjump = 1, 


### PR DESCRIPTION
<!-- Describe your PR here -->

@jhmigueles in this PR I am proposing some changes to PR #933

I tested PR #933 with strategy = 2 to see how it handles the missing sleep estimates for the first and last night.
The part5 csv-report columns `onset` and `onset_ts` were empty and the dates and times did not relate in line with how dates and times are related in the WW report. 

In my test recording I see in the part 4 output:
17/4 wakeup at 7:42
18/4 onset at 0:51
18/4 wakeup at 6:45
19/4 onset at 0:28
19/4 wakeup at 6:57

this means that we expect the first row (window) in the part 5 reports to be:
- WW report: 7:42 - 6:45 start_end_window, onset at 0:51, with date 17/4 (because that is the date on which the window starts)
- OO report: 0:51 - 0:28 start_end_window, wakeup at 6:48, with date 18/4 (because that is the date on which the window starts)

In that way the logic of the rows is consistent between WW and OO report as each row represents the description of a single window. With the changes in this PR this should be correct now.

Additionally, this PR does:

- Skip calculation of max/mean peaklight when there is, for whatever reason, no SPT or waking hours inside a window. I encountered this when using `strategy = 2` and `timewindow = "MM"`.
- Column `start_end_window` inside the csv report was skipped, I am now turning it on to ease checking the data.
- Moves conversion of iso8601 to POSIXct outside the part5_agg2_60seconds block because it is easier to have standard time format regardless of whether data is aggregated to 60sec or not.
- Replaces  `substr(ts$time[qqq[2]], 12, 19)` by `format(ts$time[qqq[2]], "%H:%M:%S")` because POSIX object do not have time for midnight and causes error. Extracting time with `format()` function is safer.

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [ ] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Updated or expanded the documentation.
- [ ] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
