### PR TITLE
address NOTE in checks related to exampledates in g.conv.actlog

### DIFF
--- a/R/g.conv.actlog.R
+++ b/R/g.conv.actlog.R
@@ -32,6 +32,7 @@ g.conv.actlog = function(qwindow, qwindow_dateformat="%d-%m-%Y", epochSize = 5) 
   # find dates
   actlog_vec = unlist(actlog) # turn into vector
   actlog_vec = sapply(actlog_vec, function(x) !all(is.na(as.Date(as.character(x),format=qwindow_dateformat))))
+  exampledates = unlist(actlog)[which(actlog_vec == TRUE)]
   Ndates = length(which(actlog_vec == TRUE))
   dim(actlog_vec) = c(nrow(actlog),ncol(actlog))
   # create new qwindow object to archive all extracted information


### PR DESCRIPTION
<!-- Describe your PR here -->
This should address the NOTE in the checks introduced in the [PR948](https://github.com/wadpac/GGIR/pull/948).
The NOTE informed that the object `exampledates` was used in `g.conv.actlog` without being generated. I have addressed this by defining the object `exampledates` before it is used in the code.

This would not affect the functionality, it only affects the generation of a warning in the case that dates format in the activity log cannot be recognized by GGIR.

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Updated or expanded the documentation.
- [ ] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
