### PR TITLE
Allow for sleeplog with only 1 row

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# CHANGES IN GGIR VERSION 3.0-9
+
+- Part 4: Allow handling sleeplog with only one record #1083
+
 # CHANGES IN GGIR VERSION 3.0-8
 
 - Part 1: In the handling of externally derived epoch data, the code and algorithm for nonwear detection is now simplified to better match expected behaviour #1080.

--- a/R/create_test_sleeplog_csv.R
+++ b/R/create_test_sleeplog_csv.R
@@ -10,7 +10,8 @@ create_test_sleeplog_csv = function(Nnights = 7,
   if (advanced == FALSE) {
     sleeplog = as.data.frame(t(c("123",rep(c("23:00:00","07:00:00"),Nnights))), stringsAsFactors = TRUE)
     if (ncol(sleeplog) >= 5) {
-      sleeplog[, 4:5] = c("03:00:00", "17:00:00") # let's add one night where the person slept untill the afternoon
+      # let's add one night where the person slept untill the afternoon
+      sleeplog[, 4:5] = c("03:00:00", "17:00:00") 
     }
     colnames(sleeplog) = c("ID",rep(c("onset","wakeup"),Nnights))
     write.table(
@@ -23,7 +24,6 @@ create_test_sleeplog_csv = function(Nnights = 7,
     )
   } else {
     times = c("07:00:00", "23:00:00", "13:00:00", "13:30:00", "15:00:00", "15:40:00",  "17:00:00", "17:15:00")
-    # when creating calendar dates create one date extra compared with number of nights
     dates = seq(as.Date("2016/06/25"), as.Date("2016/06/25") + Nnights, by = 1)
     Cnames = c(
       "_wakeup",
@@ -38,7 +38,8 @@ create_test_sleeplog_csv = function(Nnights = 7,
     names = "ID"
     log = c()
     for (di in 1:length(dates)) {
-      if (di < 10) { # include day number in the time, to ease testing sleeplog processing
+      # include day number in the time, to ease testing sleeplog processing
+      if (di < 10) {
         times2 = gsub(pattern = ":00:00", replacement = paste0(":00:0",di), x = times)
       } else {
         times2 = gsub(pattern = ":00:00", replacement = paste0(":00:", ifelse(di < 59, yes = di, no = "00")),

--- a/R/create_test_sleeplog_csv.R
+++ b/R/create_test_sleeplog_csv.R
@@ -7,10 +7,11 @@ create_test_sleeplog_csv = function(Nnights = 7,
   # Nnights is the number of nights the sleeplog has
   if (length(storagelocation) == 0) storagelocation = getwd()
   if (Nnights == 0) Nnights = 1
-  Nnights = 7
   if (advanced == FALSE) {
     sleeplog = as.data.frame(t(c("123",rep(c("23:00:00","07:00:00"),Nnights))), stringsAsFactors = TRUE)
-    sleeplog[, 4:5] = c("03:00:00", "17:00:00") # let's add one night where the person slept untill the afternoon
+    if (ncol(sleeplog) >= 5) {
+      sleeplog[, 4:5] = c("03:00:00", "17:00:00") # let's add one night where the person slept untill the afternoon
+    }
     colnames(sleeplog) = c("ID",rep(c("onset","wakeup"),Nnights))
     write.table(
       sleeplog,
@@ -23,7 +24,7 @@ create_test_sleeplog_csv = function(Nnights = 7,
   } else {
     times = c("07:00:00", "23:00:00", "13:00:00", "13:30:00", "15:00:00", "15:40:00",  "17:00:00", "17:15:00")
     # when creating calendar dates create one date extra compared with number of nights
-    dates = seq(as.Date("2016/06/25"), as.Date("2016/06/25") + Nnights + 1, by = 1)
+    dates = seq(as.Date("2016/06/25"), as.Date("2016/06/25") + Nnights, by = 1)
     Cnames = c(
       "_wakeup",
       "_inbed",

--- a/R/g.loadlog.R
+++ b/R/g.loadlog.R
@@ -273,8 +273,8 @@ g.loadlog = function(loglocation = c(), coln1 = c(), colid = c(),
   # delete id-numbers that are unrecognisable
   empty_rows = which(as.character(sleeplog[,1]) == "0")
   if (length(empty_rows) > 0) {
-    sleeplog = sleeplog[-empty_rows,]
-    sleeplog_times = sleeplog_times[-empty_rows,]
+    sleeplog = sleeplog[-empty_rows, , drop = FALSE]
+    sleeplog_times = sleeplog_times[-empty_rows, , drop = FALSE]
   }
   sleeplog = as.data.frame(sleeplog, stringsAsFactors = FALSE)
   names(sleeplog) = c("ID","night","duration")

--- a/tests/testthat/test_gloadlog.R
+++ b/tests/testthat/test_gloadlog.R
@@ -15,10 +15,10 @@ test_that("gloadlog is able to load different log formats", {
     rec_starttime = format(as.POSIXct("2016-06-25 20:20:20"), "%Y-%m-%dT%H:%M:%S%z")
     save(ID, rec_starttime, file = "mytestdir/dummyms3.RData")
     cat(paste0("\nLocal timezone: ", Sys.timezone()))
-    logs1 = g.loadlog(loglocation = fn, coln1 = 2, colid = 1, #nnights = 7,
+    logs1 = g.loadlog(loglocation = fn, coln1 = 2, colid = 1,
                       meta.sleep.folder = tempdir , desiredtz = "")
-    # after deprecating nnights, the whole sleeplog is read (it contains 8 nights)
-    # ammend tests as needed
+    # after deprecating nnights, the whole sleeplog is read (it contains 7 nights)
+    # amend tests as needed
     expect_equal(nrow(logs1$sleeplog), 7) 
     expect_equal(ncol(logs1$sleeplog), 5)
     expect_equal(logs1$sleeplog$night, as.character(1:7))
@@ -31,7 +31,7 @@ test_that("gloadlog is able to load different log formats", {
     # start of accelerometer recording 6 days earlier
     rec_starttime = format(as.POSIXct("2016-06-20 20:20:20"), "%Y-%m-%dT%H:%M:%S%z")
     save(ID, rec_starttime, file = "mytestdir/dummyms3.RData")
-    logs2 = g.loadlog(loglocation = fn, coln1 = 2, colid = 1, #nnights = 7,
+    logs2 = g.loadlog(loglocation = fn, coln1 = 2, colid = 1,
                      meta.sleep.folder = tempdir , desiredtz = "")
     expect_equal(nrow(logs2$sleeplog), 7)
     expect_equal(ncol(logs2$sleeplog), 5)
@@ -45,7 +45,7 @@ test_that("gloadlog is able to load different log formats", {
     # start of accelerometer recording 3 days later
     rec_starttime = format(as.POSIXct("2016-06-29 20:20:20"), "%Y-%m-%dT%H:%M:%S%z")
     save(ID, rec_starttime, file = "mytestdir/dummyms3.RData")
-    logs3 = g.loadlog(loglocation = fn, coln1 = 2, colid = 1, #nnights = 7,
+    logs3 = g.loadlog(loglocation = fn, coln1 = 2, colid = 1,
                       meta.sleep.folder = tempdir , desiredtz = "")
     expect_equal(nrow(logs3$sleeplog), 3)
     expect_equal(ncol(logs3$sleeplog), 5)
@@ -65,7 +65,7 @@ test_that("gloadlog is able to load different log formats", {
   # rec_starttime = "2016-06-25T20:20:20+0200"
   rec_starttime = format(as.POSIXct("2016-06-25 20:20:20"), "%Y-%m-%dT%H:%M:%S%z")
   save(ID, rec_starttime, file = "mytestdir/dummyms3.RData")
-  logs4 = g.loadlog(loglocation = fn, coln1 = 2, colid = 1, #nnights = 7,
+  logs4 = g.loadlog(loglocation = fn, coln1 = 2, colid = 1,
                     meta.sleep.folder = tempdir , desiredtz = "")
   expect_equal(nrow(logs4$sleeplog), 1)
   expect_equal(ncol(logs4$sleeplog), 5)
@@ -78,7 +78,7 @@ test_that("gloadlog is able to load different log formats", {
   expect_true(file.exists(fn))
   rec_starttime = format(as.POSIXct("2016-06-25 20:20:20"), "%Y-%m-%dT%H:%M:%S%z")
   save(ID, rec_starttime, file = "mytestdir/dummyms3.RData")
-  logs5 = g.loadlog(loglocation = fn, coln1 = 2, colid = 1, #nnights = 7,
+  logs5 = g.loadlog(loglocation = fn, coln1 = 2, colid = 1,
                     meta.sleep.folder = tempdir , desiredtz = "")
   expect_equal(nrow(logs5$sleeplog), 1)
   expect_equal(ncol(logs4$sleeplog), 5)

--- a/tests/testthat/test_gloadlog.R
+++ b/tests/testthat/test_gloadlog.R
@@ -19,13 +19,13 @@ test_that("gloadlog is able to load different log formats", {
                       meta.sleep.folder = tempdir , desiredtz = "")
     # after deprecating nnights, the whole sleeplog is read (it contains 8 nights)
     # ammend tests as needed
-    expect_equal(nrow(logs1$sleeplog), 8) 
+    expect_equal(nrow(logs1$sleeplog), 7) 
     expect_equal(ncol(logs1$sleeplog), 5)
-    expect_equal(logs1$sleeplog$night, as.character(1:8))
-    expect_equal(logs1$sleeplog$sleepwake, c("7:0:2", "7:0:3", "7:0:4", "7:0:5", "7:0:6", "7:0:7", "7:0:8", "7:0:9"))
-    expect_equal(nrow(logs1$nonwearlog), 9)
+    expect_equal(logs1$sleeplog$night, as.character(1:7))
+    expect_equal(logs1$sleeplog$sleepwake, c("7:0:2", "7:0:3", "7:0:4", "7:0:5", "7:0:6", "7:0:7", "7:0:8"))
+    expect_equal(nrow(logs1$nonwearlog), 8)
     expect_equal(ncol(logs1$nonwearlog), 4)
-    expect_equal(nrow(logs1$naplog), 9)
+    expect_equal(nrow(logs1$naplog), 8)
     expect_equal(ncol(logs1$naplog), 6)
     
     # start of accelerometer recording 6 days earlier
@@ -33,13 +33,13 @@ test_that("gloadlog is able to load different log formats", {
     save(ID, rec_starttime, file = "mytestdir/dummyms3.RData")
     logs2 = g.loadlog(loglocation = fn, coln1 = 2, colid = 1, #nnights = 7,
                      meta.sleep.folder = tempdir , desiredtz = "")
-    expect_equal(nrow(logs2$sleeplog), 8)
+    expect_equal(nrow(logs2$sleeplog), 7)
     expect_equal(ncol(logs2$sleeplog), 5)
-    expect_equal(logs2$sleeplog$night, as.character(6:13)) # these are nights in the acc recording
-    expect_equal(logs2$sleeplog$sleepwake, c("7:0:2", "7:0:3", "7:0:4", "7:0:5", "7:0:6", "7:0:7", "7:0:8", "7:0:9"))
-    expect_equal(nrow(logs2$nonwearlog), 9)
+    expect_equal(logs2$sleeplog$night, as.character(6:12)) # these are nights in the acc recording
+    expect_equal(logs2$sleeplog$sleepwake, c("7:0:2", "7:0:3", "7:0:4", "7:0:5", "7:0:6", "7:0:7", "7:0:8"))
+    expect_equal(nrow(logs2$nonwearlog), 8)
     expect_equal(ncol(logs2$nonwearlog), 4)
-    expect_equal(nrow(logs2$naplog), 9)
+    expect_equal(nrow(logs2$naplog), 8)
     expect_equal(ncol(logs2$naplog), 6)
     
     # start of accelerometer recording 3 days later
@@ -47,15 +47,43 @@ test_that("gloadlog is able to load different log formats", {
     save(ID, rec_starttime, file = "mytestdir/dummyms3.RData")
     logs3 = g.loadlog(loglocation = fn, coln1 = 2, colid = 1, #nnights = 7,
                       meta.sleep.folder = tempdir , desiredtz = "")
-    expect_equal(nrow(logs3$sleeplog), 4)
+    expect_equal(nrow(logs3$sleeplog), 3)
     expect_equal(ncol(logs3$sleeplog), 5)
-    expect_equal(logs3$sleeplog$night, as.character(1:4)) # 1:3 because these are the first three nights of the acc recording
-    expect_equal(logs3$sleeplog$sleeponset, c("23:0:5", "23:0:6", "23:0:7", "23:0:8"))
-    expect_equal(nrow(logs3$nonwearlog), 5)
+    expect_equal(logs3$sleeplog$night, as.character(1:3)) # 1:3 because these are the first three nights of the acc recording
+    expect_equal(logs3$sleeplog$sleeponset, c("23:0:5", "23:0:6", "23:0:7"))
+    expect_equal(nrow(logs3$nonwearlog), 4)
     expect_equal(ncol(logs3$nonwearlog), 4)
-    expect_equal(nrow(logs3$naplog), 5)
+    expect_equal(nrow(logs3$naplog), 4)
     expect_equal(ncol(logs3$naplog), 6)
   }
-
+  
+  # Test basic sleeplog with only 1 night:
+  create_test_sleeplog_csv(Nnights = 1, advanced = FALSE, sep = ",")
+  fn = "testsleeplogfile.csv"
+  expect_true(file.exists(fn))
+  
+  # rec_starttime = "2016-06-25T20:20:20+0200"
+  rec_starttime = format(as.POSIXct("2016-06-25 20:20:20"), "%Y-%m-%dT%H:%M:%S%z")
+  save(ID, rec_starttime, file = "mytestdir/dummyms3.RData")
+  logs4 = g.loadlog(loglocation = fn, coln1 = 2, colid = 1, #nnights = 7,
+                    meta.sleep.folder = tempdir , desiredtz = "")
+  expect_equal(nrow(logs4$sleeplog), 1)
+  expect_equal(ncol(logs4$sleeplog), 5)
+  expect_equal(logs4$sleeplog$night, "1")
+  
+  
+  # Test advanced sleeplog with only 1 night:
+  create_test_sleeplog_csv(Nnights = 1, advanced = TRUE, sep = ",")
+  fn = "testsleeplogfile.csv"
+  expect_true(file.exists(fn))
+  rec_starttime = format(as.POSIXct("2016-06-25 20:20:20"), "%Y-%m-%dT%H:%M:%S%z")
+  save(ID, rec_starttime, file = "mytestdir/dummyms3.RData")
+  logs5 = g.loadlog(loglocation = fn, coln1 = 2, colid = 1, #nnights = 7,
+                    meta.sleep.folder = tempdir , desiredtz = "")
+  expect_equal(nrow(logs5$sleeplog), 1)
+  expect_equal(ncol(logs4$sleeplog), 5)
+  expect_equal(logs4$sleeplog$night, "1")
+  
   if (dir.exists(tempdir)) unlink(tempdir, recursive = TRUE)
+  if (file.exists(fn)) unlink(fn, recursive = TRUE)
 })


### PR DESCRIPTION
<!-- Describe your PR here -->

Minor edit that fixes #1083 

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [x] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [x] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [ ] Documentation updated:
  - [ ] Function documentation
  - [ ] Chapter vignettes for GitHub IO
  - [ ] Vignettes for CRAN
- [x] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
- [ ] GGIR parameters were added/removed. If yes, please also complete checklist below.

If NEW GGIR parameter(s) were added then these NEW parameter(s) are :
- [ ] documented in `man/GGIR.Rd`
- [ ] included with a default in `R/load_params.R`
- [ ] included with value class check in `R/check_params.R`
- [ ] included in table of `vignettes/GGIRParameters.Rmd` with references to the GGIR parts the parameter is used in.
- [ ] mentioned in NEWS.Rd as NEW parameter

If GGIR parameter(s) were deprecated these parameter(s) are:
- [ ] documented as deprecated in `man/GGIR.Rd`
- [ ] removed from `R/load_params.R`
- [ ] removed from `R/check_params.R`
- [ ] removed from table in `vignettes/GGIRParameters.Rmd`
- [ ] mentioned as deprecated parameter in NEWS.Rd
- [ ] added to the list in `R/extract_params.R` with deprecated parameters such that these do not produce warnings when found in old config.csv files.