### PR TITLE
Issue 1010 in g.convert.part2.long(), don't evaluate columns that aren't there

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# CHANGES IN GGIR VERSION 3.0-8
+
+- Part 2: Fixed issue where g.convert.part2.long() was throwing an error when attempting to process data where every day had insufficient number of valid hours #1070.
+
 # CHANGES IN GGIR VERSION 3.0-7
 
 - Part 1:

--- a/R/g.conv.actlog.R
+++ b/R/g.conv.actlog.R
@@ -37,7 +37,7 @@ g.conv.actlog = function(qwindow, qwindow_dateformat="%d-%m-%Y", epochSize = 5) 
   dim(actlog_vec) = c(nrow(actlog),ncol(actlog))
   # create new qwindow object to archive all extracted information
   qwindow = data.frame(ID = rep(0,Ndates), date =  rep("",Ndates))
-  qwindow$qwindow_times = qwindow$qwindow_values = qwindow$qwindow_numes = c()
+  qwindow$qwindow_times = qwindow$qwindow_values = qwindow$qwindow_names = c()
   cnt = 1
   for (i in 1:nrow(actlog)) { # loop over rows in activity log = recordings
     datei = which(actlog_vec[i,] == TRUE)

--- a/R/g.convert.part2.long.R
+++ b/R/g.convert.part2.long.R
@@ -160,10 +160,13 @@ g.convert.part2.long = function(daySUMMARY) {
     }
   }
   df = df[, -which(colnames(df) %in% c("qwindow_names"))]
-  redundant_rows = which(df$N_valid_hours_in_window == "" & df$N_hours_in_window  == "" & 
-                           apply(df[16:ncol(df)],1,FUN=function(x) any(x=="")) &
-                           df[,ncol(df)-1] == "" & df[,ncol(df)] == "" | df$qwindow_timestamps =="not_calculated")
-  if (length(redundant_rows) > 0) df = df[-redundant_rows,]
+  
+  first_feature_col = which(colnames(df) == "timesegment2") + 1
+  if (first_feature_col <= ncol(df)) {
+    redundant_rows = which(df$N_valid_hours_in_window == "" & df$N_hours_in_window  == "" & 
+                             apply(df[first_feature_col:ncol(df)], 1, FUN = function(x) all(x=="")) | df$qwindow_timestamps =="not_calculated")
+    if (length(redundant_rows) > 0) df = df[-redundant_rows,]
+  }
   colnames(df)[which(colnames(df) == "timesegment2")] = "qwindow_name"
   if (skip.qwindow_name.conversion == FALSE) {
     if (qwindownumeric == FALSE) {

--- a/R/g.convert.part2.long.R
+++ b/R/g.convert.part2.long.R
@@ -21,67 +21,57 @@ g.convert.part2.long = function(daySUMMARY) {
   convert2minutes = function(x) {
     x = as.numeric(x)
     hour = floor(x)
-    minutes = round((x-floor(x)) * 60)
-    if (nchar(minutes) == 1) minutes = paste0("0",minutes)
-    if (nchar(hour) == 1) minutes = paste0("0",hour)
-    time = paste0(hour,":",minutes)
+    minutes = round((x - floor(x)) * 60)
+    if (nchar(minutes) == 1) minutes = paste0("0", minutes)
+    if (nchar(hour) == 1) minutes = paste0("0", hour)
+    time = paste0(hour, ":", minutes)
     return(time)
   }
   
   convert2clocktime = function(x) {
-    x2 = unlist(strsplit(x,"hr"))
+    x2 = unlist(strsplit(x, "hr"))
     if (length(x2) > 0) {
-      x3 = as.numeric(unlist(strsplit(x2[1],"-")))
+      x3 = as.numeric(unlist(strsplit(x2[1], "-")))
       myfun = function(y) {
         for (i in 1:length(y)) {
           if (y[i] < 10) {
-            y[i] = paste0(0,y[i])
+            y[i] = paste0(0, y[i])
           } else {
             y[i] = as.character(y[i])
           }
         }
         return(y)
       }
-      x4 = paste0(paste0(myfun(x3),":00"), collapse="-")
+      x4 = paste0(paste0(myfun(x3), ":00"), collapse = "-")
     } else {
       x4 = ""
     }
     return(x4)
   }
-  
-  # getvar = function(x) {
-    # tmp = unlist(strsplit(as.character(x),"_"))
-    # return(paste0(tmp[1:(length(tmp)-1)],collapse="_"))
-  # }
-  
-  gettimeseg = function(x) {
-    tmp = unlist(strsplit(as.character(x),"_"))
-    tmp2 = unlist(strsplit(tmp[length(tmp)],"[.]"))[1]
-    return(tmp2)
-  }
   #------------------------------
   # main code
   # replace spaces by underscores, because melt function struggles with it later on
-  colnames(daySUMMARY) = gsub(pattern = " ",replacement = "_", x = colnames(daySUMMARY))
+  colnames(daySUMMARY) = gsub(pattern = " ",
+                              replacement = "_",
+                              x = colnames(daySUMMARY))
   cn = names(daySUMMARY)
   # extract windowsegment specification from variable name
   tt = sapply(cn, FUN = extractlastpart)
-  id.vars = colnames(tt[,which(tt[2,] == "")]) # identify other variables, including ID
+  id.vars = colnames(tt[, which(tt[2,] == "")]) # identify other variables, including ID
   daySUMMARY = data.table::as.data.table(daySUMMARY)
   # turn into long format with melt, this will make it too long, so further
   # down we will move key variables to wide again
   daySUMMARY2 = data.table::melt(daySUMMARY, id.vars = id.vars, 
-                                 measure.vars = colnames(tt)[which(tt[2,] != "")])
+                                 measure.vars = colnames(tt)[which(tt[2, ] != "")])
   # extract variable names
-  # daySUMMARY2$variable2 = sapply(daySUMMARY2$variable, FUN = getvar)
   daySUMMARY2$variable2 = sub("_[^_]+$", "", daySUMMARY2$variable)
   # extract time segment names
-  # daySUMMARY2$timesegment2 = sapply(daySUMMARY2$variable, FUN = gettimeseg)
   daySUMMARY2$timesegment2 = sub("^.*_", "", daySUMMARY2$variable)
   daySUMMARY2 = as.data.frame(daySUMMARY2)
   # tidy up
   rem = which(colnames(daySUMMARY2) == "variable")
-  daySUMMARY2 = daySUMMARY2[, -rem] # It is a data.table object so column removal works different
+  # It is a data.table object so column removal works different
+  daySUMMARY2 = daySUMMARY2[, -rem]
   id.vars = c(id.vars, "timesegment2")
   cnt = 1
   # long format that is undersirable is now moved back to wide format
@@ -92,7 +82,9 @@ g.convert.part2.long = function(daySUMMARY) {
       rem = which(colnames(df) == "variable2")
       df = df[,-rem]
     } else {
-      df = base::merge(df, daySUMMARY2[which(daySUMMARY2$variable2 == i),], by = id.vars, all.x = T, sort = F)
+      df = base::merge(x = df,
+                       y = daySUMMARY2[which(daySUMMARY2$variable2 == i),],
+                       by = id.vars, all.x = T, sort = F)
       colnames(df)[which(colnames(df) == "value")] = i
       rem = which(colnames(df) == "variable2")
       df = df[, -rem]
@@ -107,9 +99,9 @@ g.convert.part2.long = function(daySUMMARY) {
   df$N_valid_hours_in_window[which(df$timesegment2 == "0-24hr")] = ""
   df$N_hours_in_window[which(df$timesegment2 == "0-24hr")] = ""
   # re-order columns to be more logical
-  col2move = which(colnames(df) %in% c("N_valid_hours_in_window","N_hours_in_window") == TRUE)
-  col2NH = which(colnames(df) %in% c("N_valid_hours","N_hours") == TRUE)
-  df = df[,c(1:max(col2NH),col2move,(max(col2NH)+1):(ncol(df)-2))]
+  col2move = which(colnames(df) %in% c("N_valid_hours_in_window", "N_hours_in_window") == TRUE)
+  col2NH = which(colnames(df) %in% c("N_valid_hours", "N_hours") == TRUE)
+  df = df[,c(1:max(col2NH), col2move, (max(col2NH) + 1):(ncol(df) - 2))]
   # re-place underscore to hyphen
   skip.qwindow_name.conversion = FALSE
   if (all(df$qwindow_timestamps == df$qwindow_names)) { # using qwindow vector without diary
@@ -124,28 +116,29 @@ g.convert.part2.long = function(daySUMMARY) {
   # the segment names are not correct yet, rename them
   for (ji in unique(df$ID)) {
     for (hi in unique(df$calendar_date[which(df$ID == ji)])) {
-      df_tmp = df[which(df$ID == ji & df$calendar_date == hi),c("qwindow_timestamps", "qwindow_names",
-                                                                "timesegment2")]
+      df_tmp = df[which(df$ID == ji & df$calendar_date == hi),
+                  c("qwindow_timestamps", "qwindow_names", "timesegment2")]
       tms = unlist(strsplit(df_tmp$qwindow_timestamps[1],"_"))
       nms = unlist(strsplit(df_tmp$qwindow_names[1],"_"))
       namekey = matrix("",length(tms),2)
       for (gi in 1:(length(tms))) {
         if (gi == 1) {
-          options(warn=-1)
+          options(warn = -1)
           qwindownumeric = !is.na(as.numeric(tms[1]))
-          options(warn=0)
+          options(warn = 0)
           if (qwindownumeric == FALSE) {
-            namekey[1,] = c("00:00-24:00","0-24hr")
+            namekey[1,] = c("00:00-24:00", "0-24hr")
           } else { # if qwindow is numeric then store as such to be consistent with other output
-            namekey[1,] = c("00:00-24:00","0-24hr")
+            namekey[1, ] = c("00:00-24:00", "0-24hr")
           }
         } else {
           if (qwindownumeric == FALSE) {
-            namekey[gi,] = c(paste0(tms[gi-1], "-", tms[gi]),paste0(nms[gi-1], "-", nms[gi],"hr"))
+            namekey[gi, ] = c(paste0(tms[gi - 1], "-", tms[gi]),
+                              paste0(nms[gi - 1], "-", nms[gi], "hr"))
           } else {
-            
-            namekey[gi,] = c(paste0(convert2minutes(tms[gi-1]), "-", convert2minutes(tms[gi])), 
-                             paste0(nms[gi-1], "-", nms[gi],"hr"))
+            namekey[gi, ] = c(paste0(convert2minutes(tms[gi - 1]),
+                                     "-", convert2minutes(tms[gi])), 
+                              paste0(nms[gi - 1], "-", nms[gi],"hr"))
           }
         }
         qwt_index = which(as.character(df_tmp$timesegment2) == namekey[gi,2])
@@ -155,16 +148,19 @@ g.convert.part2.long = function(daySUMMARY) {
           df_tmp$qwindow_timestamps[qwt_index] = "not_calculated"
         }
       }
-      df[which(df$ID == ji & df$calendar_date == hi),c("qwindow_timestamps", "qwindow_names",
-                                                       "timesegment2")] = df_tmp
+      df[which(df$ID == ji & df$calendar_date == hi),
+         c("qwindow_timestamps", "qwindow_names", "timesegment2")] = df_tmp
     }
   }
   df = df[, -which(colnames(df) %in% c("qwindow_names"))]
   
   first_feature_col = which(colnames(df) == "timesegment2") + 1
   if (first_feature_col <= ncol(df)) {
-    redundant_rows = which(df$N_valid_hours_in_window == "" & df$N_hours_in_window  == "" & 
-                             apply(df[first_feature_col:ncol(df)], 1, FUN = function(x) all(x=="")) | df$qwindow_timestamps =="not_calculated")
+    emptystring = function(x) all(x == "")
+    redundant_rows = which(df$N_valid_hours_in_window == "" &
+                             df$N_hours_in_window  == "" & 
+                             apply(df[first_feature_col:ncol(df)], 1, FUN = emptystring) |
+                             df$qwindow_timestamps == "not_calculated")
     if (length(redundant_rows) > 0) df = df[-redundant_rows,]
   }
   colnames(df)[which(colnames(df) == "timesegment2")] = "qwindow_name"
@@ -172,7 +168,8 @@ g.convert.part2.long = function(daySUMMARY) {
     if (qwindownumeric == FALSE) {
       df$qwindow_name[which(df$qwindow_name == "0-24hr")] = "daystart-dayendhr"
     }
-    df$qwindow_name = substr(df$qwindow_name,1,nchar(df$qwindow_name)-2) # remove last two characters, because they are hr
+    # remove last two characters, because they are hr
+    df$qwindow_name = substr(df$qwindow_name, 1, nchar(df$qwindow_name) - 2)
   }
   return(df)
 }


### PR DESCRIPTION
<!-- Describe your PR here -->

Fixes #1010

When data has no days with enough valid hours, g.analyse.perday() [doesn't add per-day-segment features to daysummary](https://github.com/wadpac/GGIR/blob/75f67093d49e440da08fc26999603576d4b17716/R/g.analyse.perday.R#L273)

Later in g.convert.part2.long(), we were attempting to [validate these features](https://github.com/wadpac/GGIR/blob/75f67093d49e440da08fc26999603576d4b17716/R/g.convert.part2.long.R#L164) and this caused the method to crash.

To fix this, I changed the code in g.convert.part2.long() to not evaluate columns that aren't there.

I also cleaned up part of the condition. It looked to me that we want `FUN = function(x) all(x==""))`, not `FUN = function(x) any(x==""))`. And also checking for `df[,ncol(df)-1] == "" & df[,ncol(df)] == ""` doesn't seem necessary because we've already just checked columns up to `ncol(df)`.  
I would appreciate it if someone could check if this makes sense.

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [X] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [X] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [ ] Documentation updated:
  - [ ] Function documentation
  - [ ] Chapter vignettes for GitHub IO
  - [ ] Vignettes for CRAN
- [X] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [X] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
- [ ] GGIR parameters were added/removed. If yes, please also complete checklist below.

If NEW GGIR parameter(s) were added then these NEW parameter(s) are :
- [ ] documented in `man/GGIR.Rd`
- [ ] included with a default in `R/load_params.R`
- [ ] included with value class check in `R/check_params.R`
- [ ] included in table of `vignettes/GGIRParameters.Rmd` with references to the GGIR parts the parameter is used in.
- [ ] mentioned in NEWS.Rd as NEW parameter

If GGIR parameter(s) were deprecated these parameter(s) are:
- [ ] documented as deprecated in `man/GGIR.Rd`
- [ ] removed from `R/load_params.R`
- [ ] removed from `R/check_params.R`
- [ ] removed from table in `vignettes/GGIRParameters.Rmd`
- [ ] mentioned as deprecated parameter in NEWS.Rd
- [ ] added to the list in `R/extract_params.R` with deprecated parameters such that these do not produce warnings when found in old config.csv files.