### PR TITLE
Issues 1090 1093 activity log

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # CHANGES IN GGIR VERSION 3.0-10
 
-- Day segmentation: Fix minor bugs in conversion of activity log timestamps #1090 and #1093.
+- Part 2 and 5: qwindow functionality enhanced to also consider fractions of minutes, #1093
+
+- Part 2 and 5: Fix minor bug in activity diary loading when date format is %Y-%m-%d, #1090
 
 # CHANGES IN GGIR VERSION 3.0-9
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# CHANGES IN GGIR VERSION 3.0-10
+
+- Day segmentation: Fix minor bugs in conversion of activity log timestamps #1090 and #1093.
+
 # CHANGES IN GGIR VERSION 3.0-9
 
 - Part 5: Temperature (if available) added to time series output #1085.

--- a/R/g.conv.actlog.R
+++ b/R/g.conv.actlog.R
@@ -22,7 +22,7 @@ g.conv.actlog = function(qwindow, qwindow_dateformat="%d-%m-%Y", epochSize = 5) 
   # main function code
   
   # Read content of activity diary file
-  actlog = data.table::fread(file = qwindow, data.table = FALSE)
+  actlog = data.table::fread(file = qwindow, data.table = FALSE, colClasses = "character")
   
   # check ID and date cols in actlog
   actlog = check_log(actlog, dateformat = qwindow_dateformat,

--- a/R/g.part5.definedays.R
+++ b/R/g.part5.definedays.R
@@ -5,10 +5,21 @@ g.part5.definedays = function(nightsi, wi, indjump, nightsi_bu,
   Nts = nrow(ts)
   lastDay = FALSE
   # define local functions ----
-  qwindow2timestamp = function(qwindow) {
+  qwindow2timestamp = function(qwindow, epochSize) {
     H = floor(qwindow)
     M = floor((qwindow - H) * 60)
     S = floor((qwindow - H - M/60) * 60 * 60)
+    expected_S = seq(0, 60, by = epochSize)
+    if (any(!S %in% expected_S)) {
+      revise = which(!S %in% expected_S)
+      for (si in revise) {
+        S[si] = expected_S[which.min(abs(expected_S - S[si]))]
+        if (S[si] == 60) { # shift minute if S == 60
+          M[si] = M[si] + 1
+          S[si] = 0
+        }
+      }
+    }
     H = as.character(H); M = as.character(M); S = as.character(S)
     H = ifelse(nchar(H) == 1, paste0("0", H), H)
     M = ifelse(nchar(M) == 1, paste0("0", M), M)
@@ -74,7 +85,7 @@ g.part5.definedays = function(nightsi, wi, indjump, nightsi_bu,
         if (qwindow[1] != 0) qwindow = c(0, qwindow)
         if (qwindow[length(qwindow)] != 24) qwindow = c(qwindow, 24)
       }
-      breaks = qwindow2timestamp(qwindow)
+      breaks = qwindow2timestamp(qwindow, epochSize)
       if (24 %in% qwindow) {
         # 24:00:00: probably does not exist, replace by last timestamp in a day
         latest_time_in_day = max(format(ts$time[1:pmin(Nts, NepochPerDay)], format = "%H:%M:%S"))

--- a/R/g.part5.definedays.R
+++ b/R/g.part5.definedays.R
@@ -6,25 +6,25 @@ g.part5.definedays = function(nightsi, wi, indjump, nightsi_bu,
   lastDay = FALSE
   # define local functions ----
   qwindow2timestamp = function(qwindow, epochSize) {
-    H = floor(qwindow)
-    M = floor((qwindow - H) * 60)
-    S = floor((qwindow - H - M/60) * 60 * 60)
-    expected_S = seq(0, 60, by = epochSize)
-    if (any(!S %in% expected_S)) {
-      revise = which(!S %in% expected_S)
-      for (si in revise) {
-        S[si] = expected_S[which.min(abs(expected_S - S[si]))]
-        if (S[si] == 60) { # shift minute if S == 60
-          M[si] = M[si] + 1
-          S[si] = 0
+    hour = floor(qwindow)
+    minute = floor((qwindow - hour) * 60)
+    second = floor((qwindow - hour - minute/60) * 60 * 60)
+    expected_seconds = seq(0, 60, by = epochSize)
+    seconds_tobe_revised = which(!second %in% expected_seconds)
+    if (length(seconds_tobe_revised) > 0) {
+      for (si in seconds_tobe_revised) {
+        second[si] = expected_seconds[which.min(abs(expected_seconds - second[si]))]
+        if (second[si] == 60) { # shift minute if second == 60
+          minute[si] = minute[si] + 1
+          second[si] = 0
         }
       }
     }
-    H = as.character(H); M = as.character(M); S = as.character(S)
-    H = ifelse(nchar(H) == 1, paste0("0", H), H)
-    M = ifelse(nchar(M) == 1, paste0("0", M), M)
-    S = ifelse(nchar(S) == 1, paste0("0", S), S)
-    HMS = paste(H, M, S, sep = ":")
+    hour = as.character(hour); minute = as.character(minute); second = as.character(second)
+    hour = ifelse(nchar(hour) == 1, paste0("0", hour), hour)
+    minute = ifelse(nchar(minute) == 1, paste0("0", minute), minute)
+    second = ifelse(nchar(second) == 1, paste0("0", second), second)
+    HMS = paste(hour, minute, second, sep = ":")
     if (HMS[1] != "00:00:00") HMS = c("00:00:00", HMS)
     return(HMS)
   }

--- a/tests/testthat/test_part5_qwindow.R
+++ b/tests/testthat/test_part5_qwindow.R
@@ -65,15 +65,15 @@ test_that("g.part5.definedays considers qwindow to generate segments", {
                                             "work-travelhome", 
                                             "travelhome-home", "home-dayend"))
   
-  # With times not multiple of epoch size
+  # With times not multiple of epoch size and date format %Y-%m-%d
   actlog = data.frame(id = c("1RAW"),
-                      date = c("01/01/2022"),
+                      date = c("2022-01-01"),
                       work = c("08:09:59"),
                       travelhome = c("16:30:43"),
                       home = c("17:30:00"))
   fn = "testactlog.csv"
   write.csv(x = actlog, file = fn, row.names = FALSE)
-  LOG = g.conv.actlog(qwindow = fn, qwindow_dateformat = "%d/%m/%Y")
+  LOG = g.conv.actlog(qwindow = fn, qwindow_dateformat = "%Y-%m-%d")
   
   # definedays
   definedays = g.part5.definedays(nightsi = nightsi, wi = 1, indjump = 1, 

--- a/tests/testthat/test_part5_qwindow.R
+++ b/tests/testthat/test_part5_qwindow.R
@@ -65,6 +65,40 @@ test_that("g.part5.definedays considers qwindow to generate segments", {
                                             "work-travelhome", 
                                             "travelhome-home", "home-dayend"))
   
+  # With times not multiple of epoch size
+  actlog = data.frame(id = c("1RAW"),
+                      date = c("01/01/2022"),
+                      work = c("08:09:59"),
+                      travelhome = c("16:30:43"),
+                      home = c("17:30:00"))
+  fn = "testactlog.csv"
+  write.csv(x = actlog, file = fn, row.names = FALSE)
+  LOG = g.conv.actlog(qwindow = fn, qwindow_dateformat = "%d/%m/%Y")
+  
+  # definedays
+  definedays = g.part5.definedays(nightsi = nightsi, wi = 1, indjump = 1, 
+                                  nightsi_bu = nightsi, epochSize = 60, 
+                                  qqq_backup=c(), 
+                                  ts = ts, timewindowi = "MM", Nwindows = 1, 
+                                  qwindow = LOG, ID = "1RAW")
+  
+  expect_false(is.null(definedays$segments))
+  expect_true(is.list(definedays$segments))
+  expect_equal(length(definedays$segments), 5)
+  expect_equal(names(definedays$segments)[1], "00:00:00-23:59:00")
+  expect_equal(definedays$segments[[1]], c(1, 1440))
+  expect_equal(names(definedays$segments)[2], "00:00:00-08:09:00")
+  expect_equal(definedays$segments[[2]], c(1, 490))
+  expect_equal(names(definedays$segments)[3], "08:10:00-16:30:00")
+  expect_equal(definedays$segments[[3]], c(491, 991))
+  expect_equal(names(definedays$segments)[4], "16:31:00-17:29:00")
+  expect_equal(definedays$segments[[4]], c(992, 1050))
+  expect_equal(names(definedays$segments)[5], "17:30:00-23:59:00")
+  expect_equal(definedays$segments[[5]], c(1051, 1440))
+  expect_equal(definedays$segments_names, c("MM", "daystart-work", 
+                                            "work-travelhome", 
+                                            "travelhome-home", "home-dayend"))
+  
   expect_true(file.exists(fn))
   if (file.exists(fn)) file.remove(fn)
   


### PR DESCRIPTION
<!-- Describe your PR here -->
Fixes #1090  => activity log dates are now read as character independently of the format of the date.
Fixes #1093  => activity log times are now interpreted considering the epoch size of the analysis to ensure matching of activity log times with time series times in part 5.

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [x] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [x] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [ ] Documentation updated:
  - [ ] Function documentation
  - [ ] Chapter vignettes for GitHub IO
  - [ ] Vignettes for CRAN
- [x] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
- [ ] GGIR parameters were added/removed. If yes, please also complete checklist below.

If NEW GGIR parameter(s) were added then these NEW parameter(s) are :
- [ ] documented in `man/GGIR.Rd`
- [ ] included with a default in `R/load_params.R`
- [ ] included with value class check in `R/check_params.R`
- [ ] included in table of `vignettes/GGIRParameters.Rmd` with references to the GGIR parts the parameter is used in.
- [ ] mentioned in NEWS.Rd as NEW parameter

If GGIR parameter(s) were deprecated these parameter(s) are:
- [ ] documented as deprecated in `man/GGIR.Rd`
- [ ] removed from `R/load_params.R`
- [ ] removed from `R/check_params.R`
- [ ] removed from table in `vignettes/GGIRParameters.Rmd`
- [ ] mentioned as deprecated parameter in NEWS.Rd
- [ ] added to the list in `R/extract_params.R` with deprecated parameters such that these do not produce warnings when found in old config.csv files.