### PR TITLE
Revise nonwear detection for externally derived epoch data

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # CHANGES IN GGIR VERSION 3.0-8
 
+- Part 1: In the handling of externally derived epoch data, the code and algorithm for nonwear detection is now simplified to better match expected behaviour #1080.
+
 - Part 2: Fixed issue where g.convert.part2.long() was throwing an error when attempting to process data where every day had insufficient number of valid hours #1070.
 
 - Part 5: Fix bug introduced with 3.0-7 causing WW window to not handle well scenario of zero windows #1078.

--- a/R/convertEpochData.R
+++ b/R/convertEpochData.R
@@ -555,15 +555,17 @@ convertEpochData = function(datadir = c(), metadatadir = c(),
                  params_general[["dataFormat"]] == "actigraph_csv" |
                  params_general[["dataFormat"]] == "sensewear_xls") {
         # Using rolling long window sum to indicate whether it is nonwear
-        nonwearscore = rep(0, length(imp))
+        nonwearscore = rep(0, LML)
+        ni = 1
         for (g in seq(from = 1, to = length(imp), by = epSizeLong / epSizeShort)) {
           iend = g + (epSizeNonWear / epSizeShort) - 1
           indices = g:iend
           if (iend <= length(imp)) {
-            if (sum(imp[indices]) == 0) {
-              nonwearscore[indices] = 3
+            if (sum(imp[indices], na.rm = TRUE) == 0) {
+              nonwearscore[ni] = 3
             }
           }
+          ni = ni + 1
         }
         if (length(nonwearscore) > length(time_longEp_8601)) nonwearscore = nonwearscore[1:length(time_longEp_8601)]
         nonwearscore = round(nonwearscore)

--- a/R/convertEpochData.R
+++ b/R/convertEpochData.R
@@ -550,27 +550,27 @@ convertEpochData = function(datadir = c(), metadatadir = c(),
         imp2 = cumsum(imp)
         imp3 = diff(imp2[seq(1, length(imp2),
                              by = ((60/epSizeShort) * (epSizeLong/60)))]) / ((60/epSizeShort) * (epSizeLong/60)) # rolling mean
-        imp4 = round(imp3 * 3) # create three level nonwear score from it, not really necessary for GGIR, but helps to retain some of the information
+        nonwearscore = round(imp3 * 3) # create three level nonwear score from it, not really necessary for GGIR, but helps to retain some of the information
       } else if (length(grep(pattern = "actiwatch", x = params_general[["dataFormat"]], ignore.case = TRUE)) > 0 |
                  params_general[["dataFormat"]] == "actigraph_csv" |
                  params_general[["dataFormat"]] == "sensewear_xls") {
         # Using rolling long window sum to indicate whether it is nonwear
-        imp4 = rep(0, length(imp)) # non-wear indicator
+        nonwearscore = rep(0, length(imp))
         for (g in seq(from = 1, to = length(imp), by = epSizeLong / epSizeShort)) {
           iend = g + (epSizeNonWear / epSizeShort) - 1
           indices = g:iend
           if (iend <= length(imp)) {
             if (sum(imp[indices]) == 0) {
-              imp4[indices] = 3
+              nonwearscore[indices] = 3
             }
           }
         }
-        if (length(imp4) > length(time_longEp_8601)) imp4 = imp4[1:length(time_longEp_8601)]
-        imp4 = round(imp4)
-        if (any(is.na(imp4))) imp4[which(is.na(imp4))] = 3
+        if (length(nonwearscore) > length(time_longEp_8601)) nonwearscore = nonwearscore[1:length(time_longEp_8601)]
+        nonwearscore = round(nonwearscore)
+        if (any(is.na(nonwearscore))) nonwearscore[which(is.na(nonwearscore))] = 3
       }
-      if (length(imp4) < LML) {
-        imp4 = c(imp4, rep(0, LML - length(imp4)))
+      if (length(nonwearscore) < LML) {
+        nonwearscore = c(nonwearscore, rep(0, LML - length(nonwearscore)))
       }
       if (params_general[["dataFormat"]] == "sensewear_xls") {
         # Create myfun object, this to trigger outcome type specific analysis
@@ -587,7 +587,7 @@ convertEpochData = function(datadir = c(), metadatadir = c(),
                      reporttype = c("scalar", "event", "type"))
       }
       # create data.frame for metalong, note that light and temperature are just set at zero
-      M$metalong = data.frame(timestamp = time_longEp_8601,nonwearscore = imp4, #rep(0,LML)
+      M$metalong = data.frame(timestamp = time_longEp_8601,nonwearscore = nonwearscore, #rep(0,LML)
                               clippingscore = rep(0,LML), lightmean = rep(0,LML),
                               lightpeak = rep(0,LML), temperaturemean = rep(0,LML), EN = rep(0,LML))
       

--- a/tests/testthat/test_convertExtEpochData.R
+++ b/tests/testthat/test_convertExtEpochData.R
@@ -37,6 +37,7 @@ test_that("External epoch data is correctly converted", {
   
   if (dir.exists(dn))  unlink(dn, recursive = TRUE)
   load(paste0(QCbasis, "/meta_Actiwatch.AWD.RData"))
+  expect_equal(sum(M$metalong$nonwearscore), 99)
   expect_equal(nrow(M$metashort), 329)
   expect_equal(ncol(M$metashort), 2)
   expect_equal(colnames(M$metashort), c("timestamp", "ZCY"))
@@ -56,6 +57,7 @@ test_that("External epoch data is correctly converted", {
                    params_general = params_general)
   if (dir.exists(dn))  unlink(dn, recursive = TRUE)
   load(paste0(QCbasis, "/meta_Actiwatch.csv.RData"))
+  expect_equal(sum(M$metalong$nonwearscore), 0)
   expect_equal(nrow(M$metashort), 860)
   expect_equal(ncol(M$metashort), 2)
   expect_equal(colnames(M$metashort), c("timestamp", "ZCY"))
@@ -71,6 +73,7 @@ test_that("External epoch data is correctly converted", {
                    params_general = params_general)
   if (dir.exists(dn))  unlink(dn, recursive = TRUE)
   load(paste0(QCbasis, "/meta_ukbiobank.csv.RData"))
+  expect_equal(sum(M$metalong$nonwearscore), 0)
   expect_equal(nrow(M$metashort), 492)
   expect_equal(ncol(M$metashort), 2)
   expect_equal(colnames(M$metashort), c("timestamp", "LFENMO"))
@@ -87,6 +90,7 @@ test_that("External epoch data is correctly converted", {
                    params_general = params_general)
   if (dir.exists(dn))  unlink(dn, recursive = TRUE)
   load(paste0(QCbasis, "/meta_ActiGraph61.csv.RData"))
+  expect_equal(sum(M$metalong$nonwearscore), 210)
   expect_equal(nrow(M$metashort), 984)
   expect_equal(ncol(M$metashort), 5)
   expect_true(all(c("timestamp", "NeishabouriCount_x", "NeishabouriCount_y", 
@@ -104,6 +108,7 @@ test_that("External epoch data is correctly converted", {
                    params_general = params_general)
   if (dir.exists(dn))  unlink(dn, recursive = TRUE)
   load(paste0(QCbasis, "/meta_ActiGraph13.csv.RData"))
+  expect_equal(sum(M$metalong$nonwearscore), 540)
   expect_equal(nrow(M$metashort), 988)
   expect_equal(ncol(M$metashort), 5)
   expect_true(all(c("timestamp", "NeishabouriCount_x", "NeishabouriCount_y", 
@@ -125,6 +130,7 @@ test_that("External epoch data is correctly converted", {
                    params_general = params_general)
   if (dir.exists(dn))  unlink(dn, recursive = TRUE)
   load(paste0(QCbasis, "/meta_sensewear.xls.RData"))
+  expect_equal(sum(M$metalong$nonwearscore), 0)
   expect_equal(nrow(M$metashort), 60)
   expect_equal(ncol(M$metashort), 4)
   expect_true(all(c("timestamp", "ExtAct", "ExtStep",

--- a/tests/testthat/test_convertExtEpochData.R
+++ b/tests/testthat/test_convertExtEpochData.R
@@ -28,6 +28,7 @@ test_that("External epoch data is correctly converted", {
   if (file.exists(outputdir)) unlink(outputdir, recursive = TRUE)
   
   # AWD
+  cat("\nActiwatch AWD")
   move2folder(system.file("testfiles/Actiwatch.AWD", package = "GGIR")[1], dn)
   params_general[["windowsizes"]][1] = 60
   params_general[["dataFormat"]] = "actiwatch_awd"
@@ -37,7 +38,7 @@ test_that("External epoch data is correctly converted", {
   
   if (dir.exists(dn))  unlink(dn, recursive = TRUE)
   load(paste0(QCbasis, "/meta_Actiwatch.AWD.RData"))
-  expect_equal(sum(M$metalong$nonwearscore), 99)
+  expect_equal(sum(M$metalong$nonwearscore), 63)
   expect_equal(nrow(M$metashort), 329)
   expect_equal(ncol(M$metashort), 2)
   expect_equal(colnames(M$metashort), c("timestamp", "ZCY"))
@@ -46,6 +47,7 @@ test_that("External epoch data is correctly converted", {
   if (file.exists(outputdir)) unlink(outputdir, recursive = TRUE)
   
   # Actiwatch CSV
+  cat("\nActiwatch CSV")
   move2folder(system.file("testfiles/Actiwatch.csv", package = "GGIR")[1], dn)
   params_general[["windowsizes"]][1] = 15
   params_general[["dataFormat"]] = "actiwatch_csv"
@@ -66,6 +68,7 @@ test_that("External epoch data is correctly converted", {
   if (file.exists(outputdir)) unlink(outputdir, recursive = TRUE)
   
   # ukbiobank CSV
+  cat("\nukbiobank CSV")
   move2folder(system.file("testfiles/ukbiobank.csv", package = "GGIR")[1], dn)
   params_general[["windowsizes"]][1] = 5
   params_general[["dataFormat"]] = "ukbiobank_csv"
@@ -82,6 +85,7 @@ test_that("External epoch data is correctly converted", {
   if (file.exists(outputdir)) unlink(outputdir, recursive = TRUE)
   
   # ActiGraph mode 61
+  cat("\nActiGraph mode 61")
   move2folder(system.file("testfiles/ActiGraph61.csv", package = "GGIR")[1], dn)
   params_general[["windowsizes"]][1] = 5
   params_general[["dataFormat"]] = "actigraph_csv"
@@ -90,7 +94,7 @@ test_that("External epoch data is correctly converted", {
                    params_general = params_general)
   if (dir.exists(dn))  unlink(dn, recursive = TRUE)
   load(paste0(QCbasis, "/meta_ActiGraph61.csv.RData"))
-  expect_equal(sum(M$metalong$nonwearscore), 210)
+  expect_equal(sum(M$metalong$nonwearscore), 165)
   expect_equal(nrow(M$metashort), 984)
   expect_equal(ncol(M$metashort), 5)
   expect_true(all(c("timestamp", "NeishabouriCount_x", "NeishabouriCount_y", 
@@ -100,6 +104,7 @@ test_that("External epoch data is correctly converted", {
   if (file.exists(outputdir)) unlink(outputdir, recursive = TRUE)
   
   # ActiGraph mode 13
+  cat("\nActiGraph mode 13")
   move2folder(system.file("testfiles/ActiGraph13.csv", package = "GGIR")[1], dn)
   params_general[["windowsizes"]][1] = 15
   params_general[["dataFormat"]] = "actigraph_csv"
@@ -108,7 +113,7 @@ test_that("External epoch data is correctly converted", {
                    params_general = params_general)
   if (dir.exists(dn))  unlink(dn, recursive = TRUE)
   load(paste0(QCbasis, "/meta_ActiGraph13.csv.RData"))
-  expect_equal(sum(M$metalong$nonwearscore), 540)
+  expect_equal(sum(M$metalong$nonwearscore), 291)
   expect_equal(nrow(M$metashort), 988)
   expect_equal(ncol(M$metashort), 5)
   expect_true(all(c("timestamp", "NeishabouriCount_x", "NeishabouriCount_y", 
@@ -117,9 +122,8 @@ test_that("External epoch data is correctly converted", {
   # Tidy up by deleting output folder
   if (file.exists(outputdir)) unlink(outputdir, recursive = TRUE)
   
-  
-  
   # Sensewear
+  cat("\nSensewear")
   move2folder(system.file("testfiles/sensewear.xls", package = "GGIR")[1], dn)
   params_general[["windowsizes"]][1] = 60
   params_general[["windowsizes"]][2] = 60


### PR DESCRIPTION
<!-- Describe your PR here -->

Improve nonwear detection for externally derived epoch data, e.g. Actiwatch or Actigraph count data produced by commercial software. The rolling window we had was not wrong, but not intuitive for those who have used a similar method in the past. Therefore, I am now simplifying the code and algorithm to better match what people expect it to do.

Fixes #1080

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [ ] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [x] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [x] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [ ] Documentation updated:
  - [ ] Function documentation
  - [ ] Chapter vignettes for GitHub IO
  - [ ] Vignettes for CRAN
- [x] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
- [ ] GGIR parameters were added/removed. If yes, please also complete checklist below.

If NEW GGIR parameter(s) were added then these NEW parameter(s) are :
- [ ] documented in `man/GGIR.Rd`
- [ ] included with a default in `R/load_params.R`
- [ ] included with value class check in `R/check_params.R`
- [ ] included in table of `vignettes/GGIRParameters.Rmd` with references to the GGIR parts the parameter is used in.
- [ ] mentioned in NEWS.Rd as NEW parameter

If GGIR parameter(s) were deprecated these parameter(s) are:
- [ ] documented as deprecated in `man/GGIR.Rd`
- [ ] removed from `R/load_params.R`
- [ ] removed from `R/check_params.R`
- [ ] removed from table in `vignettes/GGIRParameters.Rmd`
- [ ] mentioned as deprecated parameter in NEWS.Rd
- [ ] added to the list in `R/extract_params.R` with deprecated parameters such that these do not produce warnings when found in old config.csv files.