### PR TITLE
Tidy up longitudinal axis detection and re-use when sensor is worn on the hip

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 - Facilitate handling of Sensewear xls file format with externally derived epoch data #974
 
+- Part 3: Now uses longitudinal axis detected in part 2 instead re-estimating this using a different approach #1024
+
+- Part 5: If sensor.location is hip then store and use longitudinal angle in part 5 time series instead of anglez #1024.
+
 # CHANGES IN GGIR VERSION 3.0-3
 
 - Part 2: Fix bug where data_quality_report.csv contained incorrect filehealth[...] values whenever some of these values were supposed to be blank #1003

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,9 +2,9 @@
 
 - Facilitate handling of Sensewear xls file format with externally derived epoch data #974
 
-- Part 3: Now uses longitudinal axis detected in part 2 instead re-estimating this using a different approach #1024
+- Part 3: If argument sensor.location is set to hip then use longitudinal axis detected in part 2 instead of estimating it again with a different algorithm #1024
 
-- Part 5: If sensor.location is hip then store and use longitudinal angle in part 5 time series instead of anglez #1024.
+- Part 5: If argument sensor.location is set to hip then store and use longitudinal angle and possible other angles in part 5 time series instead of anglez #1024.
 
 # CHANGES IN GGIR VERSION 3.0-3
 

--- a/R/check_params.R
+++ b/R/check_params.R
@@ -171,7 +171,8 @@ check_params = function(params_sleep = c(), params_metrics = c(),
   }
   
   if (length(params_general) > 0 & length(params_metrics) > 0 & length(params_sleep) > 0) {
-    if (params_general[["sensor.location"]] == "hip" &  params_sleep[["HASPT.algo"]] != "notused") {
+    if (params_general[["sensor.location"]] == "hip" &&
+        params_sleep[["HASPT.algo"]] %in% c("notused", "NotWorn") == FALSE) {
       if (params_metrics[["do.anglex"]] == FALSE | params_metrics[["do.angley"]] == FALSE | params_metrics[["do.anglez"]] == FALSE) {
         warning(paste0("\nWhen working with hip data all three angle metrics are needed,",
                        "so GGIR now auto-sets arguments do.anglex, do.angley, and do.anglez to TRUE."), call. = FALSE)

--- a/R/check_params.R
+++ b/R/check_params.R
@@ -332,10 +332,13 @@ check_params = function(params_sleep = c(), params_metrics = c(),
   
   if (length(params_general) > 0 & length(params_sleep) > 0) {
     if (params_sleep[["HASPT.algo"]] == "HorAngle") {
-      # Not everywhere in the code we check that both HASPT.algo is HorAngle and sensor.location is hip.
+      # Not everywhere in the code we check that when HASPT.algo is HorAngle, sensor.location is hip.
       # However, the underlying assumption is that they are linked. Even if a study would
       # use a waist or chest worn sensor we refer to it as hip as the orientation and need
-      # for detecting longitudinal axis the same. Therefore, for sensor.location to be hip
+      # for detecting longitudinal axis are the same. 
+      # Therefore, sensor.location should be forced to hip if HASPT.algo is HorAngle.
+      # On the other hand hip does not mean that HorAngle needs to be used, because
+      # when using count data from the hip the user may prefer the HASPT.algo=NotWorn.
       params_general[["sensor.location"]] = "hip"
     }
   }

--- a/R/check_params.R
+++ b/R/check_params.R
@@ -328,6 +328,17 @@ check_params = function(params_sleep = c(), params_metrics = c(),
               " and expand_tail_max_hours will be set to NULL.", call. = FALSE)
     }
   }
+  
+  if (length(params_general) > 0 & length(params_sleep) > 0) {
+    if (params_sleep[["HASPT.algo"]] == "HorAngle") {
+      # Not everywhere in the code we check that both HASPT.algo is HorAngle and sensor.location is hip.
+      # However, the underlying assumption is that they are linked. Even if a study would
+      # use a waist or chest worn sensor we refer to it as hip as the orientation and need
+      # for detecting longitudinal axis the same. Therefore, for sensor.location to be hip
+      params_general[["sensor.location"]] = "hip"
+    }
+  }
+  
   if (length(params_metrics) > 0 & length(params_general) > 0) {
     if (params_general[["dataFormat"]] %in% c("actiwatch_awd", "actiwatch_csv")) {
       if (params_metrics[["do.zcy"]] == FALSE | params_general[["acc.metric"]] != "ZCY") {

--- a/R/g.part3.R
+++ b/R/g.part3.R
@@ -75,14 +75,16 @@ g.part3 = function(metadatadir = c(), f0, f1, myfun = c(),
       load(paste(metadatadir, "/meta/basic/meta_", fnames[i], sep = ""))
       load(paste(metadatadir, "/meta/ms2.out/", fnames[i], sep = ""))
       if (M$filecorrupt == FALSE & M$filetooshort == FALSE) {
-        if (is.null(params_sleep[["longitudinal_axis"]])) {
-          # If user does not specify longitudinal axis explicitly then re-use
-          # estimated longitudinal axis from part 2
-          if (is.na(SUM$summary$if_hip_long_axis_id) == FALSE) {
-            params_sleep[["longitudinal_axis"]] = SUM$summary$if_hip_long_axis_id
-          } else {
-            # If not available default to 2
-            params_sleep[["longitudinal_axis"]] = 2
+        if (params_general[["sensor.location"]] == "hip") {
+          if (is.null(params_sleep[["longitudinal_axis"]])) {
+            # If user does not specify longitudinal axis explicitly then re-use
+            # estimated longitudinal axis from part 2
+            if (is.na(SUM$summary$if_hip_long_axis_id) == FALSE) {
+              params_sleep[["longitudinal_axis"]] = SUM$summary$if_hip_long_axis_id
+            } else {
+              # If not available default to 2
+              params_sleep[["longitudinal_axis"]] = 2
+            }
           }
         }
         SLE = g.sib.det(M, IMP, I, twd = c(-12,12),

--- a/R/g.part3.R
+++ b/R/g.part3.R
@@ -75,6 +75,16 @@ g.part3 = function(metadatadir = c(), f0, f1, myfun = c(),
       load(paste(metadatadir, "/meta/basic/meta_", fnames[i], sep = ""))
       load(paste(metadatadir, "/meta/ms2.out/", fnames[i], sep = ""))
       if (M$filecorrupt == FALSE & M$filetooshort == FALSE) {
+        if (is.null(params_sleep[["longitudinal_axis"]])) {
+          # If user does not specify longitudinal axis explicitly then re-use
+          # estimated longitudinal axis from part 2
+          if (is.na(SUM$summary$if_hip_long_axis_id) == FALSE) {
+            params_sleep[["longitudinal_axis"]] = SUM$summary$if_hip_long_axis_id
+          } else {
+            # If not available default to 2
+            params_sleep[["longitudinal_axis"]] = 2
+          }
+        }
         SLE = g.sib.det(M, IMP, I, twd = c(-12,12),
                         acc.metric = params_general[["acc.metric"]],
                         desiredtz = params_general[["desiredtz"]],

--- a/R/g.part5.R
+++ b/R/g.part5.R
@@ -174,6 +174,7 @@ g.part5 = function(datadir = c(), metadatadir = c(), f0=c(), f1=c(),
         M$metashort = correctOlderMilestoneData(M$metashort)
         M$metalong = correctOlderMilestoneData(M$metalong)
         # load output g.part3
+        longitudinal_axis = NULL # initialise var that is part of ms3.out
         load(paste0(metadatadir, "/meta/ms3.out/", fnames.ms3[i]))
         # remove expanded time so that it is not used for behavioral classification
         if (length(tail_expansion_log) != 0) {
@@ -188,8 +189,10 @@ g.part5 = function(datadir = c(), metadatadir = c(), f0=c(), f1=c(),
         #====================================
         # Initialise time series data.frame (ts) which will hold the time series
         # which forms the center of all part 5 activity
+        # note longitudinal_axis comes from loaded part 3 milestone data and not from params_sleep
+        
         ts = g.part5_initialise_ts(IMP, M, params_247, params_general,
-                                   longitudinal_axis = params_sleep[["longitudinal_axis"]])
+                                   longitudinal_axis = longitudinal_axis)
         Nts = nrow(ts)
         lightpeak_available = "lightpeak" %in% names(ts)
         

--- a/R/g.part5.R
+++ b/R/g.part5.R
@@ -188,7 +188,8 @@ g.part5 = function(datadir = c(), metadatadir = c(), f0=c(), f1=c(),
         #====================================
         # Initialise time series data.frame (ts) which will hold the time series
         # which forms the center of all part 5 activity
-        ts = g.part5_initialise_ts(IMP, M, params_247, params_general)
+        ts = g.part5_initialise_ts(IMP, M, params_247, params_general,
+                                   longitudinal_axis = params_sleep[["longitudinal_axis"]])
         Nts = nrow(ts)
         lightpeak_available = "lightpeak" %in% names(ts)
         
@@ -571,9 +572,13 @@ g.part5 = function(datadir = c(), metadatadir = c(), f0=c(), f1=c(),
                     } else {
                       lightpeak_col = NULL
                     }
+                    angle_col = grep(pattern = "angle", x = names(ts), value = TRUE)
+                    if (length(angle_col) == 0) {
+                      angle_col = NULL
+                    }
                     g.part5.savetimeseries(ts = ts[, c("time", "ACC", "diur", "nonwear",
                                                        "guider", "window", napNonwear_col,
-                                                       lightpeak_col)],
+                                                       lightpeak_col, angle_col)],
                                            LEVELS = LEVELS,
                                            desiredtz = params_general[["desiredtz"]],
                                            rawlevels_fname = rawlevels_fname,

--- a/R/g.part5.R
+++ b/R/g.part5.R
@@ -224,9 +224,7 @@ g.part5 = function(datadir = c(), metadatadir = c(), f0=c(), f1=c(),
             S$sib.end.time[replaceLastWakeup] = ts$time[nrow(ts)]
           }
         }
-        
         for (sibDef in def) { # loop through sleep definitions (defined by angle and time threshold in g.part3)
-          
           ws3new = ws3 # reset wse3new, because if part5_agg2_60seconds is TRUE then this will have been change in the previous iteration of the loop
           if (params_general[["part5_agg2_60seconds"]] == TRUE) {
             ts = ts_backup
@@ -281,7 +279,7 @@ g.part5 = function(datadir = c(), metadatadir = c(), f0=c(), f1=c(),
               ts$time_num = floor(as.numeric(ts$time) / 60) * 60
               
               # only include angle if angle is present
-              angleColName = ifelse("angle" %in% names(ts), yes = "angle", no = NULL)
+              angleColName = grep(pattern = "angle", x = names(ts), value = TRUE)
               if (lightpeak_available == TRUE) {
                 ts = aggregate(ts[, c("ACC","sibdetection", "diur", "nonwear", angleColName, "lightpeak", "lightpeak_imputationcode")],
                                by = list(ts$time_num), FUN = function(x) mean(x))

--- a/R/g.part5_initialise_ts.R
+++ b/R/g.part5_initialise_ts.R
@@ -1,16 +1,34 @@
-g.part5_initialise_ts = function(IMP, M, params_247, params_general) {
-  
+g.part5_initialise_ts = function(IMP, M, params_247, params_general, longitudinal_axis = c()) {
   # extract key variables from the mile-stone data: time, acceleration and elevation angle
   # note that this is imputed ACCELERATION because we use this for describing behaviour:
   scale = ifelse(test = grepl("^Brond|^Neishabouri|^ZC|^ExtAct", params_general[["acc.metric"]]), yes = 1, no = 1000)
-  # if (length(which(names(IMP$metashort) == "anglez")) == 0 & verbose == TRUE) {
-  #   cat("Warning: anglez not extracted. Please check that do.anglez == TRUE")
-  # }
-  
-  if ("anglez" %in% names(IMP$metashort)) {
+
+  # Use anglez by default or longitudinal axis if specified when sensor is worn on hip
+  if (is.null(longitudinal_axis)) {
+    angleName = "anglez"
+  } else if (longitudinal_axis == 1) {
+    angleName = "anglex"
+  } else if (longitudinal_axis == 2) {
+    angleName = "angley"
+  } else if (longitudinal_axis == 3) {
+    angleName = "anglez"
+  }
+  if (angleName %in% names(IMP$metashort)) {
     ts = data.frame(time = IMP$metashort[,1], ACC = IMP$metashort[,params_general[["acc.metric"]]] * scale,
                     guider = rep("unknown", nrow(IMP$metashort)),
-                    angle = as.numeric(as.matrix(IMP$metashort[,which(names(IMP$metashort) == "anglez")])))
+                    angle = as.numeric(as.matrix(IMP$metashort[,which(names(IMP$metashort) == angleName)])))
+    # also store other angles if available:
+    for (otherAngle in c("anglex", "angley", "anglez")) {
+      if (otherAngle %in% names(IMP$metashort) == TRUE && angleName != otherAngle) {
+        if (otherAngle == "anglex") {
+          ts$anglex = as.numeric(as.matrix(IMP$metashort[, otherAngle]))
+        } else if (otherAngle == "angley") {
+          ts$angley = as.numeric(as.matrix(IMP$metashort[, otherAngle]))
+        } else if (otherAngle == "anglez") {
+          ts$anglez = as.numeric(as.matrix(IMP$metashort[, otherAngle]))
+        }
+      }
+    }
   } else {
     ts = data.frame(time = IMP$metashort[,1], ACC = IMP$metashort[,params_general[["acc.metric"]]] * scale,
                     guider = rep("unknown", nrow(IMP$metashort)))

--- a/R/g.part5_initialise_ts.R
+++ b/R/g.part5_initialise_ts.R
@@ -8,13 +8,13 @@ g.part5_initialise_ts = function(IMP, M, params_247, params_general, longitudina
   if (params_general[["sensor.location"]] != "hip") {
     longitudinal_axis = NULL
   }
-  if (is.null(longitudinal_axis)) {
+  if (is.null(longitudinal_axis) && "anglez" %in% names(IMP$metashort)) {
     angleName = "anglez"
-  } else if (longitudinal_axis == 1) {
+  } else if (longitudinal_axis == 1 && "anglex" %in% names(IMP$metashort)) {
     angleName = "anglex"
-  } else if (longitudinal_axis == 2) {
+  } else if (longitudinal_axis == 2 && "anglex" %in% names(IMP$metashort)) {
     angleName = "angley"
-  } else if (longitudinal_axis == 3) {
+  } else if (longitudinal_axis == 3 && "anglex" %in% names(IMP$metashort)) {
     angleName = "anglez"
   }
   if (angleName %in% names(IMP$metashort)) {

--- a/R/g.part5_initialise_ts.R
+++ b/R/g.part5_initialise_ts.R
@@ -4,6 +4,10 @@ g.part5_initialise_ts = function(IMP, M, params_247, params_general, longitudina
   scale = ifelse(test = grepl("^Brond|^Neishabouri|^ZC|^ExtAct", params_general[["acc.metric"]]), yes = 1, no = 1000)
 
   # Use anglez by default or longitudinal axis if specified when sensor is worn on hip
+  
+  if (params_general[["sensor.location"]] != "hip") {
+    longitudinal_axis = NULL
+  }
   if (is.null(longitudinal_axis)) {
     angleName = "anglez"
   } else if (longitudinal_axis == 1) {

--- a/R/g.sib.det.R
+++ b/R/g.sib.det.R
@@ -287,7 +287,15 @@ g.sib.det = function(M, IMP, I, twd = c(-12, 12),
             if (newqqq2 > length(anglez)) newqqq2 = length(anglez)
             # only try to extract SPT again if it is possible to extract a window of more than 23 hour
             if (newqqq2 < length(anglez) & (newqqq2 - newqqq1) > (23*(3600/ws3)) ) {
-              spt_estimate_tmp = HASPT(anglez[newqqq1:newqqq2], ws3 = ws3,
+              if (do.HASPT.hip == TRUE & params_sleep[["HASPT.algo"]] != "NotWorn") {
+                tmpANGLE = anglez[newqqq1:newqqq2]
+                if (params_sleep[["longitudinal_axis"]] == 1) {
+                  tmpANGLE = anglex[newqqq1:newqqq2]
+                } else if (params_sleep[["longitudinal_axis"]] == 2) {
+                  tmpANGLE = angley[newqqq1:newqqq2]
+                }
+              }
+              spt_estimate_tmp = HASPT(angle = tmpANGLE, ws3 = ws3,
                                        constrain2range = params_sleep[["constrain2range"]],
                                        perc = perc, spt_threshold = spt_threshold, sptblocksize = sptblocksize,
                                        spt_max_gap = spt_max_gap,
@@ -307,7 +315,7 @@ g.sib.det = function(M, IMP, I, twd = c(-12, 12),
             } else {
               daysleep_offset  = 0
             }
-          } 
+          }
           if (qqq1 == 1) {  # only use startTimeRecord if the start of the block send into SPTE was after noon
             startTimeRecord = unlist(iso8601chartime2POSIX(IMP$metashort$timestamp[1], tz = desiredtz))
             startTimeRecord = sum(as.numeric(startTimeRecord[c("hour", "min", "sec")]) / c(1, 60, 3600))

--- a/R/g.sib.det.R
+++ b/R/g.sib.det.R
@@ -259,20 +259,6 @@ g.sib.det = function(M, IMP, I, twd = c(-12, 12),
         daysleep_offset = 0
         if (do.HASPT.hip == TRUE & params_sleep[["HASPT.algo"]] != "NotWorn") {
           params_sleep[["HASPT.algo"]] = "HorAngle"
-          if (length(params_sleep[["longitudinal_axis"]]) == 0) { #only estimate long axis if not provided by user
-            count_updown = matrix(0,3,2)
-            count_updown[1,] = sort(c(length(which(anglex[qqq1:qqq2] < 45)), length(which(anglex[qqq1:qqq2] > 45))))
-            count_updown[2,] = sort(c(length(which(angley[qqq1:qqq2] < 45)), length(which(angley[qqq1:qqq2] > 45))))
-            count_updown[3,] = sort(c(length(which(anglez[qqq1:qqq2] < 45)), length(which(anglez[qqq1:qqq2] > 45))))
-            ratio_updown = count_updown[,1] / count_updown[,2]
-            validval = which(abs(ratio_updown) != Inf & is.na(ratio_updown) == FALSE)
-            if (length(validval) > 0) {
-              ratio_updown[validval] = ratio_updown
-              params_sleep[["longitudinal_axis"]] = which.max(ratio_updown)
-            } else {
-              params_sleep[["longitudinal_axis"]] = 2 # y-axis as fall back option if detection does not work
-            }
-          }
           if (params_sleep[["longitudinal_axis"]] == 1) {
             tmpANGLE = anglex[qqq1:qqq2]
           } else if (params_sleep[["longitudinal_axis"]] == 2) {

--- a/man/GGIR.Rd
+++ b/man/GGIR.Rd
@@ -1135,7 +1135,8 @@ GGIR(mode = 1:5,
       \item{longitudinal_axis}{
         Integer (default = NULL).
         To indicate which axis is the longitudinal axis.
-        If not provided, the function will estimate longitudinal axis. Only used when
+        If not provided, the function will estimate longitudinal axis as the axis
+        with the highest 24 hour lagged autocorrelation. Only used when
         \code{sensor.location = "hip"} or \code{HASPT.algo = "HorAngle"}.}
 
       \item{anglethreshold}{

--- a/man/g.part5_initialise_ts.Rd
+++ b/man/g.part5_initialise_ts.Rd
@@ -7,7 +7,7 @@
   Initialise time series dataframe ts, part of \link{g.part5}.
 }
 \usage{
-  g.part5_initialise_ts(IMP, M, params_247, params_general)
+  g.part5_initialise_ts(IMP, M, params_247, params_general, longitudinal_axis = c())
 }
 \arguments{
   \item{IMP}{
@@ -21,6 +21,10 @@
   }
   \item{params_general}{
     See \link{GGIR} 
+  }
+  \item{longitudinal_axis}{
+    As passed on from g.part5, which could be specified by user or estimated
+    from hip data in part 2. 
   }
 }
 \value{

--- a/tests/testthat/test_chainof5parts.R
+++ b/tests/testthat/test_chainof5parts.R
@@ -227,7 +227,7 @@ test_that("chainof5parts", {
   expect_true(file.exists(rn2[1]))
   TSFILE = read.csv(rn2[1])
   expect_that(nrow(TSFILE),equals(1150))
-  expect_equal(ncol(TSFILE), 11)
+  expect_equal(ncol(TSFILE), 12)
   expect_equal(length(unique(TSFILE$class_id)), 10)
   #GGIR
   suppressWarnings(GGIR(mode = c(2,3,4,5), datadir = fn, outputdir = getwd(),

--- a/tests/testthat/test_recordingEndSleepHour.R
+++ b/tests/testthat/test_recordingEndSleepHour.R
@@ -13,7 +13,6 @@ test_that("recordingEndSleepHour works as expected", {
        visualreport = FALSE, do.report = c(), verbose = FALSE)
   rn = dir("output_test/meta/basic/", full.names = TRUE)
   load(rn[1])
-  nrow(M$metashort)
   expect_true(nrow(M$metashort) == 43020)
   # expect_true(M$metashort$timestamp[nrow(M$metashort)] == "2016-06-25T20:44:55+0200")
   

--- a/tests/testthat/test_recordingEndSleepHour.R
+++ b/tests/testthat/test_recordingEndSleepHour.R
@@ -42,7 +42,7 @@ test_that("recordingEndSleepHour works as expected", {
   # No warning, this should work
   GGIR(datadir = fn, outputdir = getwd(),
        studyname = "test", overwrite = TRUE, desiredtz = tz,
-       recordingEndSleepHour = 20,
+       recordingEndSleepHour = 20, do.anglex = TRUE, do.angley = TRUE,
        minimum_MM_length.part5 = 6, verbose = FALSE)
   rn = dir("output_test/meta/basic/", full.names = TRUE)
   load(rn[1])
@@ -56,11 +56,68 @@ test_that("recordingEndSleepHour works as expected", {
   p4full = read.csv("output_test/results/QC/part4_nightsummary_sleep_full.csv")
   expect_equal(nrow(p4), 2) # Night 3 is not in the part 4 reports
   expect_equal(nrow(p4full), 2) # Night 3 is not in the part 4 reports
+  expect_equal(sum(p4$sleeponset), 41.848)
+  expect_equal(sum(p4$wakeup), 62.336)
+  expect_equal(sum(p4$guider_onset), 41.771)
+  expect_equal(sum(p4$guider_wakeup), 62.26)
+  expect_equal(sum(p4$number_sib_sleepperiod), 73)
+  expect_true(all(is.na(p4$longitudinal_axis)))
   
   p5 = read.csv("output_test/results/part5_daysummary_MM_L40M100V400_T5A5.csv")
   expect_equal(nrow(p5), 3) # expanded day appears in MM report
   expect_true(p5$dur_day_spt_min[nrow(p5)] < 23*60) # but expanded time is not accounted for in estimates
+  
+  #================================================================
+  # Redo but now with sensor.location="hip", HASPT.algo = "HorAngle", and all three angles
+  # we do not expect sleep to end in last hour here. Further, this allows for improving
+  # coverage for the hip-attachment scenario for which we do not have specific unit
+  # tests yet. By re-using the test file from this unit test we do not have to create it 
+  # twice.
 
+  # No warning, this should work
+  GGIR(datadir = fn, outputdir = getwd(),
+       studyname = "test", overwrite = TRUE, desiredtz = tz,
+       recordingEndSleepHour = 20, do.anglex = TRUE, do.angley = TRUE,
+       save_ms5rawlevels = TRUE, sensor.location = "hip", HASPT.algo = "HorAngle",
+       save_ms5raw_format = "RData", sleepwindowType = "TimeInBed",
+       minimum_MM_length.part5 = 6, verbose = FALSE)
+  rn = dir("output_test/meta/basic/", full.names = TRUE)
+  load(rn[1])
+  expect_true(nrow(M$metashort) > 43020) # metashort is expanded
+  
+  # expanded time is not reports
+  p2 = read.csv("output_test/results/part2_daysummary.csv")
+  expect_equal(p2$N.hours[nrow(p2)], 20.75)  # N hours in last day does not include the expanded time
+  
+  p4 = read.csv("output_test/results/part4_nightsummary_sleep_cleaned.csv")
+  p4full = read.csv("output_test/results/QC/part4_nightsummary_sleep_full.csv")
+  expect_equal(nrow(p4), 2) # Night 3 is not in the part 4 reports
+  expect_equal(nrow(p4full), 2) # Night 3 is not in the part 4 reports
+  expect_equal(sum(p4$sleeponset), 41.831)
+  expect_equal(sum(p4$wakeup), 57.917)
+  expect_equal(sum(p4$guider_inbedStart), 41.42)
+  expect_equal(sum(p4$guider_inbedEnd), 57.961)
+  expect_equal(sum(p4$number_sib_sleepperiod), 13)
+  expect_equal(sum(p4$sleepefficiency), 0.422)
+  expect_equal(sum(p4$longitudinal_axis), 6)
+  
+  p5 = read.csv("output_test/results/part5_daysummary_MM_L40M100V400_T5A5.csv")
+  expect_equal(nrow(p5), 2) # expanded day appears in MM report
+  expect_true(p5$dur_day_spt_min[nrow(p5)] < 23*60) # but expanded time is not accounted for in estimates
+  
+  # test that time series output has all expected columns including the multiple angle columns
+  # this does not align with the focus on sleep in this unit test, but if we have to 
+  # write a separate unit test for it then the functions needs to be run twice.
+  ts_file = "output_test/meta/ms5.outraw/40_100_400/123A_testaccfile_T5A5.RData"
+  expect_true(file.exists(ts_file))
+  load(ts_file)
+  expect_true(all(c("timenum", "ACC", "SleepPeriodTime", "invalidepoch",
+                    "guider", "window", "angle", "anglex", "angley",
+                    "class_id", "invalid_fullwindow", "invalid_sleepperiod",
+                    "invalid_wakinghours", "timestamp") %in% names(mdat)))
+  
+  
+  
   if (file.exists("output_test"))  unlink("output_test", recursive = TRUE)
   if (file.exists(fn)) file.remove(fn)
 })

--- a/vignettes/GGIR.Rmd
+++ b/vignettes/GGIR.Rmd
@@ -1665,6 +1665,7 @@ correspond to the date of analysis.
 | invalid_sleepperiod  | Fraction of SPT within the current window that represents invalid data.          |
 | invalid_wakinghours  | Fraction of SPT within the current window that represents invalid data.          |
 | timestamp      | Time stamp derived from converting the column timenum, only available if `save_ms5raw_format = TRUE`.|
+| angle | anglez by default. If `sensor.location = "hip"` or `HASPT.algo = "HorAngle"` then angle represents the angle for the longitudinal axis as provided by argument longitudinal_axis or estimated if no angle was provided. If more angles were extracted in part 1 then these will be add with their letter appended. }
 
 To familiarize yourself with how the variables it can be helpful to plot
 them yourself.


### PR DESCRIPTION
<!-- Describe your PR here -->

Fixes #1024
This PR tidies up the way longitudinal axis as extracted in part 2 when `sensor.location == "hip"` is used in part 3, 4, 5. 

More specifically:
- Part 3 no longer re-estimates the longitudinal axis but re-uses the estimate as stored by part 2.
- Part 3 now also uses the longitudinal axis when estimating SPT for a daysleeper (shiftworker). Previously this defaulted to anglez, which for hip attachment is not desired as we need longitudinal axis instead.
- Part 5 now uses that longitudinal_axis as stored by part 3 when sensor.location==hip instead of falling back on default anglez.
- If multiple angles were extract in part 1 then part 5 stores all angles to the time series output. Note that longitudinal axis is still stored as "angle" whereas the other two new axis are stored with their letter appended, e.g. anglex and angley. In that way the rest of the code keeps consistent.

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [x] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [x] Updated or expanded the documentation.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
