### PR TITLE
Issue1134 relyonguider

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 - Part 2: Corrected calculation of LXhr and MXhr which had one hour offset when timing was after midnight, #1117
 
+- Part 4: Corrected definition of SPT when relyonguider is set to TRUE, now occurs without modifying SIB start and end times #1134 
+
 # CHANGES IN GGIR VERSION 3.1-0
 
 - Minor issue fixes introduced in 3.0-10 related to handling nights without sustained inactivity bouts, handling recordings without midnight and storage of GGIR version in the part 4 output when there are no valid nights.

--- a/R/g.part4.R
+++ b/R/g.part4.R
@@ -613,18 +613,6 @@ g.part4 = function(datadir = c(), metadatadir = c(), f0 = f0, f1 = f1,
                     } else {
                       spo$dur[evi] = 1  #nocturnal = all acc periods that end after diary onset and start before diary wake
                     }
-                    # REDEFINITION OF ONSET/WAKE OF THIS PERIOD OVERLAPS if TRUE then sleeplog
-                    # value is assigned to accelerometer-based value for onset and wake up
-                    if (params_sleep[["relyonguider"]] == TRUE | relyonguider_thisnight == TRUE) {
-                      if ((spo$start[evi] < SptWake & spo$end[evi] > SptWake) | (spo$start[evi] < SptWake &
-                                                                                 spo$end[evi] < spo$start[evi])) {
-                        spo$end[evi] = SptWake
-                      }
-                      if ((spo$start[evi] < SptOnset & spo$end[evi] > SptOnset) | (spo$end[evi] > SptOnset &
-                                                                                   spo$end[evi] < spo$start[evi])) {
-                        spo$start[evi] = SptOnset
-                      }
-                    }
                   }
                 }
                 if (daysleeper[j] == TRUE) {
@@ -718,8 +706,21 @@ g.part4 = function(datadir = c(), metadatadir = c(), f0 = f0, f1 = f1,
                   # ACCELEROMETER
                   if (length(which(as.numeric(spocum.t$dur) == 1)) > 0) {
                     rtl = which(spocum.t$dur == 1)
-                    nightsummary[sumi, 3] = spocum.t$start[rtl[1]]
-                    nightsummary[sumi, 4] = spocum.t$end[rtl[length(rtl)]]
+                    accSptOnset = spocum.t$start[rtl[1]]
+                    accSptWake = spocum.t$end[rtl[length(rtl)]]
+                    # REDEFINITION OF ONSET/WAKE OF THIS PERIOD if relying on guider
+                    if (params_sleep[["relyonguider"]] == TRUE | relyonguider_thisnight == TRUE) {
+                      accSptOnset = SptOnset
+                      accSptWake = SptWake
+                      # REDEFINE SIBs that are part of the SPT (dur)
+                      # this is, only SIBs within spt, not overlapping, as we are
+                      # trusting the guider definition in this scenario
+                      rtl = which(spocum.t$start >= accSptOnset & spocum.t$end <= accSptWake)
+                      spocum.t$dur = 0
+                      spocum.t$dur[rtl] = 1
+                    }
+                    nightsummary[sumi, 3] = accSptOnset
+                    nightsummary[sumi, 4] = accSptWake
                   } else {
                     cleaningcode = 5  # only for first day, other cleaningcode is assigned to wrong day
                     nightsummary[sumi, 3] = SptOnset  #use default assumption about onset

--- a/tests/testthat/test_chainof5parts.R
+++ b/tests/testthat/test_chainof5parts.R
@@ -329,8 +329,8 @@ test_that("chainof5parts", {
   
   expect_true(dir.exists(dirname))
   expect_true(file.exists(vis_sleep_file))
-  expect_that(round(nightsummary$number_sib_wakinghours[1], digits = 4), equals(0))
-  expect_equal(nightsummary$SptDuration[1], 16.15, tolerance = 0.01)
+  expect_that(round(nightsummary$number_sib_wakinghours[1], digits = 4), equals(2))
+  expect_equal(nightsummary$SptDuration, nightsummary$guider_SptDuration)
   expect_true(as.logical(nightsummary$acc_available[1]))
   expect_false(as.logical(nightsummary$sleeplog_used[1]))
   #----------------------------------------------------------------------
@@ -357,8 +357,9 @@ test_that("chainof5parts", {
   rn = dir(dirname,full.names = TRUE)
   load(rn[1])
   expect_true(dir.exists(dirname))
-  expect_that(round(nightsummary$number_sib_wakinghours[1], digits = 4), equals(10))
+  expect_that(round(nightsummary$number_sib_wakinghours[1], digits = 4), equals(12))
   expect_that(round(nightsummary$SptDuration[1], digits = 4), equals(7))
+  expect_equal(nightsummary$SptDuration, nightsummary$guider_SptDuration)
   
   #----------------------------------------------------------------------
   # Part 4 - DST-1


### PR DESCRIPTION
Fixes #1134

This includes a revision of the SPT definition when `relyonguider` is set to TRUE.

In the original approach, SIB start and end time for the first and last SIB being part of the SPT was modified so that it matched the guider definition. It did not work well at finding the first and last SIB of the SPT. Additionally, this has the challenge that SIB times are modified without keeping track of that, I thought it would be good to leave SIB as they are detected to facilitate methodological research on SPT and SIBs. 

In this proposal, when `relyonguider = TRUE`, it does only affect the SPT definition without modifying the times of the SIBs.