### PR TITLE
Fix typo in g.report.part2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,8 @@ Authors@R: c(person("Vincent T","van Hees",role=c("aut","cre"),
              person(given = "Taren",family = "Sanders", role = "ctb"),
              person("Medical Research Council UK",  role = c("cph", "fnd")),
              person("Accelting",  role = c("cph", "fnd")),
-             person("French National Research Agency",  role = c("cph", "fnd")))
+             person("French National Research Agency",  role = c("cph", "fnd")),
+             person("Chenxuan","Zhao",role="ctb"))
 Maintainer: Vincent T van Hees <v.vanhees@accelting.com>
 Description: A tool to process and analyse data collected with wearable raw acceleration sensors as described in Migueles and colleagues (JMPB 2019), and van Hees and colleagues (JApplPhysiol 2014; PLoSONE 2015). The package has been developed and tested for binary data from 'GENEActiv' <https://activinsights.com/> and GENEA devices (not for sale), .csv-export data from  'Actigraph' <https://theactigraph.com> devices, and .cwa and .wav-format data from 'Axivity' <https://axivity.com>. These devices are currently widely used in research on human daily physical activity. Further, the package can handle accelerometer data file from any other sensor brand providing that the data is stored in csv format and has either no header or a two column header. Also the package allows for external function embedding.
 URL: https://github.com/wadpac/GGIR/, https://groups.google.com/forum/#!forum/RpackageGGIR, https://wadpac.github.io/GGIR/

--- a/R/g.report.part2.R
+++ b/R/g.report.part2.R
@@ -202,7 +202,7 @@ g.report.part2 = function(metadatadir = c(), f0 = c(), f1 = c(), maxdur = 0,
           QC = QC[, colnames(QCout)] # reorder to match order of QCout
         } else if (n1 < n2) {
           newcolnames = colnames(QC)[which(colnames(QC) %in% colnames(QCout) == FALSE)]
-          newcols = (n2 + 1):(n1 +  length(newcolnames))
+          newcols = (n1 + 1):(n1 +  length(newcolnames))
           QCout = cbind(QCout, matrix(" ", 1, n2 - n1))
           colnames(QCout)[newcols] = newcolnames
           QCout = QCout[, colnames(QC)] # reorder to match order of QC


### PR DESCRIPTION
<!-- Describe your PR here -->
In file `g.report.part2.R` line 205: in case "n2 > n1", the index of new columns should be "n1+1" to "n1+{length of new columns}".  The original code was "newcols = (n2 + 1):(n1 +  length(newcolnames))", which would lead to an error when assigning new clounm names (line 207).
<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Updated or expanded the documentation.
- [ ] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [x] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
