### PR TITLE
add default value for variable extranoons

### DIFF
--- a/R/g.plot.R
+++ b/R/g.plot.R
@@ -134,6 +134,7 @@ g.plot = function(IMP, M, I, durplot) {
            x.intersp = x.intersp, ncol = 4, cex = 0.6, lwd = 0.6,
            bg = "white", box.col = "black")
   }
+  extranoons = c()
   if (length(mnights) > 0 & length(noons) > 0) {
     # axis 1: midnight, noon labels (including one extra day at the beginning and end)
     extramnights = c(mnights[1] - n_ws2_perday, mnights, max(mnights) + n_ws2_perday)


### PR DESCRIPTION
<!-- Describe your PR here -->
Fixes https://github.com/wadpac/GGIR/issues/1022

variable `extranoons` needs a default because otherwise it might get accessed [here](https://github.com/wadpac/GGIR/blob/c620d16164ae0a0d93766b141ca0ca6f59590532/R/g.plot.R#L199) even if the if condition of [this block](https://github.com/wadpac/GGIR/blob/c620d16164ae0a0d93766b141ca0ca6f59590532/R/g.plot.R#L137-L150) wasn't met and so `extranoons` was never defined.

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [X] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Updated or expanded the documentation.
- [ ] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
