### PR TITLE
Reduce constraints on value of chunksize and make sure time gap imputation cal also run for adhoc csv

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: GGIR
 Type: Package
 Title: Raw Accelerometer Data Analysis
-Version: 3.1-1
-Date: 2024-06-04
+Version: 3.1-2
+Date: 2024-06-20
 Authors@R: c(person("Vincent T","van Hees",role=c("aut","cre"),
                     email="v.vanhees@accelting.com"),
              person("Jairo H","Migueles",role="aut",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: GGIR
 Type: Package
 Title: Raw Accelerometer Data Analysis
 Version: 3.1-2
-Date: 2024-06-20
+Date: 2024-06-26
 Authors@R: c(person("Vincent T","van Hees",role=c("aut","cre"),
                     email="v.vanhees@accelting.com"),
              person("Jairo H","Migueles",role="aut",

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 - Report part 5: fix bug that was introduced on 2024-Feb-19 in the calculation of wear percentage #1148
 
+- Part 1: Enable timegap imputation for ad-hoc csv data. #1154
+
+- Part 1: Reduce constraints on value for parameter chunksize #1155.
+
 - Report part 5: Rename variable sleep_efficiency to sleep_efficiency_after_onset, #1157
 
 - Vignette: Migrated many sections from main CRAN vignette to wadpac.github.io/GGIR/

--- a/R/check_params.R
+++ b/R/check_params.R
@@ -75,8 +75,7 @@ check_params = function(params_sleep = c(), params_metrics = c(),
     check_class("Raw data", params = params_rawdata, parnames = boolean_params, parclass = "boolean")
     check_class("Raw data", params = params_rawdata, parnames = character_params, parclass = "character")
 
-    if (params_rawdata[["chunksize"]] > 1.5) params_rawdata[["chunksize"]] = 1.5
-    if (params_rawdata[["chunksize"]] < 0.2) params_rawdata[["chunksize"]] = 0.2
+    if (params_rawdata[["chunksize"]] < 0.05) params_rawdata[["chunksize"]] = 0.05
   }
   if (length(params_247) > 0) {
     # iglevels and qwindow can be numeric or character, so not tested

--- a/R/g.getmeta.R
+++ b/R/g.getmeta.R
@@ -219,7 +219,9 @@ g.getmeta = function(datafile, params_metrics = c(), params_rawdata = c(),
         }
       }
 
-      if (params_rawdata[["imputeTimegaps"]] && (dformat == FORMAT$CSV || dformat == FORMAT$GT3X)) {
+      if (params_rawdata[["imputeTimegaps"]] && (dformat == FORMAT$CSV ||
+                                                 dformat == FORMAT$AD_HOC_CSV ||
+                                                 dformat == FORMAT$GT3X)) {
         P = g.imputeTimegaps(data, sf = sf, k = 0.25,
                              PreviousLastValue = PreviousLastValue,
                              PreviousLastTime = PreviousLastTime,

--- a/R/g.getmeta.R
+++ b/R/g.getmeta.R
@@ -229,7 +229,7 @@ g.getmeta = function(datafile, params_metrics = c(), params_rawdata = c(),
         data = P$x
         PreviousLastValue = data[nrow(data), c("x", "y", "z")]
         if ("time" %in% colnames(data)) {
-          PreviousLastTime = as.POSIXct(data$time[nrow(data)])
+          PreviousLastTime = as.POSIXct(data$time[nrow(data)], origin = "1970-1-1")
         } else {
           PreviousLastTime = NULL
         }

--- a/R/g.imputeTimegaps.R
+++ b/R/g.imputeTimegaps.R
@@ -79,7 +79,7 @@ g.imputeTimegaps = function(x, sf, k=0.25, impute = TRUE,
     }
     # refill if first value is not consecutive from last value in previous chunk
     if (!is.null(PreviousLastTime)) {
-      first_deltatime = diff(c(PreviousLastTime, x$time[1]))
+      first_deltatime = diff(c(as.numeric(PreviousLastTime), x$time[1]))
       if (!is.numeric(first_deltatime)) {  # in csv axivity, the time is directly read as numeric (seconds)
         units(first_deltatime) = "secs"
         first_deltatime = as.numeric(first_deltatime)

--- a/R/g.imputeTimegaps.R
+++ b/R/g.imputeTimegaps.R
@@ -79,7 +79,11 @@ g.imputeTimegaps = function(x, sf, k=0.25, impute = TRUE,
     }
     # refill if first value is not consecutive from last value in previous chunk
     if (!is.null(PreviousLastTime)) {
-      first_deltatime = diff(c(as.numeric(PreviousLastTime), x$time[1]))
+      if (!inherits(x = PreviousLastTime, what = "numeric") &&
+          inherits(x = x$time[1], what = "numeric")) {
+        PreviousLastTime = as.numeric(PreviousLastTime)
+      }
+      first_deltatime = diff(c(PreviousLastTime, x$time[1]))
       if (!is.numeric(first_deltatime)) {  # in csv axivity, the time is directly read as numeric (seconds)
         units(first_deltatime) = "secs"
         first_deltatime = as.numeric(first_deltatime)

--- a/man/GGIR.Rd
+++ b/man/GGIR.Rd
@@ -355,12 +355,13 @@ GGIR(mode = 1:5,
 
       \item{chunksize}{
         Numeric (default = 1).
-        Value between 0.2 and 1 to specify the size of chunks to be
+        Value to specify the size of chunks to be
         loaded as a fraction of an approximately 12 hour period for auto-calibration
         procedure and as fraction of 24 hour period for the metric calculation, e.g., 
         0.5 equals 6 and 12 hour chunks, respectively. 
         For machines with less than 4Gb of RAM memory or with < 2GB memory per process
-        when using \code{do.parallel = TRUE} a value below 1 is recommended.}
+        when using \code{do.parallel = TRUE} a value below 1 is recommended.
+        The value is constrained by GGIR to not be lower than 0.05.}
 
       \item{dynrange}{
         Numeric (default = NULL).

--- a/man/GGIR.Rd
+++ b/man/GGIR.Rd
@@ -361,7 +361,9 @@ GGIR(mode = 1:5,
         0.5 equals 6 and 12 hour chunks, respectively. 
         For machines with less than 4Gb of RAM memory or with < 2GB memory per process
         when using \code{do.parallel = TRUE} a value below 1 is recommended.
-        The value is constrained by GGIR to not be lower than 0.05.}
+        The value is constrained by GGIR to not be lower than 0.05. Please note that
+        setting 0.05 will not produce output when 3rd value of parameter windowsizes
+        is 3600.}
 
       \item{dynrange}{
         Numeric (default = NULL).


### PR DESCRIPTION
<!-- Describe your PR here -->

Fixes #1155 
Fixes #1154

<!-- Please, make sure the following items are checked -->
### Checklist before merging:

- [ ] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [x] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [ ] Documentation updated:
  - [x] Function documentation
  - [ ] Chapter vignettes for GitHub IO
  - [ ] Vignettes for CRAN
- [x] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
- [ ] GGIR parameters were added/removed. If yes, please also complete checklist below.

**If NEW GGIR parameter(s) were added then these NEW parameter(s) are:**
- [ ] documented in `man/GGIR.Rd`
- [ ] included with a default in `R/load_params.R`
- [ ] included with value class check in `R/check_params.R`
- [ ] included in table of `vignettes/GGIRParameters.Rmd` with references to the GGIR parts the parameter is used in.
- [ ] mentioned in NEWS.Rd as NEW parameter

**If GGIR parameter(s) were deprecated these parameter(s) are:**
- [ ] documented as deprecated in `man/GGIR.Rd`
- [ ] removed from `R/load_params.R`
- [ ] removed from `R/check_params.R`
- [ ] removed from table in `vignettes/GGIRParameters.Rmd`
- [ ] mentioned as deprecated parameter in NEWS.Rd
- [ ] added to the list in `R/extract_params.R` with deprecated parameters such that these do not produce warnings when found in old config.csv files.