### PR TITLE
Expand chapter 4 with discussion of zero crossing count

### DIFF
--- a/vignettes/chapter4_AccMetrics.Rmd
+++ b/vignettes/chapter4_AccMetrics.Rmd
@@ -101,9 +101,9 @@ GGIR(do.enmo = TRUE, do.mad = TRUE, do.bfen = TRUE, …)
 | bfx                | Band-pass filtered x-axis                                                                                                                                      | Average           | do.bfx                                                                      | Frequency               |
 | bfy                | Band-pass filtered y-axis                                                                                                                                      | Average           | do.bfy                                                                      | Frequency               |
 | bfen               | Euclidean norm of the band-pass filtered signals                                                                                                               | Average           | do.bfz                                                                      | Frequency               |
-| zcx                | Zero crossing count x-axis                                                                                                                                     | Sum               | do.zcx                                                                      | Frequency               |
-| zcy                | Zero crossing count y-axis                                                                                                                                     | Sum               | do.zcy                                                                      | Frequency               |
-| zcz                | Zero crossing count z-axis                                                                                                                                     | Sum               | do.zcz                                                                      | Frequency               |
+| zcx                | Zero crossing count x-axis (see notes below)                                                                                                                   | Sum               | do.zcx                                                                      | Frequency               |
+| zcy                | Zero crossing count y-axis (see notes below)                                                                                                                                     | Sum               | do.zcy                                                    | Frequency               |
+| zcz                | Zero crossing count z-axis (see notes below)                                                                                                                                    | Sum               | do.zcz                                                                      | Frequency               |
 | neishabouricounts  | Counts as described by [Neishabouri et al. 2022](https://doi.org/10.1038/s41598-022-16003-x) as used in the ActiLife software for raw ActiGraph data           | Sum               | do.neishabouricounts                                                        | Frequency               |
 
 ### Approach to removing the gravitational signal component
@@ -151,6 +151,37 @@ The 2013 paper showed that when ENMO is used in combination with auto-calibratio
 Studies who have criticised ENMO consistently failed to apply auto-calibration, or attempted to apply auto-calibration in a lab setting, ignoring the fact that the auto-calibration is not designed for short lasting lab settings.
 It needs free-living data to work properly.
 Further, studies are often not clear about how the problematic zero imputation during the idle sleep mode in ActiGraph devices is dealt with.
+
+
+### Notes on implementation of zero crossing counts
+
+The implementation of the zero-crossing count in GGIR is an attempt to imitat the zero-crossed counts as described by Sadeh, Cole, Kripke and colleagues in late 1980s and 1990s. However, it cannot be guaranteed to be an exact copy of the original approach, which used the AMA-32 Motionlogger Actigraph by Ambulatory-monitoring Inc. ("AMI"). 
+
+No complete publicly accessible description of that approach exists.
+
+#### Missing information
+
+The missing information about the calculation is:
+
+1. Sadeh specified that calculations were done on data from the Y-axis but the direction of the Y-axis was not clarified. Therefore, it is unclear whether the Y-axis at the time corresponds to the Y-axis of modern sensors
+2. A frequency filter was used, but properties of the filter are missing
+3. Sensitivity of the sensor, we are now guessing that the Motionlogger had a sensitivity of 0.01 _g_ but without direct proof.
+4. Relationship between piezo-electric acceleration signal used at the time and modern piezo-capacitive acceleration signals.
+
+From personal correspondence with AMI, we learnt that the technique has been kept proprietary and has never been shared with or sold to other actigraphy manufacturers (time of correspondence October 2021). Based on the correspondence with AMI we can conclude that even Actiwatch, ActiGraph and other manufacturers who have facilitated the use of 1990s sleep classification algorithms cannot guarantee exact replication of the original studies.
+
+#### Our guess on the missing information
+
+Following the above challenges the implementation of the zero-crossing count in GGIR is based on an educated guess where we used all information we could find in literature and product documentation. In relation to the missing information listed above:
+
+1. We allow you to specify which axis you want to use with parameter `Sadeh_axis` but choose as default the second axis.
+2. We use a 0.25 - 3 Hertz band-pass filter with order 2, which you can modify with parameters `zc.lb`, `zc.hb`, and `zc.order`.
+3. We use a 0.01 _g_ stop band, which you can change with parameter `zc.sb`.
+4. We assume that the band-passed signal is comparable in the absence of evidence on the contrary.
+
+In our own evaluation the zero-crossing count value range looks plausible when compared to the value range in the original publications.
+
+As a note to ActiGraph users: If you decide to compare GGIR Cole-Kripke estimates with ActiLife Cole Kripke estimate be aware that ActiLife may have adopted a different Cole-Kripke algorithm as the original publication presented four algorithms, by which that could also be a source of variation. Further, ActiLife may have used different educated guesses about how Motionlogger counts are calculated.
 
 ## Embedding your own metrics
 


### PR DESCRIPTION
Relates to #1046
In this PR I expand chapter 4 with paragraphs that discuss the zero crossing count algorithm.
I previously had it in the sleep chapters but think this is best discussed in the context of the other metrics.

<!-- Describe your PR here -->

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [ ] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [x] Documentation updated:
  - [ ] Function documentation
  - [x] Chapter vignettes for GitHub IO
  - [ ] Vignettes for CRAN
- [x] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [ ] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
- [ ] GGIR parameters were added/removed. If yes, please also complete checklist below.

If NEW GGIR parameter(s) were added then these NEW parameter(s) are :
- [ ] documented in `man/GGIR.Rd`
- [ ] included with a default in `R/load_params.R`
- [ ] included with value class check in `R/check_params.R`
- [ ] included in table of `vignettes/GGIRParameters.Rmd` with references to the GGIR parts the parameter is used in.
- [ ] mentioned in NEWS.Rd as NEW parameter

If GGIR parameter(s) were deprecated these parameter(s) are:
- [ ] documented as deprecated in `man/GGIR.Rd`
- [ ] removed from `R/load_params.R`
- [ ] removed from `R/check_params.R`
- [ ] removed from table in `vignettes/GGIRParameters.Rmd`
- [ ] mentioned as deprecated parameter in NEWS.Rd
- [ ] added to the list in `R/extract_params.R` with deprecated parameters such that these do not produce warnings when found in old config.csv files.