### PR TITLE
Issue994 movisens ID handling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,11 +2,17 @@
 
 - Part 2: Fix bug that caused part 2 to struggle with corrupt ActiGraph .gt3x files #972
 
+- Part 2: Redefine horizontal axis of plots_to_check_data_quality #983
+
 - Documentation: Expanded documentation on desiredtz, configtz, and time stamp format in part 5 time series #966
 
 - Part 1: Now also able to handle some more variations in Actigraph csv count file format #978, and automatically aggregates to lower resolution if short epoch size is longer than observed epoch size in actigraph count csv.
 
-- Part 5: Fix bug in recently added fucntionality for studying overlap between sibs and self-reported beahviours #989.
+- Part 5: Reverting decision to prohibit segmentDAYSPTcrit.part5 to be c(0, 0). The default remains unchanged and documentation now only emphasizes the downside of using c(0, 0). #980
+
+- Argument documentation: Fixing series of typos (thanks to Pieter-Jan Marent for pointing them out)
+
+- Part 5: Fix bug in recently added functionality for studying overlap between sibs and self-reported behaviours #989.
 
 - Part 1: Fix bug that caused a mismatch between IDs and filenames in part 1 when movisens participant folders did not contain the acc.bin file #994.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,17 +2,13 @@
 
 - Part 2: Fix bug that caused part 2 to struggle with corrupt ActiGraph .gt3x files #972
 
-- Part 2: Redefine horizontal axis of plots_to_check_data_quality #983
-
 - Documentation: Expanded documentation on desiredtz, configtz, and time stamp format in part 5 time series #966
 
 - Part 1: Now also able to handle some more variations in Actigraph csv count file format #978, and automatically aggregates to lower resolution if short epoch size is longer than observed epoch size in actigraph count csv.
 
-- Part 5: Reverting decision to prohibit segmentDAYSPTcrit.part5 to be c(0, 0). The default remains unchanged and documentation now only emphasizes the downside of using c(0, 0). #980
+- Part 5: Fix bug in recently added fucntionality for studying overlap between sibs and self-reported beahviours #989.
 
-- Argument documentation: Fixing series of typos (thanks to Pieter-Jan Marent for pointing them out)
-
-- Part 5: Fix bug in recently added functionality for studying overlap between sibs and self-reported behaviours #989.
+- Part 1: Fix bug that caused a mismatch between IDs and filenames in part 1 when movisens participant folders did not contain the acc.bin file #994.
 
 # CHANGES IN GGIR VERSION 3.0-1
 

--- a/R/datadir2fnames.R
+++ b/R/datadir2fnames.R
@@ -12,8 +12,24 @@ datadir2fnames = function(datadir,filelist) {
       fnamesfull = fnamesRD
     }
   } else {
-    fnamesfull = datadir
-    fnames = basename(fnamesfull)
+    if (ismovisens(datadir)) {
+      fnamesfull = dir(datadir, recursive = TRUE, pattern = "acc.bin", full.names = TRUE)
+      fnames = basename(dirname(fnamesfull))
+      nfolders = length(dir(datadir))
+      if (nfolders > length(fnamesfull)) { # meaning there are participants folder without acc.bin
+        # folders without acc.bin
+        allfolders = dir(datadir, full.names = TRUE)
+        foldersWithAccBin = dirname(fnamesfull)
+        noAccBin = allfolders[which(!allfolders %in% foldersWithAccBin)]
+        warning(paste0("The following participant folders do not contain the ",
+                       "acc.bin file with the accelerometer recording, and ",
+                       "therefore cannot be processed in GGIR: ",
+                       paste(noAccBin, collapse = ", ")), call. = FALSE)
+      }
+    } else {
+      fnamesfull = datadir
+      fnames = basename(fnamesfull)
+    }
   }
   invisible(list(fnames = fnames, fnamesfull = fnamesfull))
 }

--- a/R/datadir2fnames.R
+++ b/R/datadir2fnames.R
@@ -16,12 +16,12 @@ datadir2fnames = function(datadir,filelist) {
       fnamesfull = dir(datadir, recursive = TRUE, pattern = "acc.bin", full.names = TRUE)
       fnames = basename(dirname(fnamesfull))
       nfolders = length(dir(datadir))
-      if (nfolders > length(fnamesfull)) { # meaning there are participants folder without acc.bin
+      if (nfolders > length(fnamesfull)) { # meaning there are movisens data folder without acc.bin
         # folders without acc.bin
         allfolders = dir(datadir, full.names = TRUE)
         foldersWithAccBin = dirname(fnamesfull)
         noAccBin = allfolders[which(!allfolders %in% foldersWithAccBin)]
-        warning(paste0("The following participant folders do not contain the ",
+        warning(paste0("The following movisens data folders do not contain the ",
                        "acc.bin file with the accelerometer recording, and ",
                        "therefore cannot be processed in GGIR: ",
                        paste(noAccBin, collapse = ", ")), call. = FALSE)

--- a/R/g.part1.R
+++ b/R/g.part1.R
@@ -18,17 +18,12 @@ g.part1 = function(datadir = c(), metadatadir = c(), f0 = 1, f1 = c(), myfun = c
   
   if (f1 == 0) warning("\nWarning: f1 = 0 is not a meaningful value")
   filelist = isfilelist(datadir)
+  if (ismovisens(datadir)) filelist = TRUE
 
   # list all accelerometer files
   dir2fn = datadir2fnames(datadir, filelist)
   fnames = dir2fn$fnames
   fnamesfull = dir2fn$fnamesfull
-
-  # check whether these are movisens files
-  if (filelist == FALSE & ismovisens(datadir) == TRUE) {
-    fnamesfull = dir(datadir, recursive = TRUE, pattern = "acc.bin", full.names = TRUE)
-    fnames = dir(datadir, recursive = FALSE)
-  }
   filesizes = file.size(fnamesfull) # in bytes
   bigEnough = which(filesizes/1e6 > params_rawdata[["minimumFileSizeMB"]])
   fnamesfull = fnamesfull[bigEnough]

--- a/vignettes/GGIR.Rmd
+++ b/vignettes/GGIR.Rmd
@@ -159,8 +159,9 @@ additional packages:
         the absence of timestamps GGIR will calculate timestamps from
         the sample frequency, the start time and start date as presented
         in the file header.
-    -   [Movisens](https://www.movisens.com/en/) with data stored in
-        folders.
+    -   [Movisens](https://www.movisens.com/en/) .bin files with data 
+        stored in folders. GGIR expects that each participant's folder 
+        contains at least a file named acc.bin.
     -   Any other accelerometer brand that generates csv output, see
         documentation for functions `read.myacc.csv` and argument
         `rmc.noise` in the [GGIR function documentation


### PR DESCRIPTION
<!-- Describe your PR here -->
Fixes #994 => When processing movisens files, if any of the participant folders does not contain the acc.bin file that GGIR will try to read, then this produced a mismatch between IDs and filenames. This has been addressed and the `fnames` definition of movisens files moved to the `datadir2fnames` function. A warning is triggered to let the user know that some of their folders do not contain the expected acc.bin file (this could be of help for them to contact movisens support and try to get this file).

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [x] Updated or expanded the documentation.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
