### PR TITLE
Issue1098 handling missing sf gt3x

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# CHANGES IN GGIR VERSION 3.0-10
+
+- Part 1: Improve handling of failure to extract sampling frequency from gt3x file #1098
+
 # CHANGES IN GGIR VERSION 3.0-9
 
 - Part 5: Temperature (if available) added to time series output #1085.

--- a/R/g.inspectfile.R
+++ b/R/g.inspectfile.R
@@ -275,9 +275,8 @@ g.inspectfile = function(datafile, desiredtz = "", params_rawdata = c(),
       sf = as.numeric(H[which(H[,1] == "Sample Rate"), 2])
     }
   }
-
-  if (sf == 0) {
-    stop(paste0("\nSample frequency not recognised in ", datafile), call. = FALSE)
+  if (is.null(sf) || sf == 0) {
+    warning(paste0("\nSample frequency not recognised in ", basename(datafile)), call. = FALSE)
   }
 
   if (dformat != FORMAT$AD_HOC_CSV && is.null(sf) == FALSE) {
@@ -331,14 +330,16 @@ g.inspectfile = function(datafile, desiredtz = "", params_rawdata = c(),
       }
     }
   } 
-
-  # detect dot or comma separator in the data file
-  op <- options(warn = -1) # turn off warnings
-  on.exit(options(op))
-  suppressWarnings(expr = {decn = g.dotorcomma(datafile, dformat, mon,
-                                               rmc.dec = params_rawdata[["rmc.dec"]])})
-  options(warn = 0) # turn on warnings
-
+  if (!is.null(sf)) {
+    # detect dot or comma separator in the data file
+    op <- options(warn = -1) # turn off warnings
+    on.exit(options(op))
+    suppressWarnings(expr = {decn = g.dotorcomma(datafile, dformat, mon,
+                                                 rmc.dec = params_rawdata[["rmc.dec"]])})
+    options(warn = 0) # turn on warnings
+  } else {
+    decn = "."
+  }
   monc = mon
   monn = ifelse(mon > 0, monnames[mon], "unknown")
   dformc = dformat

--- a/R/g.report.part2.R
+++ b/R/g.report.part2.R
@@ -178,6 +178,8 @@ g.report.part2 = function(metadatadir = c(), f0 = c(), f1 = c(), maxdur = 0,
         if (i == 1 | i == f0) {
           QCout = QC
         } else {
+          # fill up missing columns with NA
+          QC[setdiff(names(QCout), names(QC))] <- NA
           QCout = rbind(QCout, QC)
         }
         next()


### PR DESCRIPTION
<!-- Describe your PR here -->

Fixes #1098.
I was able to test this with a set of test files where for one of them sampling frequency could not be extracted.

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [ ] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [x] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [ ] Documentation updated:
  - [ ] Function documentation
  - [ ] Chapter vignettes for GitHub IO
  - [ ] Vignettes for CRAN
- [x] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
- [ ] GGIR parameters were added/removed. If yes, please also complete checklist below.

If NEW GGIR parameter(s) were added then these NEW parameter(s) are :
- [ ] documented in `man/GGIR.Rd`
- [ ] included with a default in `R/load_params.R`
- [ ] included with value class check in `R/check_params.R`
- [ ] included in table of `vignettes/GGIRParameters.Rmd` with references to the GGIR parts the parameter is used in.
- [ ] mentioned in NEWS.Rd as NEW parameter

If GGIR parameter(s) were deprecated these parameter(s) are:
- [ ] documented as deprecated in `man/GGIR.Rd`
- [ ] removed from `R/load_params.R`
- [ ] removed from `R/check_params.R`
- [ ] removed from table in `vignettes/GGIRParameters.Rmd`
- [ ] mentioned as deprecated parameter in NEWS.Rd
- [ ] added to the list in `R/extract_params.R` with deprecated parameters such that these do not produce warnings when found in old config.csv files.