### PR TITLE
Speedup create_test_acc_csv (as only used for unit tests)

### DIFF
--- a/R/create_test_acc_csv.R
+++ b/R/create_test_acc_csv.R
@@ -193,6 +193,6 @@ create_test_acc_csv = function(sf = 3, Nmin = 2000, storagelocation = c(),
   testfile[1:10,1] = header
   testfile[11,1:3] = variablenames
   testfile[12:(Nrows + 11), 1:3] = testdata
-  write.table(testfile, file = paste0(storagelocation,"/123A_testaccfile.csv"),
-              row.names = FALSE, col.names = FALSE, sep = ",", fileEncoding = "UTF-8")
+  data.table::fwrite(x = testfile, file = paste0(storagelocation,"/123A_testaccfile.csv"),
+              row.names = FALSE, col.names = FALSE)
 }


### PR DESCRIPTION
<!-- Describe your PR here -->

Fixes #963 by speeding up the create_test_acc_csv.R function. The writing of the file was by far the slowest component and I have now replaced this by `data.table::fwrite`.

No need to mention this in changelog as it does not affect GGIR behaviour for the user.

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [ ] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [x] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [ ] Documentation updated:
  - [ ] Function documentation
  - [ ] Chapter vignettes for GitHub IO
  - [ ] Vignettes for CRAN
- [x] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [ ] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
- [ ] GGIR parameters were added/removed. If yes, please also complete checklist below.

If NEW GGIR parameter(s) were added then these NEW parameter(s) are :
- [ ] documented in `man/GGIR.Rd`
- [ ] included with a default in `R/load_params.R`
- [ ] included with value class check in `R/check_params.R`
- [ ] included in table of `vignettes/GGIRParameters.Rmd` with references to the GGIR parts the parameter is used in.
- [ ] mentioned in NEWS.Rd as NEW parameter

If GGIR parameter(s) were deprecated these parameter(s) are:
- [ ] documented as deprecated in `man/GGIR.Rd`
- [ ] removed from `R/load_params.R`
- [ ] removed from `R/check_params.R`
- [ ] removed from table in `vignettes/GGIRParameters.Rmd`
- [ ] mentioned as deprecated parameter in NEWS.Rd
- [ ] added to the list in `R/extract_params.R` with deprecated parameters such that these do not produce warnings when found in old config.csv files.