### PR TITLE
Fix sleep efficiency calculation and naming

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 - Report part 5: fix bug that was introduced on 2024-Feb-19 in the calculation of wear percentage #1148
 
+- Report part 5: Rename variable sleep_efficiency to sleep_efficiency_after_onset, #1157
+
 - Vignette: Migrated many sections from main CRAN vignette to wadpac.github.io/GGIR/
 
 # CHANGES IN GGIR VERSION 3.1-1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # CHANGES IN GGIR VERSION 3.1-2
 
+- Part 4: Correct calculation of sleep efficiency for `sleepefficiency.metric = 1`, fixed #1157
+
 - Parts 2-5: Give more informative error when folders with expected milestone files are empty. #1144
 
 - Report part 5: fix bug that was introduced on 2024-Feb-19 in the calculation of wear percentage #1148

--- a/R/g.part4.R
+++ b/R/g.part4.R
@@ -916,9 +916,9 @@ g.part4 = function(datadir = c(), metadatadir = c(), f0 = f0, f1 = f1,
                                                    digits = 7)  #sleeponset - guider_onset
                     # sleep efficiency:
                     if (params_sleep[["sleepefficiency.metric"]] == 1) {
-                      nightsummary[sumi, 26] = round(nightsummary[sumi, 14]/nightsummary[sumi, 9], digits = 5)  #accumulated nocturnal sleep / guider
+                      nightsummary[sumi, 26] = round(nightsummary[sumi, 14]/nightsummary[sumi, 5], digits = 5)  # accumulated sleep in spt / duration of spt
                     } else if (params_sleep[["sleepefficiency.metric"]] == 2) {
-                      nightsummary[sumi, 26] = round(nightsummary[sumi, 14]/(nightsummary[sumi, 5] + nightsummary[sumi, 25]), digits = 5)  #accumulated nocturnal sleep / detected spt + latency
+                      nightsummary[sumi, 26] = round(nightsummary[sumi, 14]/(nightsummary[sumi, 5] + nightsummary[sumi, 25]), digits = 5)  # accumulated sleep in spt / duration of spt + latency
                     }
                   }
                   nightsummary[sumi, 27] = pagei

--- a/R/g.part5_analyseSegment.R
+++ b/R/g.part5_analyseSegment.R
@@ -186,7 +186,7 @@ g.part5_analyseSegment = function(indexlog, timeList, levelList,
     # sleep efficiency
     dsummary[si,fi] = length(which(ts$sibdetection[sse] == 1 &
                                      ts$diur[sse] == 1)) / length(which(ts$diur[sse] == 1))
-    ds_names[fi] = "sleep_efficiency";      fi = fi + 1
+    ds_names[fi] = "sleep_efficiency_after_onset";      fi = fi + 1
     #===============================================
     # NAPS (estimation)
     if (params_output[["do.sibreport"]] == TRUE & "nap1_nonwear2" %in% colnames(ts) &

--- a/tests/testthat/test_chainof5parts.R
+++ b/tests/testthat/test_chainof5parts.R
@@ -282,7 +282,7 @@ test_that("chainof5parts", {
   load(rn[1])
   expect_true("sleeplatency" %in% colnames(nightsummary))
   expect_true("sleepefficiency" %in% colnames(nightsummary))
-  expect_equal(round(nightsummary$sleepefficiency[1], 3), 0.851)
+  expect_equal(round(nightsummary$sleepefficiency[1], 3), 0.974)
   
   #--------------------------------------------
   # part 4 without sleeplog

--- a/tests/testthat/test_recordingEndSleepHour.R
+++ b/tests/testthat/test_recordingEndSleepHour.R
@@ -98,7 +98,7 @@ test_that("recordingEndSleepHour works as expected", {
   expect_equal(sum(p4$guider_inbedStart), 41.42)
   expect_equal(sum(p4$guider_inbedEnd), 57.961)
   expect_equal(sum(p4$number_sib_sleepperiod), 13)
-  expect_equal(sum(p4$sleepefficiency), 0.422)
+  expect_equal(sum(p4$sleepefficiency), 0.428)
   expect_equal(sum(p4$longitudinal_axis), 6)
   
   p5 = read.csv("output_test/results/part5_daysummary_MM_L40M100V400_T5A5.csv")


### PR DESCRIPTION
<!-- Describe your PR here -->

Fixes #1147 
Fixes #1157

<!-- Please, make sure the following items are checked -->
### Checklist before merging:

- [ ] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [x] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [ ] Documentation updated:
  - [ ] Function documentation
  - [ ] Chapter vignettes for GitHub IO
  - [ ] Vignettes for CRAN
- [ ] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [ ] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
- [ ] GGIR parameters were added/removed. If yes, please also complete checklist below.

**If NEW GGIR parameter(s) were added then these NEW parameter(s) are:**
- [ ] documented in `man/GGIR.Rd`
- [ ] included with a default in `R/load_params.R`
- [ ] included with value class check in `R/check_params.R`
- [ ] included in table of `vignettes/GGIRParameters.Rmd` with references to the GGIR parts the parameter is used in.
- [ ] mentioned in NEWS.Rd as NEW parameter

**If GGIR parameter(s) were deprecated these parameter(s) are:**
- [ ] documented as deprecated in `man/GGIR.Rd`
- [ ] removed from `R/load_params.R`
- [ ] removed from `R/check_params.R`
- [ ] removed from table in `vignettes/GGIRParameters.Rmd`
- [ ] mentioned as deprecated parameter in NEWS.Rd
- [ ] added to the list in `R/extract_params.R` with deprecated parameters such that these do not produce warnings when found in old config.csv files.