### PR TITLE
modifications to PR #1028

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,24 @@
 # CHANGES IN GGIR VERSION 3.1-??
 
-- Part 6: Add DFA functionality #839 (credits: Ian Meneghel Danilevicz and Victor Barreto Mesquita)
+- Part 6:
+
+  - Add DFA functionality #839 (credits: Ian Meneghel Danilevicz and Victor Barreto Mesquita)
+
+  - Add fragmentation metrics, same function as in part 5 but now applied at recording level #839
+  
+  - Circadian rhythm analysis now ignore invalid nights, which are not excluded in part 5.
 
 - Part 2 + 6: Revised and simplified IV and IS calculation which now ignores invalid timestamps and also comes with phi statistic (credits: Ian Meneghel Danilevicz). In part 2 we used to have 2 calculation, which is now replaced by just one and applied to all valid data points in the recordings. In part 6 this is repeated by for the time window as specified with parameter part6Window. Further, IVIS now uses argument threshold.lig as threshold to distinguish inactivity from active.
 
-- Part 6: Add fragmentation metrics, same function as in part 5 but now applied at recording level #839
-
 - Part 2: Increase sensitivity clipping detection from 80% to 30% of a window. If the long epoch has more than 30% of its values close to the dynamic range of the sensor then it will be labelled as clipping.
+
+- Part 4: Now also has copy of part 5 variable ACC_spt_mg.
+
+- Part 5:
+
+  - Moving LXMX from part 5 to part 6 as these are circadian rhythm analysis.
+  
+  - Omitted fragmentation metrics for spt window as not meaningful given that part 5 only focusses on valid daytime behaviours.
 
 
 # CHANGES IN GGIR VERSION 3.0-??

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 
   - Add fragmentation metrics, same function as in part 5 but now applied at recording level #839
   
-  - Circadian rhythm analysis now ignore invalid nights, which are not excluded in part 5.
+  - Circadian rhythm analysis now ignore invalid nights controlled with new parameter "includecrit.part6".
 
 - Part 2 + 6: Revised and simplified IV and IS calculation which now ignores invalid timestamps and also comes with phi statistic (credits: Ian Meneghel Danilevicz). In part 2 we used to have 2 calculation, which is now replaced by just one and applied to all valid data points in the recordings. In part 6 this is repeated by for the time window as specified with parameter part6Window. Further, IVIS now uses argument threshold.lig as threshold to distinguish inactivity from active.
 

--- a/R/GGIR.R
+++ b/R/GGIR.R
@@ -320,7 +320,7 @@ GGIR = function(mode = 1:5, datadir = c(), outputdir = c(),
     }
     g.part6(datadir = datadir, metadatadir = metadatadir, f0 = f0, f1 = f1,
             params_general = params_general, params_phyact = params_phyact,
-            params_247 = params_247,
+            params_247 = params_247, params_cleaning = params_cleaning,
             verbose = verbose)
   }
   

--- a/R/check_params.R
+++ b/R/check_params.R
@@ -104,7 +104,7 @@ check_params = function(params_sleep = c(), params_metrics = c(),
   if (length(params_cleaning) > 0) {
     numeric_params = c("includedaycrit", "ndayswindow", "data_masking_strategy", "maxdur", "hrs.del.start",
                        "hrs.del.end", "includedaycrit.part5", "minimum_MM_length.part5",
-                       "includenightcrit", "max_calendar_days")
+                       "includenightcrit", "max_calendar_days", "includecrit.part6")
     boolean_params = c("excludefirstlast.part5", "do.imp", "excludefirstlast",
                        "excludefirst.part4", "excludelast.part4", "nonWearEdgeCorrection")
     character_params = c("data_cleaning_file", "TimeSegments2ZeroFile")

--- a/R/g.part5_analyseSegment.R
+++ b/R/g.part5_analyseSegment.R
@@ -235,101 +235,6 @@ g.part5_analyseSegment = function(indexlog, timeList, levelList,
     dsummary[si, fi] = quantile(ts$ACC[sse],probs = ((WLH - 0.5)/WLH), na.rm = TRUE)
     ds_names[fi] = paste("quantile_mostactive30min_mg", sep = "");      fi = fi + 1
     #===============================================
-    # L5 M5, L10 M10...
-    for (wini in params_247[["winhr"]]) {
-      reso = params_247[["M5L5res"]] #resolution at 5 minutes
-      endd = floor(WLH * 10) / 10 # rounding needed for non-integer window lengths
-      nwindow_f = (endd - wini) #number of windows for L5M5 analyses
-      ignore = FALSE
-      if (endd <= wini | nwindow_f < 1) ignore = TRUE # day is shorter then time window, so ignore this
-      nwindow_f = nwindow_f * (60/reso)
-      if (ignore == FALSE) {
-        # Calculate running window variables
-        ACCrunwin = matrix(0, nwindow_f, 1)
-        TIMErunwin = matrix("", nwindow_f, 1)
-        for (hri in 0:floor((((endd - wini) * (60/reso)) - 1))) {
-          e1 = (hri * reso * (60/ws3new)) + 1
-          e2 = (hri + (wini * (60/reso))) * reso * (60/ws3new)
-          if (e2 > length(sse)) e2 = length(sse)
-          ACCrunwin[(hri + 1), 1] = mean(ts$ACC[sse[e1:e2]])
-          TIMErunwin[(hri + 1), 1] = format(ts$time[sse[e1]])
-        }
-        ACCrunwin = ACCrunwin[is.na(ACCrunwin) == F]
-        TIMErunwin = TIMErunwin[is.na(ACCrunwin) == F]
-        if (length(ACCrunwin) > 0 & length(TIMErunwin) > 0) {
-          # Derive day level variables
-          L5HOUR = TIMErunwin[which(ACCrunwin == min(ACCrunwin))[1]]
-          L5VALUE = min(ACCrunwin)
-          M5HOUR = TIMErunwin[which(ACCrunwin == max(ACCrunwin))[1]]
-          M5VALUE = max(ACCrunwin)
-          if (lightpeak_available == TRUE) {
-            if (length(unlist(strsplit(M5HOUR, " |T"))) == 1) M5HOUR = paste0(M5HOUR, " 00:00:00")
-            startM5 = which(format(ts$time) == M5HOUR)
-            M5_mean_peakLUX = round(mean(ts$lightpeak[startM5[1]:(startM5[1] + (wini*60*(60/ws3new)))], na.rm = TRUE), digits = 1)
-            M5_max_peakLUX = round(max(ts$lightpeak[startM5[1]:(startM5[1] + (wini*60*(60/ws3new)))], na.rm = TRUE), digits = 1)
-          }
-        } else {
-          L5HOUR = M5HOUR = "not detected"
-          L5VALUE = M5VALUE = ""
-          if (lightpeak_available == TRUE) {
-            M5_mean_peakLUX = M5_max_peakLUX = ""
-          }
-        }
-      }
-      # Add variables calculated above to the output matrix
-      if (ignore == FALSE) {
-        dsummary[si, fi:(fi + 3)] = c(L5HOUR, L5VALUE, M5HOUR, M5VALUE)
-      }
-      ds_names[fi:(fi + 3)] = c(paste0("L", wini, "TIME"),
-                                paste0("L", wini, "VALUE"),
-                                paste0("M", wini, "TIME"),
-                                paste0("M", wini, "VALUE"))
-      fi = fi + 4
-      if ("lightpeak" %in% colnames(ts)) {
-        if (ignore == FALSE) {
-          dsummary[si,fi] = M5_mean_peakLUX
-          dsummary[si,fi + 1] = M5_max_peakLUX
-        }
-        ds_names[fi] = paste("M", wini, "_mean_peakLUX", sep = "")
-        ds_names[fi + 1] = paste("M", wini,"_max_peakLUX", sep = "")
-        fi = fi + 2
-      }
-      if (ignore == FALSE) {
-        # Add also numeric time
-        if (is.ISO8601(L5HOUR)) { # only do this for ISO8601 format
-          L5HOUR = format(iso8601chartime2POSIX(L5HOUR, tz = params_general[["desiredtz"]]))
-          M5HOUR = format(iso8601chartime2POSIX(M5HOUR, tz = params_general[["desiredtz"]]))
-        }
-        if (length(unlist(strsplit(L5HOUR," "))) == 1) L5HOUR = paste0(L5HOUR," 00:00:00") #added because on some OS timestamps are deleted for midnight
-        if (length(unlist(strsplit(M5HOUR," "))) == 1) M5HOUR = paste0(M5HOUR," 00:00:00")
-        if (L5HOUR != "not detected") {
-          time_num = sum(as.numeric(unlist(strsplit(unlist(strsplit(L5HOUR," "))[2], ":"))) * c(3600, 60, 1)) / 3600
-          if (!is.null(dayofinterest) && length(sumSleep$daysleeper[dayofinterest]) == 1) {
-            daysleeper_value = sumSleep$daysleeper[dayofinterest]
-          } else {
-            daysleeper_value = 0
-          }
-          if ((time_num < 12 & daysleeper_value == 0) |
-            (time_num < 18 & daysleeper_value == 1)) {
-            time_num = time_num + 24
-          }
-          dsummary[si,fi] = time_num
-        } else {
-          dsummary[si,fi] = NA
-        }
-      }
-      ds_names[fi] = paste("L", wini, "TIME_num", sep = "");      fi = fi + 1
-      if (ignore == FALSE) {
-        if (M5HOUR != "not detected") {
-          time_num = sum(as.numeric(unlist(strsplit(unlist(strsplit(M5HOUR," "))[2], ":"))) * c(3600, 60, 1)) / 3600
-          dsummary[si, fi] = time_num
-        } else {
-          dsummary[si, fi] = NA
-        }
-      }
-      ds_names[fi] = paste("M", wini, "TIME_num", sep = "");      fi = fi + 1
-    }
-    #===============================================
     NANS = which(is.nan(dsummary[si,]) == TRUE) #average of no values will results in NaN
     if (length(NANS) > 0) dsummary[si,NANS] = ""
     #===============================================
@@ -425,15 +330,18 @@ g.part5_analyseSegment = function(indexlog, timeList, levelList,
     #===============================================
     # FRAGMENTATION
     if (length(params_phyact[["frag.metrics"]]) > 0) {
-      for (fragmode in c("day", "spt")) {
-        frag.out = g.fragmentation(frag.metrics = params_phyact[["frag.metrics"]],
-                                   LEVELS = LEVELS[sse[ts$diur[sse] == ifelse(fragmode == "day", 0, 1)]],
-                                   Lnames = Lnames, xmin = 60/ws3new, mode = fragmode)
-        # fragmentation values can come with a lot of decimal places
-        dsummary[si, fi:(fi + (length(frag.out) - 1))] = round(as.numeric(frag.out), digits = 6)
-        ds_names[fi:(fi + (length(frag.out) - 1))] = paste0("FRAG_", names(frag.out), "_", fragmode)
-        fi = fi + length(frag.out)
-      }
+      # Only do daytime fragmentation and not spt window because in part 5 the spt window does
+      # not necessarily include valid data. spt window fragmentation will be performed in part 6
+      fragmode = "day"
+      frag.out = g.fragmentation(frag.metrics = params_phyact[["frag.metrics"]],
+                                 LEVELS = LEVELS[sse[ts$diur[sse] == ifelse(fragmode == "day", 0, 1)]],
+                                 Lnames = Lnames, xmin = 60/ws3new, mode = fragmode)
+      # fragmentation values can come with a lot of decimal places
+      frag.out = round(as.numeric(frag.out), digits = 6)
+      
+      dsummary[si, fi:(fi + (length(frag.out) - 1))] = frag.out
+      ds_names[fi:(fi + (length(frag.out) - 1))] = paste0("FRAG_", names(frag.out), "_", fragmode)
+      fi = fi + length(frag.out)
     }
     #===============================================
     # LIGHT, IF AVAILABLE

--- a/R/g.report.part4.R
+++ b/R/g.report.part4.R
@@ -105,7 +105,7 @@ g.report.part4 = function(datadir = c(), metadatadir = c(), loglocation = c(),
           output = output[-cut, which(colnames(output) != "")]
         }
         WW = which(output[, "window"] == "WW")
-        out = as.matrix(output[WW, which(colnames(output) %in% c("ID", "nonwear_perc_spt", "night_number", "window"))])
+        out = as.matrix(output[WW, which(colnames(output) %in% c("ID", "nonwear_perc_spt", "ACC_spt_mg", "night_number", "window"))])
       }
       outputp5 = as.data.frame(do.call(rbind, lapply(fnames.ms5[f0:f1], myfun5)), stringsAsFactors = FALSE)
       dupl = which(duplicated(outputp5[, c("ID", "night_number")]) == TRUE)
@@ -140,6 +140,7 @@ g.report.part4 = function(datadir = c(), metadatadir = c(), loglocation = c(),
       }
       nightsummary2 = nightsummary2[order(nightsummary2$ID, nightsummary2$night), ]
       nightsummary2$nonwear_perc_spt = as.numeric(nightsummary2$nonwear_perc_spt)
+      nightsummary2$ACC_spt_mg = as.numeric(nightsummary2$ACC_spt_mg)
     }
     # =============
     skip = FALSE
@@ -351,6 +352,11 @@ g.report.part4 = function(datadir = c(), metadatadir = c(), loglocation = c(),
                 if ("nonwear_perc_spt" %in% colnames(nightsummary.tmp)) {
                   personSummary[i, cnt + 1] = mean(nightsummary.tmp$nonwear_perc_spt[this_sleepparam[Seli]], na.rm = TRUE)
                   personSummarynames = c(personSummarynames, paste("nonwear_perc_spt_", TW, "_mn", sep = ""))
+                  cnt = cnt + 1
+                }
+                if ("ACC_spt_mg" %in% colnames(nightsummary.tmp)) {
+                  personSummary[i, cnt + 1] = mean(nightsummary.tmp$ACC_spt_mg[this_sleepparam[Seli]], na.rm = TRUE)
+                  personSummarynames = c(personSummarynames, paste("ACC_spt_mg_", TW, "_mn", sep = ""))
                   cnt = cnt + 1
                 }
               }

--- a/R/load_params.R
+++ b/R/load_params.R
@@ -104,7 +104,8 @@ load_params = function(topic = c("sleep", "metrics", "rawdata",
                            nonWearEdgeCorrection = TRUE, nonwear_approach = "2023",
                            segmentWEARcrit.part5 = 0.5,
                            segmentDAYSPTcrit.part5 = c(0.9, 0),
-                           study_dates_file = c(), study_dates_dateformat = "%d-%m-%Y")
+                           study_dates_file = c(), study_dates_dateformat = "%d-%m-%Y",
+                           includecrit.part6 = c(33.33, 33.33))
   }
   if ("output" %in% topic) {
     params_output = list(epochvalues2csv = FALSE, save_ms5rawlevels = FALSE,

--- a/man/GGIR.Rd
+++ b/man/GGIR.Rd
@@ -953,6 +953,13 @@ GGIR(mode = 1:5,
         in the centre of the mediumsize window, while in the 2023 method the longsizewindow 
         is aligned with its left edge to the left edge of the mediumsize window.
       }
+      
+      \item{includecrit.part6}{
+        Numeric (default = c(33.33, 33.33))
+        Vector of two with the maximum percentage of invalid data allowed for day
+        and spt time, respectively. This criteria is only used for fragmentation and DFA
+        analysis.
+      }
     }
   }
 

--- a/man/g.part6.Rd
+++ b/man/g.part6.Rd
@@ -10,7 +10,7 @@
 \usage{
 g.part6(datadir = c(), metadatadir = c(), f0 = c(), f1 = c(),
                    params_general = c(), params_phyact = c(), params_247 = c(),
-                   verbose = TRUE, ...)
+                   params_cleaning = c(), verbose = TRUE, ...)
 }
 \arguments{
   \item{datadir}{
@@ -38,6 +38,9 @@ g.part6(datadir = c(), metadatadir = c(), f0 = c(), f1 = c(),
    See details in \link{GGIR}.
   }
   \item{params_247}{
+   See details in \link{GGIR}.
+  }
+  \item{params_cleaning}{
    See details in \link{GGIR}.
   }
   \item{verbose}{

--- a/tests/testthat/test_chainof5parts.R
+++ b/tests/testthat/test_chainof5parts.R
@@ -217,8 +217,8 @@ test_that("chainof5parts", {
   
   expect_true(dir.exists(dirname))
   expect_true(file.exists(rn[1]))
-  expect_that(nrow(output),equals(5)) # changed because OO window is exported
-  expect_that(ncol(output),equals(198))
+  expect_that(nrow(output),equals(5))
+  expect_that(ncol(output),equals(184))
   expect_that(round(as.numeric(output$wakeup[2]), digits = 4), equals(36))
   expect_that(as.numeric(output$dur_day_spt_min[4]), equals(1150)) # WW window duration
   expect_that(as.numeric(output$dur_day_spt_min[5]), equals(1680)) # OO window duration

--- a/tests/testthat/test_load_check_params.R
+++ b/tests/testthat/test_load_check_params.R
@@ -15,7 +15,7 @@ test_that("load_params can load parameters", {
   expect_equal(length(params$params_metrics), 41)
   expect_equal(length(params$params_rawdata), 38)
   expect_equal(length(params$params_247), 23)
-  expect_equal(length(params$params_cleaning), 24)
+  expect_equal(length(params$params_cleaning), 25)
   expect_equal(length(params$params_phyact), 14)
   expect_equal(length(params$params_output), 21)
   expect_equal(length(params$params_general), 17)

--- a/tests/testthat/test_part6.R
+++ b/tests/testthat/test_part6.R
@@ -88,7 +88,7 @@ test_that("Part 6 with household co-analysis", {
   expect_true(file.exists(path_to_ms6))
   
   load(path_to_ms6)
-  expect_equal(ncol(output_part6), 39)
+  expect_equal(ncol(output_part6), 47)
   expect_equal(output_part6$starttime, "2022-06-02 03:00:00")
   expect_equal(output_part6$cosinor_mes, 2.451769, tolerance = 0.00001)
   expect_equal(output_part6$cosinorExt_minimum, 1.288636, tolerance = 0.00001)
@@ -108,7 +108,7 @@ test_that("Part 6 with household co-analysis", {
   expect_true(file.exists(path_to_ms6))
   
   load(path_to_ms6)
-  expect_equal(ncol(output_part6), 39)
+  expect_equal(ncol(output_part6), 47)
   expect_equal(output_part6$starttime, "2022-06-03 01:41:00")
   expect_equal(output_part6$cosinor_mes, 2.448485, tolerance = 0.00001)
   expect_equal(output_part6$cosinorExt_minimum, 0, tolerance = 0.00001)

--- a/vignettes/GGIRParameters.Rmd
+++ b/vignettes/GGIRParameters.Rmd
@@ -214,6 +214,12 @@ find a description and default value for all the arguments.
 | save_ms5raw_format          | 5                 | params_output            |
 | save_ms5raw_without_invalid | 5                 | params_output            |
 | do.sibreport                | 5                 | params_output            |
+| includecrit.part6           | 6                 | params_cleaning          |
+| part6_threshold_combi       | 6                 | params_phyact            |
+| part6CR                     | 6                 | params_247               |
+| part6HCA                    | 6                 | params_247               |
+| part6Window                 | 6                 | params_247               |
+| part6DFA                    | 6                 | params_247               |
 | visualreport_without_invalid| visualreport      | params_output            |
 | dofirstpage                 | visualreport      | params_output            |
 | visualreport                | visualreport      | params_output            |


### PR DESCRIPTION
Modification to #1028

- moving LXMX from part 5 to part 6
- ignoring invalid windows in part 6 with new parameter includecrit.part6 to control this
- remove fragmentation metrics for the spt window in part 5 as not meaningful, part5 is focused on daytime behaviours
- copy average acceleration during SPT from part 5 to part 4.

<!-- Describe your PR here -->

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [ ] Documentation updated:
  - [x] Function documentation
  - [ ] Chapter vignettes for GitHub IO
  - [ ] Vignettes for CRAN
- [ ] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
- [x] GGIR parameters were added/removed. If yes, please also complete checklist below.

If NEW GGIR parameter(s) were added then these NEW parameter(s) are :
- [x] documented in `man/GGIR.Rd`
- [x] included with a default in `R/load_params.R`
- [x] included with value class check in `R/check_params.R`
- [x] included in table of `vignettes/GGIRParameters.Rmd` with references to the GGIR parts the parameter is used in.
- [x] mentioned in NEWS.Rd as NEW parameter

If GGIR parameter(s) were deprecated these parameter(s) are:
- [ ] documented as deprecated in `man/GGIR.Rd`
- [ ] removed from `R/load_params.R`
- [ ] removed from `R/check_params.R`
- [ ] removed from table in `vignettes/GGIRParameters.Rmd`
- [ ] mentioned as deprecated parameter in NEWS.Rd
- [ ] added to the list in `R/extract_params.R` with deprecated parameters such that these do not produce warnings when found in old config.csv files.