### PR TITLE
revert HDCZA algorithm change in 3.0-7

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: GGIR
 Type: Package
 Title: Raw Accelerometer Data Analysis
-Version: 3.0-8
-Date: 2024-03-05
+Version: 3.0-9
+Date: 2024-03-19
 Authors@R: c(person("Vincent T","van Hees",role=c("aut","cre"),
                     email="v.vanhees@accelting.com"),
              person("Jairo H","Migueles",role="aut",

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,8 +9,7 @@ reports to ease tracing what release was used per recording and per GGIR part, s
 
 - Part 1: Improve handling of failure to extract sampling frequency from gt3x file #1098
 
-- Part 4: Fixes issue #1095 introduced in 3.0-7 that causes GGIR part 4 to stop when processing
-data without non-default sleep algorithms.
+- Part 4: Fixes issue #1095 introduced in 3.0-7 that causes GGIR part 4 to stop when processing data without non-default sleep algorithms.
 
 - Part 2 and 5: qwindow functionality enhanced to also consider fractions of minutes, #1093
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # CHANGES IN GGIR VERSION 3.0-10
 
+- Part 3: Revert change to HDCZA in 3.0-7, see issue #1102
+
 - Part 1: Improve handling of failure to extract sampling frequency from gt3x file #1098
 
 - Part 4: Fixes issue #1095 introduced in 3.0-7 that causes GGIR part 4 to stop when processing

--- a/R/GGIR.R
+++ b/R/GGIR.R
@@ -334,7 +334,7 @@ GGIR = function(mode = 1:5, datadir = c(), outputdir = c(),
                           "print_console_header", "configfile_csv", "myfun", "ex",
                           "GGIRversion",  "dupArgValues", "verbose", "is_GGIRread_installed", 
                           "is_read.gt3x_installed", "is_ActCR_installed", 
-                          "is_actilifecounts_installed", "rawaccfiles", 
+                          "is_actilifecounts_installed", "rawaccfiles", "is_readxl_installed", 
                           "checkFormat", "getExt") == FALSE)]
   
   config.parameters = mget(LS)

--- a/R/HASPT.R
+++ b/R/HASPT.R
@@ -21,11 +21,19 @@ HASPT = function(angle, sptblocksize = 30, spt_max_gap = 60, ws3 = 5,
         angvar = stats::median(abs(diff(angle))) 
         return(angvar)
       }
-      # x = angle
-      # threshold = 0.2
       k1 = 5 * (60/ws3)
+      
       x = zoo::rollapply(angle, width = k1, FUN = medabsdi) # 5 minute rolling median of the absolute difference
-      threshold = HDCZA_threshold
+      if (is.null(HDCZA_threshold)) {
+        threshold = quantile(x, probs = 0.1) * 15
+        if (threshold < 0.13) {
+          threshold = 0.13
+        } else if (threshold > 0.50) {
+          threshold = 0.50
+        }
+      } else {
+        threshold = HDCZA_threshold
+      }
     } else if (HASPT.algo == "HorAngle") {  # if hip, then require horizontal angle
       # x = absolute angle
       # threshold = 45 degrees

--- a/R/HASPT.R
+++ b/R/HASPT.R
@@ -91,8 +91,7 @@ HASPT = function(angle, sptblocksize = 30, spt_max_gap = 60, ws3 = 5,
       outofspt = c(0,outofspt,0)
       s3 = which(diff(outofspt) == 1) #start of blocks out of spt?
       e3 = which(diff(outofspt) == -1) #end blocks out of spt?
-      # starting block not to be filled, which will be a movement block at
-      # the start of the recording less than 60 minutes in length
+      # starting block not to be filled
       if (length(s3) > 0) {
         if (s3[1] == 1) {
           s3 = s3[-1]
@@ -101,8 +100,7 @@ HASPT = function(angle, sptblocksize = 30, spt_max_gap = 60, ws3 = 5,
       }
       if (length(e3) > 0) {
         if (e3[length(e3)] > length(x)) {
-          # ending block not to be filled, which will be a movement block at
-          # the end the recording less than 60 minutes in length
+          # ending block not to be filled
           s3 = s3[-length(s3)]
           e3 = e3[-length(e3)]
         }

--- a/R/HASPT.R
+++ b/R/HASPT.R
@@ -23,7 +23,7 @@ HASPT = function(angle, sptblocksize = 30, spt_max_gap = 60, ws3 = 5,
       }
       k1 = 5 * (60/ws3)
       
-      x = zoo::rollapply(angle, width = k1, FUN = medabsdi) # 5 minute rolling median of the absolute difference
+      x = zoo::rollapply(angle, width = k1, FUN = medabsdi, fill = 0) # 5 minute rolling median of the absolute difference
       if (is.null(HDCZA_threshold)) {
         threshold = quantile(x, probs = 0.1) * 15
         if (threshold < 0.13) {

--- a/R/extract_params.R
+++ b/R/extract_params.R
@@ -72,7 +72,7 @@ extract_params = function(params_sleep = c(), params_metrics = c(),
           } else if (numi == FALSE & logi == FALSE) {
             if (length(config[ci,2]) > 0 & !is.na(config[ci,2])) {
               if (config[ci,2] == 'c()') {
-                if (config[ci,1] == "def.no.sleep") def.no.sleep = c()
+                if (config[ci,1] == "def.noc.sleep") def.noc.sleep = c()
                 if (config[ci,1] == "backup.cal.coef") backup.cal.coef = c()
                 # Note that we do not re-assign the c(), because they are the default for most arguments that
                 # can hold a c() anyway. def.noc.sleep is the only exception.

--- a/R/extract_params.R
+++ b/R/extract_params.R
@@ -109,7 +109,7 @@ extract_params = function(params_sleep = c(), params_metrics = c(),
                               "do.sgAngley", "do.sgAnglez", "frag.classes.spt", "i", 
                               "isna", "tmp", "vecchar", "dupi", "GGIRread_version",
                               "closedbout", "bout.metric", "sleeplogidnum", "LC_TIME_backup",
-                              "constrain2range")
+                              "constrain2range", "is_readxl_installed")
           # Find argument in the various parameter objects
           if (newValue[1] != "notfound" & varName %in% ArgNames2Ignore == FALSE) {
             if (varName %in% names(params_general)) {

--- a/R/g.sib.det.R
+++ b/R/g.sib.det.R
@@ -299,7 +299,7 @@ g.sib.det = function(M, IMP, I, twd = c(-12, 12),
                                        spt_max_gap = spt_max_gap,
                                        HASPT.algo = params_sleep[["HASPT.algo"]], invalid = invalid[newqqq1:newqqq2],
                                        HASPT.ignore.invalid = params_sleep[["HASPT.ignore.invalid"]],
-                                       activity = tmpACC[newqqq1:newqqq2])
+                                       activity = ACC[newqqq1:newqqq2])
               if (length(spt_estimate_tmp$SPTE_start) > 0) {
                 if (spt_estimate_tmp$SPTE_start + newqqq1 >= newqqq2) {
                   spt_estimate_tmp$SPTE_start = (newqqq2 - newqqq1) - 1

--- a/R/load_params.R
+++ b/R/load_params.R
@@ -26,7 +26,7 @@ load_params = function(topic = c("sleep", "metrics", "rawdata",
                         possible_nap_dur = c(15, 240),
                         nap_model = c(), sleepefficiency.metric = 1,
                         possible_nap_edge_acc = Inf,
-                        HDCZA_threshold = 0.2)
+                        HDCZA_threshold = c())
   }
   if ("metrics" %in% topic) {
     params_metrics = list(do.anglex = FALSE, do.angley = FALSE, do.anglez = TRUE,

--- a/man/GGIR-package.Rd
+++ b/man/GGIR-package.Rd
@@ -21,8 +21,8 @@
   \tabular{ll}{
   Package: \tab GGIR\cr
   Type: \tab Package\cr
-  Version: \tab 3.0-8\cr
-  Date: \tab 2023-03-05\cr
+  Version: \tab 3.0-9\cr
+  Date: \tab 2023-03-19\cr
   License: \tab Apache License (== 2.0)\cr
   Discussion group: \tab https://groups.google.com/forum/#!forum/rpackageggir\cr
   }

--- a/man/GGIR.Rd
+++ b/man/GGIR.Rd
@@ -1124,12 +1124,12 @@ GGIR(mode = 1:5,
         below 20 per cent of its standard deviation.}
     
       \item{HDCZA_threshold}{
-        Numeric (default = 0.2)
-        If \code{HASPT.algo} is set to "HDCZA" then HDCZA_threshold will be used
-        as threshold instead of 6th step in the diagram of Figure 1 in
-        van Hees et al. 2018 Scientific Report (doi: 10.1038/s41598-018-31266-z). We have
-        now simplified this step to a constant number, which can be modified via 
-        HDCZA_threshold.
+        Numeric (default = c())
+        If \code{HASPT.algo} is set to "HDCZA" and HDCZA_threshold is not NULL then
+        it will be used as threshold instead of 6th step in the diagram of Figure 1 in
+        van Hees et al. 2018 Scientific Report (doi: 10.1038/s41598-018-31266-z). This
+        is not the default but facilitates a simplification of the algorithm (WARNING:
+        not supported by research yet).
       }
 
       \item{HASPT.ignore.invalid}{

--- a/tests/testthat/test_recordingEndSleepHour.R
+++ b/tests/testthat/test_recordingEndSleepHour.R
@@ -58,8 +58,8 @@ test_that("recordingEndSleepHour works as expected", {
   expect_equal(nrow(p4full), 2) # Night 3 is not in the part 4 reports
   expect_equal(sum(p4$sleeponset), 41.848)
   expect_equal(sum(p4$wakeup), 62.336)
-  expect_equal(sum(p4$guider_onset), 41.771)
-  expect_equal(sum(p4$guider_wakeup), 62.26)
+  expect_equal(sum(p4$guider_onset), 41.851)
+  expect_equal(sum(p4$guider_wakeup), 62.34)
   expect_equal(sum(p4$number_sib_sleepperiod), 73)
   expect_true(all(is.na(p4$longitudinal_axis)))
   


### PR DESCRIPTION
<!-- Describe your PR here -->
Fixes #1102:
- Reinserts HDCZA algorithm component that was dropped in 3.0-7 as consistency with previous releases was too much of a concern. However, if parameter `HDCZA_threshold` is specified by the user then it is still possible to explore the new option.
- Fixes bug in that `tmpACC[newqqq1:newqqq2]` should be `ACC[newqqq1:newqqq2]` in `g.sib.det()`.

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [ ] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [x] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [x] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [ ] Documentation updated:
  - [x] Function documentation
  - [ ] Chapter vignettes for GitHub IO
  - [ ] Vignettes for CRAN
- [x] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
- [ ] GGIR parameters were added/removed. If yes, please also complete checklist below.

If NEW GGIR parameter(s) were added then these NEW parameter(s) are :
- [ ] documented in `man/GGIR.Rd`
- [ ] included with a default in `R/load_params.R`
- [ ] included with value class check in `R/check_params.R`
- [ ] included in table of `vignettes/GGIRParameters.Rmd` with references to the GGIR parts the parameter is used in.
- [ ] mentioned in NEWS.Rd as NEW parameter

If GGIR parameter(s) were deprecated these parameter(s) are:
- [ ] documented as deprecated in `man/GGIR.Rd`
- [ ] removed from `R/load_params.R`
- [ ] removed from `R/check_params.R`
- [ ] removed from table in `vignettes/GGIRParameters.Rmd`
- [ ] mentioned as deprecated parameter in NEWS.Rd
- [ ] added to the list in `R/extract_params.R` with deprecated parameters such that these do not produce warnings when found in old config.csv files.