### PR TITLE
Speed up detect_nonwear_clipping

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # CHANGES IN GGIR VERSION 3.0-0
 
-- Part 1 and 2: Change default value for nonwear_approach to 2023
+- Part 1 and 2: Change default value for nonwear_approach to "2023" which labels the entire window as nonwear if conditions are met. This instead of only the middle 15 minutes as is the case for "2013" setting. Further, setting "2023" now uses a 5 Hertz version of the signals for non-wear detection, for clipping detection the code uses the original signal.
 
 - Part 2: Move cosinor analysis code to its own function in order to ease re-using it in both part 2 and part 6.
 
@@ -9,13 +9,9 @@
 - Part 2: Arguments hrs.del.start and hrs.del.end when combined with strategy = 3 and strategy = 5 now count
 relative to start and end of the most active time window as identified.  #905
 
-- Part 5: Change default for segmentDAYSPTcrit.part5 from c(0,0) to c(0, 0.9) and now
-prohibiting the use of c(0, 0) as it gives biased estimates. We knew this, but some users
-started using the default without attempting to understand it, by which it seems necessary
-to force a sensible selection. #940
+- Part 5: Change default for segmentDAYSPTcrit.part5 from c(0,0) to c(0, 0.9) and now prohibiting the use of c(0, 0) as it gives biased estimates. We knew this, but some users started using the default without attempting to understand it, by which it seems necessary to force a sensible default. #940
 
-- Part 5: Added optioned "OO" to argument timewindow, which defines windows from
-sleep Onset to sleep Onset #931
+- Part 5: Added optioned "OO" to argument timewindow, which defines windows from sleep Onset to sleep Onset #931
 
 # CHANGES IN GGIR VERSION 2.10-4
 

--- a/R/GGIR.R
+++ b/R/GGIR.R
@@ -152,8 +152,6 @@ GGIR = function(mode = 1:5, datadir = c(), outputdir = c(),
   }
 
   if (length(myfun) != 0) { # Run check on myfun object, if provided
-    warning("\nAre you using GGIR as online service to others? If yes, then make sure you prohibit the",
-            " user from specifying argument myfun as this poses a security risk.", call. = FALSE)
     check_myfun(myfun, params_general[["windowsizes"]])
   }
 

--- a/R/check_params.R
+++ b/R/check_params.R
@@ -402,12 +402,16 @@ check_params = function(params_sleep = c(), params_metrics = c(),
     }
     if (sum(params_cleaning[["segmentDAYSPTcrit.part5"]]) < 0.5 |
         0 %in% params_cleaning[["segmentDAYSPTcrit.part5"]] == FALSE) {
-      stop(paste0("\nArgument segmentDAYSPTcrit.part5 needs to include one zero",
-                  " and one value of at least 0.5 as mixing incomplete windows with complete windows",
-                  " biases the estimates"), call. = FALSE)
+      
+      stop(paste0("\nIf you used argument segmentDAYSPTcrit.part5 then make sure",
+                  " it includes one zero",
+                  " and one value of at least 0.5, see documentation for",
+                  " argument segmentDAYSPTcrit.part5. If you do not use",
+                  " argument segmentDAYSPTcrit.part5",
+                  " then delete it from your config.csv file (in your output folder)",
+                  " or delete the config.csv file itself."), call. = FALSE)
     }
   }
-  
   
   invisible(list(params_sleep = params_sleep,
                  params_metrics = params_metrics,

--- a/R/detect_nonwear_clipping.R
+++ b/R/detect_nonwear_clipping.R
@@ -11,6 +11,11 @@ detect_nonwear_clipping = function(data = c(), windowsizes = c(5, 900, 3600), sf
   CWav = NWav = rep(0, nmin)
   crit = ((window/window2)/2) + 1
   
+  if (is.numeric(data[,1]) == FALSE) {
+    data[,1] = as.numeric(data[,1])
+    data[,2] = as.numeric(data[,2])
+    data[,3] = as.numeric(data[,3])
+  }
   if (nonwear_approach %in% c("2013", "2023")) {
     # define windows to check:
     for (h in 1:nmin) { #number of windows
@@ -26,8 +31,8 @@ detect_nonwear_clipping = function(data = c(), windowsizes = c(5, 900, 3600), sf
           hoc1 = 1
           hoc2 = window
         } else if (h >= (nmin - crit)) {
-          hoc1 = (nmin - crit)*window2
-          hoc2 = nmin*window2 #end of data
+          hoc1 = (nmin - crit) * window2
+          hoc2 = nmin * window2 #end of data
         } else if (h > crit & h < (nmin - crit)) {
           hoc1 = (((h - 1) * window2) + window2 * 0.5 ) - window * 0.5
           hoc2 = (((h - 1) * window2) + window2 * 0.5 ) + window * 0.5
@@ -38,7 +43,7 @@ detect_nonwear_clipping = function(data = c(), windowsizes = c(5, 900, 3600), sf
         NWflag = h:(h + window/window2 - 1)
         if (NWflag[length(NWflag)] > nmin) NWflag = NWflag[-which(NWflag > nmin)]
         # window to check (not aggregated values)
-        hoc1 = h*window2 - window2 + 1
+        hoc1 = h * window2 - window2 + 1
         hoc2 = hoc1 + window - 1
         if (hoc2 > nrow(data)) {
           hoc2 = nrow(data)
@@ -53,35 +58,32 @@ detect_nonwear_clipping = function(data = c(), windowsizes = c(5, 900, 3600), sf
       }
       for (jj in  1:3) {
         # Clipping
-        CW[h,jj] = length(which(abs(as.numeric(data[(1 + cliphoc1):cliphoc2,jj])) > clipthres))
-        if (length(which(abs(as.numeric(data[(1 + cliphoc1):cliphoc2,jj])) > clipthres*1.5)) > 0) {
-          CW[h,jj] = window2 # If there is a a value that is more than 150% the dynamic range then ignore entire block.
+        CW[h, jj] = length(which(abs(data[(1 + cliphoc1):cliphoc2, jj]) > clipthres))
+        if (length(which(abs(data[(1 + cliphoc1):cliphoc2,jj]) > clipthres * 1.5)) > 0) {
+          CW[h, jj] = window2 # If there is a a value that is more than 150% the dynamic range then ignore entire block.
         }
         # Non-wear
         #hoc1 & hoc2 = edges of windows
         #window is bigger& window2 is smaller one
-        sdwacc = sd(as.numeric(data[(1 + hoc1):hoc2,jj]), na.rm = TRUE)
-        maxwacc = max(as.numeric(data[(1 + hoc1):hoc2,jj]), na.rm = TRUE)
-        minwacc = min(as.numeric(data[(1 + hoc1):hoc2,jj]), na.rm = TRUE)
+        # (1 + hoc1):hoc2
+        indices = seq((1 + hoc1), hoc2, by = ceiling(sf / 5))
+        maxwacc = max(data[indices, jj], na.rm = TRUE)
+        minwacc = min(data[indices, jj], na.rm = TRUE)
         absrange = abs(maxwacc - minwacc)
-        if (is.numeric(absrange) == TRUE & is.numeric(sdwacc) == TRUE & is.na(sdwacc) == FALSE) {
+        if (absrange < racriter) {
+          sdwacc = sd(data[indices,jj], na.rm = TRUE)
           if (sdwacc < sdcriter) {
-            if (absrange < racriter) {
-              NW[NWflag,jj] = 1
-            }
+            NW[NWflag,jj] = 1
           }
-        } else {
-          NW[NWflag,jj] = 1 # if sdwacc, maxwacc, or minwacc could not be derived then label as non-wear
         }
       }
-      CW = CW / (window2) #changed 30-1-2012, was window*sf
+      CW = CW / (window2)
       if (length(params_rawdata[["rmc.col.wear"]]) == 0) {
         NWav[h] = (NW[h,1] + NW[h,2] + NW[h,3]) #indicator of non-wear
       }
-      CWav[h] = max(c(CW[h,1],CW[h,2],CW[h,3])) #indicator of clipping
+      CWav[h] = max(c(CW[h, 1], CW[h, 2], CW[h, 3])) #indicator of clipping
     }
   } 
-  
   # In NWav: single 1's surrounded by 2's or 3's --> 2 (so it is considered nonwear)
   ones = which(NWav == 1)
   if (length(ones) > 0) {

--- a/R/detect_nonwear_clipping.R
+++ b/R/detect_nonwear_clipping.R
@@ -58,15 +58,21 @@ detect_nonwear_clipping = function(data = c(), windowsizes = c(5, 900, 3600), sf
       }
       for (jj in  1:3) {
         # Clipping
-        CW[h, jj] = length(which(abs(data[(1 + cliphoc1):cliphoc2, jj]) > clipthres))
-        if (length(which(abs(data[(1 + cliphoc1):cliphoc2,jj]) > clipthres * 1.5)) > 0) {
-          CW[h, jj] = window2 # If there is a a value that is more than 150% the dynamic range then ignore entire block.
+        aboveThreshold = which(abs(data[(1 + cliphoc1):cliphoc2, jj]) > clipthres)
+        CW[h, jj] = length(aboveThreshold)
+        if (length(aboveThreshold) > 0) {
+          if (length(which(abs(data[c((1 + cliphoc1):cliphoc2)[aboveThreshold],jj]) > clipthres * 1.5)) > 0) {
+            CW[h, jj] = window2 # If there is a a value that is more than 150% the dynamic range then ignore entire block.
+          }
         }
         # Non-wear
         #hoc1 & hoc2 = edges of windows
         #window is bigger& window2 is smaller one
-        # (1 + hoc1):hoc2
-        indices = seq((1 + hoc1), hoc2, by = ceiling(sf / 5))
+        if (nonwear_approach == "2013") {
+          indices = (1 + hoc1):hoc2
+        } else if (nonwear_approach == "2023") {
+          indices = seq((1 + hoc1), hoc2, by = ceiling(sf / 5))
+        }
         maxwacc = max(data[indices, jj], na.rm = TRUE)
         minwacc = min(data[indices, jj], na.rm = TRUE)
         absrange = abs(maxwacc - minwacc)

--- a/tests/testthat/test_detect_nonwear.R
+++ b/tests/testthat/test_detect_nonwear.R
@@ -3,27 +3,27 @@ context("detect_nonwear_clipping")
 test_that("detects non wear time", {
   skip_on_cran()
   
+  
   # This will produce a 2-day long acc file with a 2-hour block of nonwear
   # starting at the 5th minute of every day
   Ndays = 2
-  create_test_acc_csv(Nmin = Ndays*1440)
+  sf = 3
+  create_test_acc_csv(Nmin = Ndays * 1440, sf = sf)
   
   data = as.matrix(read.csv("123A_testaccfile.csv", skip = 10))
 
   # 2013 algorithm ------
   # clipthres to 1.7 to test the clipping detection
   NWCW = detect_nonwear_clipping(data = data, nonwear_approach = "2013", 
-                                 sf = 3, clipthres = 1.7)
+                                 sf = sf, clipthres = 1.7)
   CW = NWCW$CWav; NW = NWCW$NWav
   NW_rle_2013 = rle(NW)
   CW = sum(NWCW$CWav > 0)
-  
+
   # 2023 algorithm ------
-  NWCW = detect_nonwear_clipping(data = data, nonwear_approach = "2023", sf = 3)
+  NWCW = detect_nonwear_clipping(data = data, nonwear_approach = "2023", sf = sf)
   NW = NWCW$NWav
   NW_rle_2023 = rle(NW)
-  
-  
   # tests ----------------
   # Does it find the 2 periods of nonwear?
   expect_equal(sum(NW_rle_2013$values == 3), 2)


### PR DESCRIPTION
<!-- Describe your PR here -->

Final updates in preparation for CRAN submission:
- Speeding up function detect_nonwear_clipping.R to make it easier to work with shorter long epoch size #945 even though we keep the same default of 900 seconds.
- Removes the warning about security risk of external functions as it was getting annoying. #944
- Improves error message for segmentDAYSPTcrit.part5 setting because users will see this after switching from 2.10-1 to 3.0-0 regardless of whether they used argument qwindow, which could be confusing.
- Tidy up changelog message

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Updated or expanded the documentation.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
