### PR TITLE
Address minor bug when appending records

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,9 @@
 
 - Part 1: Reduce constraints on value for parameter chunksize #1155.
 
+- Part 1: Fix minor bug when appending records if any of the files has not enough data to produce
+meaningful metashort and metalong objects in part 1. #1162
+
 - Report part 5: Rename variable sleep_efficiency to sleep_efficiency_after_onset, #1157
 
 - Vignette: Migrated many sections from main CRAN vignette to wadpac.github.io/GGIR/

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,8 +8,7 @@
 
 - Part 1: Reduce constraints on value for parameter chunksize #1155.
 
-- Part 1: Fix minor bug when appending records if any of the files has not enough data to produce
-meaningful metashort and metalong objects in part 1. #1162
+- Part 1: When appending records ignore files that have not enough data to produce meaningful metashort and metalong objects in part 1. #1162
 
 - Report part 5: Rename variable sleep_efficiency to sleep_efficiency_after_onset, #1157
 

--- a/R/appendRecords.R
+++ b/R/appendRecords.R
@@ -3,6 +3,7 @@ appendRecords = function(metadatadir, desiredtz = "", idloc = 1, maxRecordingInt
   # Declare local functions:
   getInfo = function(fn, idloc, tz) {
     load(fn)
+    if (is.null(M$metashort)) return()
     hvars = g.extractheadervars(I)
     if (exists("Clist")) {
       ID = NA # If Clist exists then ignore this file as it was previously appended


### PR DESCRIPTION
<!-- Describe your PR here -->
Fixes #1162 => When appending records with `maxRecordingInterval`, if any of the recording files does not have enough data (part 1 `M$metashort == NULL`), then it used to trigger an error because it also tries to append this recording.

<!-- Please, make sure the following items are checked -->
### Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [x] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [ ] Documentation updated:
  - [ ] Function documentation
  - [ ] Chapter vignettes for GitHub IO
  - [ ] Vignettes for CRAN
- [x] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
- [ ] GGIR parameters were added/removed. If yes, please also complete checklist below.

**If NEW GGIR parameter(s) were added then these NEW parameter(s) are:**
- [ ] documented in `man/GGIR.Rd`
- [ ] included with a default in `R/load_params.R`
- [ ] included with value class check in `R/check_params.R`
- [ ] included in table of `vignettes/GGIRParameters.Rmd` with references to the GGIR parts the parameter is used in.
- [ ] mentioned in NEWS.Rd as NEW parameter

**If GGIR parameter(s) were deprecated these parameter(s) are:**
- [ ] documented as deprecated in `man/GGIR.Rd`
- [ ] removed from `R/load_params.R`
- [ ] removed from `R/check_params.R`
- [ ] removed from table in `vignettes/GGIRParameters.Rmd`
- [ ] mentioned as deprecated parameter in NEWS.Rd
- [ ] added to the list in `R/extract_params.R` with deprecated parameters such that these do not produce warnings when found in old config.csv files.