### PR TITLE
Corrupt axivity

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # CHANGES IN GGIR VERSION 3.0-3
 
+- Part 2: Fix bug where data_quality_report.csv contained incorrect filehealth[...] values whenever some of these values were supposed to be blank #1003
+
 - Part 1: Fix bug where on machines with GMT timezone and R >= 4.3.0, for GENEActiv .bin files, the starting timestamps of M$metalong and M$metashort were truncated to midninght #1000
 
 # CHANGES IN GGIR VERSION 3.0-2

--- a/R/g.analyse.perfile.R
+++ b/R/g.analyse.perfile.R
@@ -72,13 +72,13 @@ g.analyse.perfile = function(I, C, metrics_nav,
     # them and logging the information.
     # Normally we do not expect issue with cwa files, but by logging the information
     # we will facilitate better insight into when this happens.
-    filesummary[vi:(vi + 6)] = c(file_summary$Dur_imputed, # total imputed
-                                 file_summary$Dur_chsum_failed, # checksum
-                                 file_summary$Dur_nonincremental, # nonincremental id between blocks
-                                 file_summary$Dur_freqissue_5_10, # bias 5-10%
-                                 file_summary$Dur_freqissue_10_20, # bias 10-20%
-                                 file_summary$Dur_freqissue_20_30, # bias 20-30%
-                                 file_summary$Dur_freqissue_30) # bias >30%
+    filesummary[vi:(vi + 6)] = c(ifelse(is.null(file_summary$Dur_imputed), " ", file_summary$Dur_imputed), # total imputed
+                                 ifelse(is.null(file_summary$Dur_chsum_failed), " ", file_summary$Dur_chsum_failed), # checksum
+                                 ifelse(is.null(file_summary$Dur_nonincremental), " ", file_summary$Dur_nonincremental), # nonincremental id between blocks
+                                 ifelse(is.null(file_summary$Dur_freqissue_5_10), " ", file_summary$Dur_freqissue_5_10), # bias 5-10%
+                                 ifelse(is.null(file_summary$Dur_freqissue_10_20), " ", file_summary$Dur_freqissue_10_20), # bias 10-20%
+                                 ifelse(is.null(file_summary$Dur_freqissue_20_30), " ", file_summary$Dur_freqissue_20_30), # bias 20-30%
+                                 ifelse(is.null(file_summary$Dur_freqissue_30), " ", file_summary$Dur_freqissue_30)) # bias >30%
     s_names[vi:(vi + 6)] = c("filehealth_totimp_min",
                              "filehealth_checksumfail_min",
                              "filehealth_niblockid_min", # non incremental block id
@@ -87,13 +87,13 @@ g.analyse.perfile = function(I, C, metrics_nav,
                              "filehealth_fbias2030_min",
                              "filehealth_fbias30_min")
     vi = vi + 7
-    filesummary[vi:(vi + 6)] = c( file_summary$Nblocks_imputed,
-                                  file_summary$Nblocks_chsum_failed,
-                                  file_summary$Nblocks_nonincremental,
-                                  file_summary$Nblock_freqissue_5_10,
-                                  file_summary$Nblock_freqissue_10_20,
-                                  file_summary$Nblock_freqissue_20_30,
-                                  file_summary$Nblock_freqissue_30)
+    filesummary[vi:(vi + 6)] = c( ifelse(is.null(file_summary$Nblocks_imputed), " ", file_summary$Nblocks_imputed),
+                                  ifelse(is.null(file_summary$Nblocks_chsum_failed), " ", file_summary$Nblocks_chsum_failed),
+                                  ifelse(is.null(file_summary$Nblocks_nonincremental), " ", file_summary$Nblocks_nonincremental),
+                                  ifelse(is.null(file_summary$Nblock_freqissue_5_10), " ", file_summary$Nblock_freqissue_5_10),
+                                  ifelse(is.null(file_summary$Nblock_freqissue_10_20), " ", file_summary$Nblock_freqissue_10_20),
+                                  ifelse(is.null(file_summary$Nblock_freqissue_20_30), " ", file_summary$Nblock_freqissue_20_30),
+                                  ifelse(is.null(file_summary$Nblock_freqissue_30), " ", file_summary$Nblock_freqissue_30))
     s_names[vi:(vi + 6)] = c("filehealth_totimp_N",
                              "filehealth_checksumfail_N",
                              "filehealth_niblockid_N",

--- a/R/g.applymetrics.R
+++ b/R/g.applymetrics.R
@@ -106,6 +106,7 @@ g.applymetrics = function(data, sf, ws3, metrics2do,
         xm[which(xm[1:S2check] == 0)] = xm[which(xm[1:S2check] != 0)[1]]
         # tail
         LN = length(xm)
+        S2check = min(LN-1, S2check)
         xm_tail = xm[(LN - S2check):LN]
         lastvalue = xm_tail[which(xm_tail != 0)][1]
         if (length(lastvalue) == 0) lastvalue = xm[which(xm != 0)][1]

--- a/R/g.getmeta.R
+++ b/R/g.getmeta.R
@@ -724,7 +724,14 @@ g.getmeta = function(datafile, params_metrics = c(), params_rawdata = c(),
   if (filecorrupt == FALSE & filetooshort == FALSE & filedoesnotholdday == FALSE) {
     cut = count:nrow(metashort)
     if (length(cut) > 1) {
-      metashort = as.matrix(metashort[-cut,])
+      tmp = metashort[-cut,]
+      # for a very small file, there could be just one row in metashort[-cut,], so it gets coerced to a vector.
+      # But what we actually need is a 1-row matrix. So we need to transpose it. 
+      if(is.vector(tmp)) { 
+        metashort = as.matrix(t(tmp))
+      } else {
+        metashort = as.matrix(tmp)
+      }
     }
     if (nrow(metashort) > 1) {
       starttime3 = round(as.numeric(starttime)) #numeric time but relative to the desiredtz
@@ -737,9 +744,16 @@ g.getmeta = function(datafile, params_metrics = c(), params_rawdata = c(),
       time6 = strftime(time6, format = "%Y-%m-%dT%H:%M:%S%z")
       metashort[,1] = as.character(time6)
     }
-    cut2 = (count2):nrow(metalong) # how it was
+    cut2 = count2:nrow(metalong)
     if (length(cut2) > 1) {
-      metalong = as.matrix(metalong[-cut2,])
+      tmp = metalong[-cut2,]
+      # for a very small file, there could be just one row in metalong[-cut2,], so it gets coerced to a vector.
+      # But what we actually need is a 1-row matrix. So we need to transpose it. 
+      if(is.vector(tmp)) { 
+        metalong = as.matrix(t(tmp))
+      } else {
+        metalong = as.matrix(tmp)
+      }
     }
     if (nrow(metalong) > 2) {
       starttime4 = round(as.numeric(starttime)) #numeric time but relative to the desiredtz

--- a/R/g.plot.R
+++ b/R/g.plot.R
@@ -10,8 +10,8 @@ g.plot = function(IMP, M, I, durplot) {
   if (length(fname2) > 1) fname = paste0(fname2[1], fname2[2])
   
   # Time variable and duration of recording
-  ws3 = M$windowsize[1]
-  ws2 = M$windowsize[2]
+  ws3 = M$windowsizes[1]
+  ws2 = M$windowsizes[2]
   n_ws2_perday = (1440*60) / ws2
   timeline = 1:nrow(M$metalong)
   durplot = durplot * n_ws2_perday


### PR DESCRIPTION
Fixes https://github.com/wadpac/GGIR/issues/1003

The main commit of this PR is https://github.com/wadpac/GGIR/commit/bdfbc6fcdf7d970bdf0bed63d3e92d6c41241fdb, changes to `g.analyse.perfile()`. The other 3 commits were minor things that I bumped into while debugging this issue on a very short file.

The problem was that the assignment on [lines 75-81](https://github.com/wadpac/GGIR/blob/master/R/g.analyse.perfile.R#L75-L81) assumed that all the file_summary$[...] variables have non-NULL values. However in practice only some of them might be set, which means that their concatenation is a vector of length < 7, resulting in incorrect value assignments.

Same for [lines 90-96](https://github.com/wadpac/GGIR/blob/master/R/g.analyse.perfile.R#L90-L96)

I addressed this by keeping the default " " value whenever a file_summary$[...] variable is NULL.

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [X] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Updated or expanded the documentation.
- [X] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
