### PR TITLE
remove character that devtools::load_all() can't parse

### DIFF
--- a/R/HASPT.R
+++ b/R/HASPT.R
@@ -28,7 +28,7 @@ HASPT = function(angle, sptblocksize = 30, spt_max_gap = 60, ws3 = 5,
       threshold = HDCZA_threshold
     } else if (HASPT.algo == "HorAngle") {  # if hip, then require horizontal angle
       # x = absolute angle
-      # threshold = 45º
+      # threshold = 45 degrees
       x = abs(angle)
       threshold = 45
     } else if (HASPT.algo == "NotWorn") {  


### PR DESCRIPTION
This is just a tiny edit of the comment text.

Removing a "degree" character that devtools::load_all() on Mac OS for some reason can't parse.