### PR TITLE
Add central function to aid checking milestone folders

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# CHANGES IN GGIR VERSION 3.1-2
+
+- Parts 2-5: Give more informative error when folders with expected milestone files are empty. #1144
+
 # CHANGES IN GGIR VERSION 3.1-1
 
 - Part 2: Corrected calculation of LXhr and MXhr which had one hour offset when timing was after midnight, #1117

--- a/R/checkMilestoneFolders.R
+++ b/R/checkMilestoneFolders.R
@@ -32,7 +32,7 @@ checkMilestoneFolders = function(metadatadir, partNumber) {
     expectedParts = c(2, 3, 4)
   }
    
-  # Give error when do data was found in the expected parts
+  # Give error when no data was found in the expected parts
   warnAbout = NULL
   for (i in expectedParts) {
     N = length(dir(paths[i]))

--- a/R/checkMilestoneFolders.R
+++ b/R/checkMilestoneFolders.R
@@ -12,12 +12,12 @@ checkMilestoneFolders = function(metadatadir, partNumber) {
   # Make sure folders exists
   for (i in 1:partNumber) {
     if (!dir.exists(paths[i])) {
-      dir.create(file.path(paths[i]))
+      dir.create(file.path(paths[i]), recursive = TRUE)
     }
   }
   if (partNumber >= 3) {
     if (!dir.exists(sleepqc)) {
-      dir.create(file.path(sleepqc))
+      dir.create(file.path(sleepqc), recursive = TRUE)
     }
   }
   

--- a/R/checkMilestoneFolders.R
+++ b/R/checkMilestoneFolders.R
@@ -1,7 +1,9 @@
 checkMilestoneFolders = function(metadatadir, partNumber) {
   if (partNumber == 1) return()
-  # This function checks where expected output folders exists and if necessary creates them
-  # Further it check whether folders with expected content are empty and if yes gives error.
+  # This function checks whether expected output folder(s) exists
+  # If not, it creates them
+  # Further it check whether folders with expected content are empty.
+  # If yesm it gives error.
   paths = c(paste0(metadatadir, "/meta/basic"),
             paste0(metadatadir, "/meta/ms2.out"),
             paste0(metadatadir, "/meta/ms3.out"),

--- a/R/checkMilestoneFolders.R
+++ b/R/checkMilestoneFolders.R
@@ -1,0 +1,47 @@
+checkMilestoneFolders = function(metadatadir, partNumber) {
+  if (partNumber == 1) return()
+  # This function checks where expected output folders exists and if necessary creates them
+  # Further it check whether folders with expected content are empty and if yes gives error.
+  paths = c(paste0(metadatadir, "/meta/basic"),
+            paste0(metadatadir, "/meta/ms2.out"),
+            paste0(metadatadir, "/meta/ms3.out"),
+            paste0(metadatadir, "/meta/ms4.out"),
+            paste0(metadatadir, "/meta/ms5.out"))
+  sleepqc = paste0(metadatadir, "/meta/sleep.qc")
+  
+  # Make sure folders exists
+  for (i in 1:partNumber) {
+    if (!dir.exists(paths[i])) {
+      dir.create(file.path(paths[i]))
+    }
+  }
+  if (partNumber >= 3) {
+    if (!dir.exists(sleepqc)) {
+      dir.create(file.path(sleepqc))
+    }
+  }
+  
+  # Make sure preceding parts have files
+  if (partNumber == 2) {
+    expectedParts = 1
+  } else if (partNumber == 3) {
+    expectedParts = 2
+  } else if (partNumber == 4) {
+    expectedParts = 3
+  } else if (partNumber == 5) {
+    expectedParts = c(2, 3, 4)
+  }
+   
+  # Give error when do data was found in the expected parts
+  warnAbout = NULL
+  for (i in expectedParts) {
+    N = length(dir(paths[i]))
+    if (N == 0) {
+      warnAbout = c(warnAbout, i)
+    }
+  }
+  if (length(warnAbout) > 0) {
+    stop(paste0("\nNo milestone data found for part(s) ", paste0(warnAbout, collapse = " and "),
+                ". Run this/these first before running part ", partNumber, "."), call. = FALSE)
+  }
+}

--- a/R/g.part2.R
+++ b/R/g.part2.R
@@ -29,6 +29,7 @@ g.part2 = function(datadir = c(), metadatadir = c(), f0 = c(), f1 = c(),
   #---------------------------------
   # Specifying directories with meta-data and extracting filenames
   path = paste0(metadatadir,"/meta/basic/")  #values stored per long epoch, e.g. 15 minutes
+  checkMilestoneFolders(metadatadir, partNumber = 2)
   fnames = dir(path)
   if (f1 > length(fnames)) f1 = length(fnames)
   # create output folders

--- a/R/g.part3.R
+++ b/R/g.part3.R
@@ -16,15 +16,7 @@ g.part3 = function(metadatadir = c(), f0, f1, myfun = c(),
   params_general = params$params_general
   params_output = params$params_output
 
-  #----------------------------------------------------------
-  # create output directory if it does not exist
-  if (!file.exists(paste(metadatadir, sep = ""))) {
-    dir.create(file.path(metadatadir))
-  }
-  if (!file.exists(paste(metadatadir, "/meta/ms3.out", sep = ""))) {
-    dir.create(file.path(paste(metadatadir, "/meta", sep = ""), "ms3.out"))
-    dir.create(file.path(paste(metadatadir, "/meta", sep = ""), "sleep.qc"))
-  }
+  checkMilestoneFolders(metadatadir, partNumber = 3)
   #------------------------------------------------------
   fnames = dir(paste(metadatadir,"/meta/ms2.out", sep = ""))
   if (f1 > length(fnames) | f1 == 0) f1 = length(fnames)

--- a/R/g.part4.R
+++ b/R/g.part4.R
@@ -20,7 +20,6 @@ g.part4 = function(datadir = c(), metadatadir = c(), f0 = f0, f1 = f1,
   # possibly aided by sleep log/diary information (if available and provided by end-user)
   nnpp = 40 # number of nights to be displayed in the report (hard-coded not a critical parameter for most scenarios)
   #------------------------------------------------
-  # check whether milestone 3 data exists, if not give error
   ms3.out = "/meta/ms3.out"
   meta.sleep.folder = paste0(metadatadir, ms3.out)
   ms4.out = "/meta/ms4.out"

--- a/R/g.part4.R
+++ b/R/g.part4.R
@@ -20,18 +20,11 @@ g.part4 = function(datadir = c(), metadatadir = c(), f0 = f0, f1 = f1,
   # possibly aided by sleep log/diary information (if available and provided by end-user)
   nnpp = 40 # number of nights to be displayed in the report (hard-coded not a critical parameter for most scenarios)
   #------------------------------------------------
-  # check whether milestone 3 data exists, if not give warning
+  # check whether milestone 3 data exists, if not give error
   ms3.out = "/meta/ms3.out"
-  if (!file.exists(paste0(metadatadir,ms3.out))) {
-    if (verbose == TRUE) cat("Warning: First run g.part3 (mode = 3) before running g.part4 (mode = 4)")
-  }
-  # check whether milestone 4 data exists, if no create folder
+  meta.sleep.folder = paste0(metadatadir, ms3.out)
   ms4.out = "/meta/ms4.out"
-  if (file.exists(paste0(metadatadir,ms4.out))) {
-  } else {
-    dir.create(file.path(metadatadir,ms4.out))
-  }
-  meta.sleep.folder = paste0(metadatadir,"/meta/ms3.out")
+  checkMilestoneFolders(metadatadir, partNumber = 4)
   #------------------------------------------------
   # Get sleeplog data
   if (length(params_sleep[["loglocation"]]) > 0) {
@@ -49,6 +42,7 @@ g.part4 = function(datadir = c(), metadatadir = c(), f0 = f0, f1 = f1,
   #------------------------------------------------
   # get list of accelerometer milestone data files from sleep (produced by g.part3)
   fnames = dir(meta.sleep.folder)
+
   if (f1 > length(fnames)) f1 = length(fnames)
   if (f0 > length(fnames)) f0 = 1
   if (f1 == 0 | length(f1) == 0 | f1 > length(fnames))  f1 = length(fnames)

--- a/R/g.part5.R
+++ b/R/g.part5.R
@@ -30,10 +30,8 @@ g.part5 = function(datadir = c(), metadatadir = c(), f0=c(), f1=c(),
   params_general = params$params_general
   #======================================================================
   # create new folder (if not existent) for storing milestone data
+  checkMilestoneFolders(metadatadir, partNumber = 5)
   ms5.out = "/meta/ms5.out"
-  if (!file.exists(paste(metadatadir, ms5.out, sep = ""))) {
-    dir.create(file.path(metadatadir, ms5.out))
-  }
   if (params_output[["save_ms5rawlevels"]] == TRUE | params_output[["do.sibreport"]] == TRUE) {
     ms5.outraw = "/meta/ms5.outraw"
     if (file.exists(paste(metadatadir, ms5.outraw, sep = ""))) {

--- a/man/checkMilestoneFolders.Rd
+++ b/man/checkMilestoneFolders.Rd
@@ -1,0 +1,28 @@
+\name{checkMilestoneFolders}
+\alias{checkMilestoneFolders}
+\title{
+  Checks for existence of folders to process
+}
+\description{
+  Checks whether milestone folders exist, create them if needed,
+  and check whether folders are not empty. Only done for part 1 to 5
+  and not part 6, which is different and handled inside \link{g.part6}.
+}
+\usage{
+  checkMilestoneFolders(metadatadir, partNumber)
+}
+\arguments{
+  \item{metadatadir}{
+    Character, path to root of outputfolder.
+  }
+  \item{partNumber}{
+    Numeric, number from the set 2, 3, 4 or 5.
+  }
+}
+\value{
+  No value is produced
+}
+\keyword{internal}
+\author{
+  Vincent T van Hees <v.vanhees@accelting.com>
+}

--- a/tests/testthat/test_checkMilestoneFolders.R
+++ b/tests/testthat/test_checkMilestoneFolders.R
@@ -1,0 +1,9 @@
+library(GGIR)
+context("checkMilestoneFolders")
+test_that("checkMilestoneFolders creates expected folders and gives expected warnings", {
+  test_folder = "test_milestone_folders"
+  dir.create(test_folder)
+  expect_error(checkMilestoneFolders(test_folder, partNumber = 5))
+  expect_true(dir.exists(paste0(test_folder, "/meta/ms5.out")))
+  if (dir.exists(test_folder)) unlink(test_folder, recursive = TRUE)
+})


### PR DESCRIPTION
<!-- Describe your PR here -->

Fixes #1144 

Function checks:
- Do milestone folder(s) exists as needed for current or preceding GGIR part(s). If not, it creates them.
- Are folders empty, if yes then give error telling the user what part(s) need to be run first.

This is useful when running part X when part X - 1 has not been run yet, which always produced cryptic error messages.

We already had some of this functionality but ad-hoc in some of the parts. In this PR I am moving all this to a central function to ensure we systematically do this for parts 1 to 5. I am skipping this for part 6, because part 6 is a bit different as it depends on threshold combination specific input folders.

<!-- Please, make sure the following items are checked -->
### Checklist before merging:

- [ ] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [x] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [x] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [ ] Documentation updated:
  - [x] Function documentation
  - [ ] Chapter vignettes for GitHub IO
  - [ ] Vignettes for CRAN
- [x] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
- [ ] GGIR parameters were added/removed. If yes, please also complete checklist below.

**If NEW GGIR parameter(s) were added then these NEW parameter(s) are:**
- [ ] documented in `man/GGIR.Rd`
- [ ] included with a default in `R/load_params.R`
- [ ] included with value class check in `R/check_params.R`
- [ ] included in table of `vignettes/GGIRParameters.Rmd` with references to the GGIR parts the parameter is used in.
- [ ] mentioned in NEWS.Rd as NEW parameter

**If GGIR parameter(s) were deprecated these parameter(s) are:**
- [ ] documented as deprecated in `man/GGIR.Rd`
- [ ] removed from `R/load_params.R`
- [ ] removed from `R/check_params.R`
- [ ] removed from table in `vignettes/GGIRParameters.Rmd`
- [ ] mentioned as deprecated parameter in NEWS.Rd
- [ ] added to the list in `R/extract_params.R` with deprecated parameters such that these do not produce warnings when found in old config.csv files.