### PR TITLE
g.getstarttime() should return same timestamp format for all sensor types.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# CHANGES IN GGIR VERSION 3.0-3
+
+- Part 1: Fix bug where on machines with GMT timezone and R >= 4.3.0, for GENEActiv .bin files, the starting timestamps of M$metalong and M$metashort were truncated to midninght #1000
+
 # CHANGES IN GGIR VERSION 3.0-2
 
 - Part 2: Fix bug that caused part 2 to struggle with corrupt ActiGraph .gt3x files #972

--- a/R/g.getstarttime.R
+++ b/R/g.getstarttime.R
@@ -4,10 +4,8 @@ g.getstarttime = function(datafile, P, header, mon, dformat, desiredtz, configtz
   if (mon == MONITOR$AXIVITY && dformat == FORMAT$CWA) {
     starttime = P$data[1,1]
     starttime = as.POSIXlt(starttime, tz = desiredtz, origin = "1970-01-01")
-    starttime = POSIXtime2iso8601(starttime, tz = desiredtz)
   } else if (mon == MONITOR$GENEACTIV && dformat == FORMAT$BIN) {
     starttime = as.POSIXlt(P$data.out$time[1], tz = desiredtz, origin = "1970-01-01")
-    starttime = POSIXtime2iso8601(starttime, tz = desiredtz)
   } else if (dformat == FORMAT$CSV && (mon == MONITOR$ACTIGRAPH || mon == MONITOR$AXIVITY || mon == MONITOR$VERISENSE)) {
     if (mon == MONITOR$ACTIGRAPH || mon == MONITOR$VERISENSE) {
       tmph = read.csv(datafile, nrow = 8, skip = 1)


### PR DESCRIPTION
Fixes https://github.com/wadpac/GGIR/issues/1000

`g.getstarttime()`was returning timestamps as iso8601 strings for Axivity .cwa and GENEActiv .bin files, but it was returning timestamps as POSIX objects for all other input formats.

The only caller of `g.getstarttime()` is `get_starttime_weekday_meantemp_truncdata()`, [here](https://github.com/wadpac/GGIR/blob/master/R/get_starttime_weekday_meantemp_truncdata.R#L36), and it doesn't always handle  iso8601 format correctly. More specifically, **_if the timezone is GMT for GENEActiv .bin files_**, `starttime` value is [processed through as.POSIXlt()](https://github.com/wadpac/GGIR/blob/master/R/get_starttime_weekday_meantemp_truncdata.R#L57), but without specifying a custom format, which means that only the default formats are used to parse  `starttime`. The default formats are:
```
                      c("%Y-%m-%d %H:%M:%OS",
                          "%Y/%m/%d %H:%M:%OS",
                          "%Y-%m-%d %H:%M",
                          "%Y/%m/%d %H:%M",
                          "%Y-%m-%d",
                          "%Y/%m/%d")
```
And for iso8601 we'd need `"%Y-%m-%dT%H:%M:%S%z"` format.
With the default formats being used by as.POSIXlt(), the time part of the iso8601 timestamp was getting lost, only the date remaining. This resulted in the starting timestamp for M$metalong and M$metashort being truncated to 00:00:00, or midnight. 

I decided to fix this by modifying  g.getstarttime() to return POSIX timestamps for all sensor types.

An alternative solution would have been to change [line 57 of get_starttime_weekday_meantemp_truncdata.R](https://github.com/wadpac/GGIR/blob/master/R/get_starttime_weekday_meantemp_truncdata.R#L57) to use the right format, like this:
```
as.POSIXlt(starttime[1], format = "%Y-%m-%dT%H:%M:%S%z", tz = desiredtz)
```
But I think it's cleaner if `g.getstarttime()` returns the same type for every input.

I think `get_starttime_weekday_meantemp_truncdata.R` could use further cleanup, and I'll do that as I'm doing the general cleanup of part 1.

### The reason this bug only showed up when we upgraded to R 4.3.0: 
Before R 4.3.0, the object returned by `as.POSIXlt()` actually didn't contain an `attr("tzone")` (I'm not sure why), so the timezone value [here](https://github.com/wadpac/GGIR/blob/master/R/get_starttime_weekday_meantemp_truncdata.R#L48)  was always NULL, and [this condition](https://github.com/wadpac/GGIR/blob/master/R/get_starttime_weekday_meantemp_truncdata.R#L52) was never true, even if the system was in fact running in the GTM timezone. So [the code on line 57](https://github.com/wadpac/GGIR/blob/master/R/get_starttime_weekday_meantemp_truncdata.R#L57) never got executed.

Checklist before merging:

- [X] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Updated or expanded the documentation.
- [X] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
