### PR TITLE
improved error message when sleeplog timestamp is not in expected format

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 - Part 1: Add parameter nonwear_range_threshold to control range threshold for nonwear detection,
 this used to be a constant. And default changed to 50mg. #1172
+
+- Part 4: Improved error message when a sleeplog timestamp is not in expected format. #1184
   
 # CHANGES IN GGIR VERSION 3.1-2
 

--- a/R/g.loadlog.R
+++ b/R/g.loadlog.R
@@ -243,6 +243,8 @@ g.loadlog = function(loglocation = c(), coln1 = c(), colid = c(),
         WK[j] = paste0(WKN[1], ":", WKN[2], ":", WKN[3])
         SLN2 = SLN[1] * 3600 + SLN[2] * 60 + SLN[3]
         WKN2 = WKN[1] * 3600 + WKN[2] * 60  + WKN[3]
+        if (is.na(WKN2)) stop(paste0(WKN[1]," as found in the sleeplog is not a valid timestamp"), call. = FALSE)
+        if (is.na(SLN2)) stop(paste0(SLN[1]," as found in the sleeplog is not a valid timestamp"), call. = FALSE)
         if (WKN2 > SLN2) { #e.g. 01:00 - 07:00
           dur = WKN2 - SLN2
         } else if (WKN2 < SLN2) { #e.g. 22:00 - 07:00


### PR DESCRIPTION
<!-- Describe your PR here -->

Fixes #1184

<!-- Please, make sure the following items are checked -->
### Checklist before merging:

- [ ] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [ ] Documentation updated:
  - [ ] Function documentation
  - [ ] Chapter vignettes for GitHub IO
  - [ ] Vignettes for CRAN
- [x] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
- [ ] GGIR parameters were added/removed. If yes, please also complete checklist below.

**If NEW GGIR parameter(s) were added then these NEW parameter(s) are:**
- [ ] documented in `man/GGIR.Rd`
- [ ] included with a default in `R/load_params.R`
- [ ] included with value class check in `R/check_params.R`
- [ ] included in table of `vignettes/GGIRParameters.Rmd` with references to the GGIR parts the parameter is used in.
- [ ] mentioned in NEWS.Rd as NEW parameter

**If GGIR parameter(s) were deprecated these parameter(s) are:**
- [ ] documented as deprecated in `man/GGIR.Rd`
- [ ] removed from `R/load_params.R`
- [ ] removed from `R/check_params.R`
- [ ] removed from table in `vignettes/GGIRParameters.Rmd`
- [ ] mentioned as deprecated parameter in NEWS.Rd
- [ ] added to the list in `R/extract_params.R` with deprecated parameters such that these do not produce warnings when found in old config.csv files.