### PR TITLE
Add fragmentation metrics to PR1028

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - Part 2 + 6: Revised and simplified IV and IS calculation which now ignores invalid timestamps and also comes with phi statistic (credits: Ian Meneghel Danilevicz). In part 2 we used to have 2 calculation, which is now replaced by just one and applied to all valid data points in the recordings. In part 6 this is repeated by for the time window as specified with parameter part6Window. Further, IVIS now uses argument threshold.lig as threshold to distinguish inactivity from active.
 
+- Part 6: Add fragmentation metrics, same function as in part 5 but now applied at recording level #839
+
 # CHANGES IN GGIR VERSION 3.0-7
 
 - Part 1:

--- a/R/g.part5.R
+++ b/R/g.part5.R
@@ -594,7 +594,8 @@ g.part5 = function(datadir = c(), metadatadir = c(), f0=c(), f1=c(),
                                            includedaycrit.part5 = params_cleaning[["includedaycrit.part5"]],
                                            ID = ID,
                                            params_output = params_output,
-                                           params_247 = params_247)
+                                           params_247 = params_247,
+                                           Lnames = Lnames)
                   }
                 }
               }

--- a/R/g.part5.savetimeseries.R
+++ b/R/g.part5.savetimeseries.R
@@ -2,7 +2,8 @@ g.part5.savetimeseries = function(ts, LEVELS, desiredtz, rawlevels_fname,
                                   DaCleanFile = NULL,
                                   includedaycrit.part5 = 2/3, ID = NULL,
                                   params_output,
-                                  params_247 = NULL) {
+                                  params_247 = NULL,
+                                  Lnames = NULL) {
   
   ms5rawlevels = data.frame(date_time = ts$time, class_id = LEVELS,
                             # class_name = rep("",Nts),
@@ -91,7 +92,7 @@ g.part5.savetimeseries = function(ts, LEVELS, desiredtz, rawlevels_fname,
       mdat$timestamp = as.POSIXct(mdat$timenum, origin = "1970-01-01",tz = desiredtz)
       rawlevels_fname = gsub(pattern = ".csv", replacement = ".RData", x = rawlevels_fname)
       fname = unique(rawlevels_fname[grep("*RData$", rawlevels_fname)])
-      save(mdat, file = fname)
+      save(mdat, Lnames, file = fname)
     }
     #===============================
     rm(mdat)

--- a/R/g.part6.R
+++ b/R/g.part6.R
@@ -117,7 +117,7 @@ g.part6 = function(datadir = c(), metadatadir = c(), f0 = c(), f1 = c(),
         mdat = data.table::fread(file = paste0(metadatadir, "/meta/ms5.outraw/", 
                                                params_phyact[["part6_threshold_combi"]],  "/", fnames.ms5raw[i]), data.table = FALSE)
       }
-      nfeatures = 50
+      nfeatures = 200
       summary = matrix(NA, nfeatures, 1)
       s_names = rep("", nfeatures)
       fi = 1
@@ -202,8 +202,9 @@ g.part6 = function(datadir = c(), metadatadir = c(), f0 = c(), f1 = c(),
       s_names[fi] = "N_valid_days"
       fi = fi + 1
       #=================================================================
-      # Cosinor analysis which comes with IV IS estimtes
+      # Circadian rhythm analysis
       if (do.cr == TRUE) {
+        # Cosinor analysis which comes with IV IS estimtes
         # Note: applyCosinorAnalyses below uses column invalidepoch to turn
         # imputed values to NA.
         colnames(ts)[which(colnames(ts) == "timenum")] = "time"
@@ -250,6 +251,19 @@ g.part6 = function(datadir = c(), metadatadir = c(), f0 = c(), f1 = c(),
                                  cosinor_coef$IVIS$phi)
         s_names[fi:(fi + 2)] = c("IS", "IV", "phi")
         fi = fi + 3
+        # Transition probabilities
+        for (fragmode in c("day", "spt")) {
+          ts_temp = ts
+          # turn other half of data to NA
+          ts_temp[which(ts$diur == ifelse(fragmode == "spt", 0, 1))] = NA
+          frag.out = g.fragmentation(frag.metrics = params_phyact[["frag.metrics"]],
+                                     LEVELS = ts_temp$class_id,
+                                     Lnames = Lnames, xmin = 60/epochSize, mode = fragmode)
+          # fragmentation values can come with a lot of decimal places
+          summary[fi:(fi + (length(frag.out) - 1))] = round(as.numeric(frag.out), digits = 6)
+          s_names[fi:(fi + (length(frag.out) - 1))] = paste0("FRAG_", names(frag.out), "_", fragmode)
+          fi = fi + length(frag.out)
+        }
       } else {
         cosinor_coef = NULL
         s_names[fi:(fi + 20)] = c("cosinor_timeOffsetHours", "cosinor_mes", 
@@ -290,9 +304,9 @@ g.part6 = function(datadir = c(), metadatadir = c(), f0 = c(), f1 = c(),
           cosinor_ts = c()
         }
         save(output_part6, cosinor_ts, file = paste0(metadatadir,
-                                         ms6.out, "/", gsub(pattern = "[.]csv|[.]RData",
-                                                            replacement = "",
-                                                            x = fnames.ms5raw[i]), ".RData"))
+                                                     ms6.out, "/", gsub(pattern = "[.]csv|[.]RData",
+                                                                        replacement = "",
+                                                                        x = fnames.ms5raw[i]), ".RData"))
       }
       rm(output_part6, summary)
     }

--- a/R/g.part6.R
+++ b/R/g.part6.R
@@ -106,14 +106,25 @@ g.part6 = function(datadir = c(), metadatadir = c(), f0 = c(), f1 = c(),
       skip = 0
     }
     if (params_general[["overwrite"]] == TRUE) skip = 0
-    cosinor_coef = NULL
+    Lnames = cosinor_coef = mdat = NULL
     if (skip == 0) {
       # Load time series:
       if (EXT == "RData") {
         load(file = paste0(metadatadir, "/meta/ms5.outraw/",
                            params_phyact[["part6_threshold_combi"]], "/", fnames.ms5raw[i]))
+        if (is.null(Lnames)) stop("Part 5 was processed with an older version of GGIR, reprocess part 5")
         mdat$time = mdat$timestamp # duplicate column because cosinor function expect columntime
       } else {
+        # use behavioural codes files to derive Lnames object (names of behavioural classes)
+        legendfile = dir(path = paste0(metadatadir, "/meta/ms5.outraw"), pattern = "behavioralcodes", full.names = TRUE)
+        if (length(legendfile) > 1) {
+          df <- file.info(legendfile)
+          legendfile = rownames(df)[which.max(df$mtime)]
+        } else if (length(legendfile) == 0) {
+          stop(paste0("behaviouralcodes file could not be found in ",
+                      paste0(metadatadir, "/meta/ms5.outraw")))
+        }
+        Lnames = data.table::fread(file = legendfile)$class_name
         mdat = data.table::fread(file = paste0(metadatadir, "/meta/ms5.outraw/", 
                                                params_phyact[["part6_threshold_combi"]],  "/", fnames.ms5raw[i]), data.table = FALSE)
       }
@@ -264,18 +275,18 @@ g.part6 = function(datadir = c(), metadatadir = c(), f0 = c(), f1 = c(),
           s_names[fi:(fi + (length(frag.out) - 1))] = paste0("FRAG_", names(frag.out), "_", fragmode)
           fi = fi + length(frag.out)
         }
-      } else {
-        cosinor_coef = NULL
-        s_names[fi:(fi + 20)] = c("cosinor_timeOffsetHours", "cosinor_mes", 
-                                  "cosinor_amp", "cosinor_acrophase",
-                                  "cosinor_acrotime", "cosinor_ndays", "cosinor_R2", 
-                                  "cosinorExt_minimum", "cosinorExt_amp", 
-                                  "cosinorExt_alpha", "cosinorExt_beta", 
-                                  "cosinorExt_acrotime", "cosinorExt_UpMesor",
-                                  "cosinorExt_DownMesor", "cosinorExt_MESOR",
-                                  "cosinorExt_ndays", "cosinorExt_F_pseudo", 
-                                  "cosinorExt_R2", "IS", "IV", "phi")
-        fi = fi + 21
+      # } else {
+      #   cosinor_coef = NULL
+      #   s_names[fi:(fi + 20)] = c("cosinor_timeOffsetHours", "cosinor_mes", 
+      #                             "cosinor_amp", "cosinor_acrophase",
+      #                             "cosinor_acrotime", "cosinor_ndays", "cosinor_R2", 
+      #                             "cosinorExt_minimum", "cosinorExt_amp", 
+      #                             "cosinorExt_alpha", "cosinorExt_beta", 
+      #                             "cosinorExt_acrotime", "cosinorExt_UpMesor",
+      #                             "cosinorExt_DownMesor", "cosinorExt_MESOR",
+      #                             "cosinorExt_ndays", "cosinorExt_F_pseudo", 
+      #                             "cosinorExt_R2", "IS", "IV", "phi")
+      #   fi = fi + 21
       }
       
       #=======================================================================

--- a/man/g.part5.savetimeseries.Rd
+++ b/man/g.part5.savetimeseries.Rd
@@ -12,7 +12,8 @@
                               DaCleanFile = NULL,
                               includedaycrit.part5 = 2/3,
                               ID = NULL, params_output,
-                              params_247 = NULL)
+                              params_247 = NULL,
+                              Lnames = NULL)
 }
 \arguments{
   \item{ts}{
@@ -47,6 +48,10 @@
   }
   \item{params_247}{
     See \link{GGIR}
+  }
+  \item{Lnames}{
+    Level names as passed on from \link{identify_levels}, these are the names
+    corresponding the ID of the behavioural classes as stored in column class_id.
   }
 }
 \value{

--- a/tests/testthat/test_part6.R
+++ b/tests/testthat/test_part6.R
@@ -18,12 +18,18 @@ test_that("Part 6 with household co-analysis", {
   # Use time shifts to simulate three household members
   data(data.ts)
   mdat = data.ts
+  
+  Lnames = c("spt_sleep", "spt_wake_IN", "spt_wake_LIG", "spt_wake_MOD",
+             "spt_wake_VIG", "day_IN_unbt", "day_LIG_unbt", "day_MOD_unbt",
+             "day_VIG_unbt", "day_MVPA_bts_10", "day_IN_bts_30",
+             "day_IN_bts_10_30", "day_LIG_bts_10")
+  
   mdat$timenum = mdat$timenum - (5 * 60) 
-  save(mdat, file = paste0(dn, "/800-900-001_left wrist.RData"))
+  save(mdat, Lnames, file = paste0(dn, "/800-900-001_left wrist.RData"))
   mdat$timenum = mdat$timenum + (7 * 60)
-  save(mdat, file = paste0(dn, "/800-900-002_left wrist.RData"))
+  save(mdat, Lnames, file = paste0(dn, "/800-900-002_left wrist.RData"))
   mdat$timenum = mdat$timenum + (14 * 60)
-  save(mdat, file = paste0(dn, "/800-900-003_left wrist.RData"))
+  save(mdat, Lnames, file = paste0(dn, "/800-900-003_left wrist.RData"))
   
   # Run household co-analysis  
   # Update parameters to align with datset
@@ -82,7 +88,7 @@ test_that("Part 6 with household co-analysis", {
   expect_true(file.exists(path_to_ms6))
   
   load(path_to_ms6)
-  expect_equal(ncol(output_part6), 26)
+  expect_equal(ncol(output_part6), 38)
   expect_equal(output_part6$starttime, "2022-06-02 03:00:00")
   expect_equal(output_part6$cosinor_mes, 2.451769, tolerance = 0.00001)
   expect_equal(output_part6$cosinorExt_minimum, 1.288636, tolerance = 0.00001)
@@ -102,7 +108,7 @@ test_that("Part 6 with household co-analysis", {
   expect_true(file.exists(path_to_ms6))
   
   load(path_to_ms6)
-  expect_equal(ncol(output_part6), 26)
+  expect_equal(ncol(output_part6), 38)
   expect_equal(output_part6$starttime, "2022-06-03 01:41:00")
   expect_equal(output_part6$cosinor_mes, 2.448485, tolerance = 0.00001)
   expect_equal(output_part6$cosinorExt_minimum, 0, tolerance = 0.00001)


### PR DESCRIPTION
<!-- Describe your PR here -->

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [ ] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [ ] Documentation updated:
  - [ ] Function documentation
  - [ ] Chapter vignettes for GitHub IO
  - [ ] Vignettes for CRAN
- [ ] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [ ] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
- [ ] GGIR parameters were added/removed. If yes, please also complete checklist below.

If NEW GGIR parameter(s) were added then these NEW parameter(s) are :
- [ ] documented in `man/GGIR.Rd`
- [ ] included with a default in `R/load_params.R`
- [ ] included with value class check in `R/check_params.R`
- [ ] included in table of `vignettes/GGIRParameters.Rmd` with references to the GGIR parts the parameter is used in.
- [ ] mentioned in NEWS.Rd as NEW parameter

If GGIR parameter(s) were deprecated these parameter(s) are:
- [ ] documented as deprecated in `man/GGIR.Rd`
- [ ] removed from `R/load_params.R`
- [ ] removed from `R/check_params.R`
- [ ] removed from table in `vignettes/GGIRParameters.Rmd`
- [ ] mentioned as deprecated parameter in NEWS.Rd
- [ ] added to the list in `R/extract_params.R` with deprecated parameters such that these do not produce warnings when found in old config.csv files.