### PR TITLE
Improve handling of NotWorn with second guider (HorAngle or HDCZA)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,7 +23,6 @@ this used to be a constant. And default changed to 50mg. #1172
 
 - Part 4: Improved error message when a sleeplog timestamp is not in expected format. #1184
 
-
 # CHANGES IN GGIR VERSION 3.1-2
 
 - Part 1:

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,13 @@
 
 - Part 1: Add parameter nonwear_range_threshold to control range threshold for nonwear detection,
 this used to be a constant. And default changed to 50mg. #1172
-  
+
+- Part 4:
+
+  - Improved logging of what guider was used when using NotWorn and optional backup guider, #1156
+
+  - Skip night in part 4 csv report if guider was NotWorn, #1156
+
 # CHANGES IN GGIR VERSION 3.1-2
 
 - Part 1:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# CHANGES IN GGIR VERSION 3.1-?
+# CHANGES IN GGIR VERSION 3.1-4
+
+- Part 3: Update threshold used for HorAngle to 60 degree, and auto-setting HASPT.ignore.invalid to NA when NotWorn guider is used. #1186
 
 - Part 4:
 

--- a/R/HASPT.R
+++ b/R/HASPT.R
@@ -1,9 +1,6 @@
 HASPT = function(angle, sptblocksize = 30, spt_max_gap = 60, ws3 = 5,
                  HASPT.algo="HDCZA", HDCZA_threshold = c(), invalid,
                  HASPT.ignore.invalid=FALSE, activity = NULL) {
-  if (HASPT.algo == "HorAngle") {
-    sptblocksize = 15
-  }
   tib.threshold = SPTE_start = SPTE_end = part3_guider = c()
   # internal functions ---------
   adjustlength = function(x, invalid) {

--- a/R/HASPT.R
+++ b/R/HASPT.R
@@ -1,6 +1,7 @@
 HASPT = function(angle, sptblocksize = 30, spt_max_gap = 60, ws3 = 5,
                  HASPT.algo="HDCZA", HDCZA_threshold = c(), invalid,
                  HASPT.ignore.invalid=FALSE, activity = NULL) {
+  # sptblocksize = 15
   tib.threshold = SPTE_start = SPTE_end = part3_guider = c()
   # internal functions ---------
   adjustlength = function(x, invalid) {
@@ -41,7 +42,7 @@ HASPT = function(angle, sptblocksize = 30, spt_max_gap = 60, ws3 = 5,
       # x = absolute angle
       # threshold = 45 degrees
       x = abs(angle)
-      threshold = 45
+      threshold = 60
     } else if (HASPT.algo == "NotWorn") {
       # When protocol is to not wear sensor during the night,
       # and data is collected in count units we do not know angle
@@ -69,6 +70,7 @@ HASPT = function(angle, sptblocksize = 30, spt_max_gap = 60, ws3 = 5,
       # to the threshold to allow for consistent definition of nomov below
       # i.e., x < threshold
       threshold = activityThreshold + 0.001
+      HASPT.ignore.invalid = NA # Only for NotWorn, because not good to rely on imputed time series
     }
     # Now define nomov periods with the selected strategy for invalid time
     nomov = rep(0,length(x)) # no movement
@@ -148,7 +150,6 @@ HASPT = function(angle, sptblocksize = 30, spt_max_gap = 60, ws3 = 5,
           part3_guider = paste0(HASPT.algo, "+invalid")
         }
       }
-      
       # # Code to help investigate classifications:
       # plot(x, col = "black", type = "l")
       # abline(v = SPTE_start, col = "green", lwd = 2)
@@ -170,7 +171,6 @@ HASPT = function(angle, sptblocksize = 30, spt_max_gap = 60, ws3 = 5,
       # lines(invalid* 0.05, type = "l", col = "red")
       # # graphics.off()
       # browser()
-
     } else {
       SPTE_end = c()
       SPTE_start = c()

--- a/R/HASPT.R
+++ b/R/HASPT.R
@@ -1,7 +1,9 @@
 HASPT = function(angle, sptblocksize = 30, spt_max_gap = 60, ws3 = 5,
                  HASPT.algo="HDCZA", HDCZA_threshold = c(), invalid,
                  HASPT.ignore.invalid=FALSE, activity = NULL) {
-  # sptblocksize = 15
+  if (HASPT.algo == "HorAngle") {
+    sptblocksize = 15
+  }
   tib.threshold = SPTE_start = SPTE_end = part3_guider = c()
   # internal functions ---------
   adjustlength = function(x, invalid) {

--- a/R/HASPT.R
+++ b/R/HASPT.R
@@ -69,7 +69,10 @@ HASPT = function(angle, sptblocksize = 30, spt_max_gap = 60, ws3 = 5,
       # to the threshold to allow for consistent definition of nomov below
       # i.e., x < threshold
       threshold = activityThreshold + 0.001
-      HASPT.ignore.invalid = NA # Only for NotWorn, because not good to rely on imputed time series
+      # Always set HASPT.ignore.invalid to NA for HASPT.algo NotWorn
+      # because NotWorn is by definition interested in invalid periods
+      # and we definitely do not want to rely on imputed time series
+      HASPT.ignore.invalid = NA
     }
     # Now define nomov periods with the selected strategy for invalid time
     nomov = rep(0,length(x)) # no movement
@@ -149,6 +152,7 @@ HASPT = function(angle, sptblocksize = 30, spt_max_gap = 60, ws3 = 5,
           part3_guider = paste0(HASPT.algo, "+invalid")
         }
       }
+      
       # # Code to help investigate classifications:
       # plot(x, col = "black", type = "l")
       # abline(v = SPTE_start, col = "green", lwd = 2)
@@ -170,6 +174,7 @@ HASPT = function(angle, sptblocksize = 30, spt_max_gap = 60, ws3 = 5,
       # lines(invalid* 0.05, type = "l", col = "red")
       # # graphics.off()
       # browser()
+      
     } else {
       SPTE_end = c()
       SPTE_start = c()

--- a/R/check_params.R
+++ b/R/check_params.R
@@ -210,7 +210,7 @@ check_params = function(params_sleep = c(), params_metrics = c(),
                        "so GGIR now auto-sets arguments do.anglex, do.angley, and do.anglez to TRUE."), call. = FALSE)
         params_metrics[["do.anglex"]] = params_metrics[["do.angley"]] = params_metrics[["do.anglez"]] = TRUE
       }
-      if (params_sleep[["HASPT.algo"]][1] != "HorAngle") {
+      if (length(params_sleep[["HASPT.algo"]]) == 1 && params_sleep[["HASPT.algo"]][1] != "HorAngle") {
         warning("\nChanging HASPT.algo value to HorAngle, because sensor.location is set as hip", call. = FALSE)
         params_sleep[["HASPT.algo"]] = "HorAngle"; params_sleep[["def.noc.sleep"]] = 1
       }

--- a/R/check_params.R
+++ b/R/check_params.R
@@ -180,6 +180,9 @@ check_params = function(params_sleep = c(), params_metrics = c(),
       if (params_sleep[["HASPT.algo"]][1] %in% c("HorAngle", "NotWorn") == FALSE) {
         params_sleep[["HASPT.algo"]] = "HDCZA"
       }
+      if (length(params_sleep[["HASPT.algo"]]) == 2 && params_sleep[["HASPT.algo"]][2] == "NotWorn") {
+        params_sleep[["HASPT.algo"]] = params_sleep[["HASPT.algo"]][2:1] # NotWorn is expected to be first
+      }
     } else if (length(params_sleep[["def.noc.sleep"]]) == 2) {
       params_sleep[["HASPT.algo"]] = "notused"
     }

--- a/R/g.part5.savetimeseries.R
+++ b/R/g.part5.savetimeseries.R
@@ -71,12 +71,13 @@ g.part5.savetimeseries = function(ts, LEVELS, desiredtz, rawlevels_fname,
       if (length(cut) > 0) mdat = mdat[-cut,] # remove days from which we already know that they are not going to be included (first and last day)
     }
     mdat$guider = ifelse(mdat$guider == 'sleeplog', yes = 1, # digitize guider to save storage space
-                         no = ifelse(mdat$guider == 'HDCZA', yes = 2,
+                         no = ifelse(mdat$guider == 'HDCZA' | mdat$guider == 'HDCZA+invalid', yes = 2,
                                      no =  ifelse(mdat$guider == 'setwindow', yes = 3,
                                                   no = ifelse(mdat$guider == 'L512', yes = 4,
-                                                              no = ifelse(mdat$guider == 'HorAngle', yes = 5,
-                                                                          no = ifelse(mdat$guider == 'NotWorn', yes = 6,
+                                                              no = ifelse(mdat$guider == 'HorAngle' | mdat$guider == 'HorAngle+invalid', yes = 5,
+                                                                          no = ifelse(mdat$guider == 'NotWorn' | mdat$guider == 'NotWorn+invalid', yes = 6,
                                                                                       no = 0))))))
+    
     mdat = mdat[,-which(names(mdat) %in% c("timestamp","time"))]
     # re-oder columns
     if ("csv" %in% params_output[["save_ms5raw_format"]]) {

--- a/R/g.report.part4.R
+++ b/R/g.report.part4.R
@@ -180,11 +180,11 @@ g.report.part4 = function(datadir = c(), metadatadir = c(), loglocation = c(),
         if (dotwice == 2) {
           # ignore nights that were derived without sleep log?
           if (only.use.sleeplog == TRUE) {
-            del = which(nightsummary$cleaningcode > 0 | nightsummary$sleeplog_used == "FALSE")
+            del = which(nightsummary$cleaningcode > 0 | nightsummary$sleeplog_used == "FALSE"  | nightsummary$guider == "NotWorn")
           } else {
-            # only delete nights with no or no valid accelerometer data data, but consider nigths with
+            # only delete nights with no or no valid accelerometer data or when accelerometer not worn, but consider nights with
             # missing sleep log data
-            del = which(nightsummary$cleaningcode > 1)
+            del = which(nightsummary$cleaningcode > 1 | nightsummary$guider == "NotWorn")
           }
           if (length(del) > 0) {
             nightsummary = nightsummary_bu[-del, ]

--- a/R/g.report.part4.R
+++ b/R/g.report.part4.R
@@ -180,11 +180,13 @@ g.report.part4 = function(datadir = c(), metadatadir = c(), loglocation = c(),
         if (dotwice == 2) {
           # ignore nights that were derived without sleep log?
           if (only.use.sleeplog == TRUE) {
-            del = which(nightsummary$cleaningcode > 0 | nightsummary$sleeplog_used == "FALSE"  | nightsummary$guider == "NotWorn")
+            del = which(nightsummary$cleaningcode > 0 | nightsummary$sleeplog_used == "FALSE"  |
+                          nightsummary$guider == "NotWorn" | nightsummary$guider == "NotWorn+invalid")
           } else {
             # only delete nights with no or no valid accelerometer data or when accelerometer not worn, but consider nights with
             # missing sleep log data
-            del = which(nightsummary$cleaningcode > 1 | nightsummary$guider == "NotWorn")
+            del = which(nightsummary$cleaningcode > 1 | nightsummary$guider == "NotWorn" | 
+                          nightsummary$guider == "NotWorn+invalid")
           }
           if (length(del) > 0) {
             nightsummary = nightsummary_bu[-del, ]

--- a/R/g.sib.det.R
+++ b/R/g.sib.det.R
@@ -270,7 +270,6 @@ g.sib.det = function(M, IMP, I, twd = c(-12, 12),
         tmpTIME = time[qqq1:qqq2]
         daysleep_offset = 0
         if (do.HASPT.hip == TRUE & params_sleep[["HASPT.algo"]][guider_to_use] != "NotWorn") {
-          params_sleep[["HASPT.algo"]][1] = "HorAngle"
           if (params_sleep[["longitudinal_axis"]] == 1) {
             tmpANGLE = anglex[qqq1:qqq2]
           } else if (params_sleep[["longitudinal_axis"]] == 2) {

--- a/R/g.sib.det.R
+++ b/R/g.sib.det.R
@@ -269,7 +269,7 @@ g.sib.det = function(M, IMP, I, twd = c(-12, 12),
         tmpANGLE = anglez[qqq1:qqq2]
         tmpTIME = time[qqq1:qqq2]
         daysleep_offset = 0
-        if (do.HASPT.hip == TRUE & params_sleep[["HASPT.algo"]][1] != "NotWorn") {
+        if (do.HASPT.hip == TRUE & params_sleep[["HASPT.algo"]][guider_to_use] != "NotWorn") {
           params_sleep[["HASPT.algo"]][1] = "HorAngle"
           if (params_sleep[["longitudinal_axis"]] == 1) {
             tmpANGLE = anglex[qqq1:qqq2]

--- a/R/g.sib.det.R
+++ b/R/g.sib.det.R
@@ -227,8 +227,8 @@ g.sib.det = function(M, IMP, I, twd = c(-12, 12),
           qqq1 = midnightsi[j] + (twd[1] * (3600 / ws3)) #preceding noon
           qqq2 = midnightsi[j] + (twd[2] * (3600 / ws3)) #next noon
         }
-        if (qqq2 - qqq1 < 60) next # skip night if it has less than 60 epochs
         sptei = sptei + 1
+        if (qqq2 - qqq1 < 60) next # skip night if it has less than 60 epochs
         if (qqq2 > length(time))  qqq2 = length(time)
         if (qqq1 < 1)             qqq1 = 1
         if (qqq1 == 1 && qqq2 != 24 * 3600 / ws3) {

--- a/man/GGIR.Rd
+++ b/man/GGIR.Rd
@@ -1178,6 +1178,8 @@ GGIR(mode = 1:5,
         If \code{TRUE}, invalid time segments are ignored (i.e., they cannot 
         contribute to the guider). If \code{NA}, then invalid time segments are 
         considered to be no movement segments and can contribute to the guider.
+        When HASPT.algo is "NotWorn", HASPT.ignore.invalid is automatically set to
+        NA.
         }
 
       \item{HASIB.algo}{

--- a/tests/testthat/test_chainof5parts.R
+++ b/tests/testthat/test_chainof5parts.R
@@ -388,7 +388,7 @@ test_that("chainof5parts", {
   expect_that(round(nightsummary$number_sib_wakinghours[1], digits = 4), equals(6))
   expect_that(round(nightsummary$SptDuration[1], digits = 4), equals(13.075))
   #---------------------
-  # Part 1 with external function and selectdaysfile:
+  # Part 1 with external function:
   exampleExtFunction = function(data=c(), parameters=c()) {
     data = data.frame(data, agglevel = round((1:nrow(data)) / (30 * 60 * 15)))
     output = aggregate(data, by = list(data$agglevel), FUN = mean)
@@ -405,14 +405,6 @@ test_that("chainof5parts", {
                 outputtype = "numeric", #"numeric" (averaging is possible), "category" (majority vote)
                 aggfunction = mean,
                 timestamp = as.numeric(Sys.time())) # for unit test only
-  # create selectdaysfile
-  SDF = matrix("", 1, 3)
-  SDF[1, 1] = "MOS2D12345678"
-  SDF[1, 2:3] =  c("23-05-2016", "24-05-2016")
-  colnames(SDF) = c("Monitor", "Day1", "Day2")
-  selectdaysfile = "selectdaysfile.csv"
-  write.csv(SDF, file = selectdaysfile)
-  
   
   g.part1(datadir = fn, metadatadir = metadatadir, f0 = 1, f1 = 1,
           overwrite = TRUE, desiredtz = desiredtz,
@@ -424,7 +416,7 @@ test_that("chainof5parts", {
           do.dev_roll_med_acc_x = TRUE, do.dev_roll_med_acc_y = TRUE, do.dev_roll_med_acc_z = TRUE,
           do.bfx = TRUE, do.bfy = TRUE, do.bfz = TRUE, do.hfen = TRUE,
           do.hfx = TRUE, do.hfy = TRUE, do.hfz = TRUE, do.lfen = TRUE,
-          do.enmoa = TRUE, selectdaysfile = selectdaysfile, verbose = FALSE)
+          do.enmoa = TRUE, verbose = FALSE)
   
   rn = dir("output_test/meta/basic/", full.names = TRUE)
   load(rn[1])
@@ -438,8 +430,6 @@ test_that("chainof5parts", {
   expect_equal(mean(M$metashort$dev_roll_med_acc_x, na.rm = T), 0.007, tolerance = 3)
   expect_equal(mean(M$metashort$ENMOa, na.rm = T), 0.03, tolerance = 3)
   
-  
-  if (file.exists(selectdaysfile)) file.remove(selectdaysfile)
   if (dir.exists(dn))  unlink(dn, recursive = TRUE)
   if (file.exists(fn)) unlink(fn)
   if (file.exists(sleeplog_fn)) file.remove(sleeplog_fn)

--- a/tests/testthat/test_recordingEndSleepHour.R
+++ b/tests/testthat/test_recordingEndSleepHour.R
@@ -93,12 +93,12 @@ test_that("recordingEndSleepHour works as expected", {
   p4full = read.csv("output_test/results/QC/part4_nightsummary_sleep_full.csv")
   expect_equal(nrow(p4), 2) # Night 3 is not in the part 4 reports
   expect_equal(nrow(p4full), 2) # Night 3 is not in the part 4 reports
-  expect_equal(sum(p4$sleeponset), 41.831)
-  expect_equal(sum(p4$wakeup), 58.424)
-  expect_equal(sum(p4$guider_inbedStart), 41.42)
-  expect_equal(sum(p4$guider_inbedEnd), 63.961)
-  expect_equal(sum(p4$number_sib_sleepperiod), 15)
-  expect_equal(sum(p4$sleepefficiency), 0.301)
+  expect_equal(sum(p4$sleeponset), 41.581)
+  expect_equal(sum(p4$wakeup), 58.924)
+  expect_equal(sum(p4$guider_inbedStart), 41.17)
+  expect_equal(sum(p4$guider_inbedEnd), 64.427)
+  expect_equal(sum(p4$number_sib_sleepperiod), 18)
+  expect_equal(sum(p4$sleepefficiency), 0.358)
   expect_equal(sum(p4$longitudinal_axis), 6)
   
   p5 = read.csv("output_test/results/part5_daysummary_MM_L40M100V400_T5A5.csv")

--- a/vignettes/chapter9_SleepFundamentalsGuiders.Rmd
+++ b/vignettes/chapter9_SleepFundamentalsGuiders.Rmd
@@ -162,7 +162,7 @@ Next, this is used to identify the largest non-movement period, by only consider
 
 The algorithm is expected to work with any acceleration metric, so both count-type metrics and metrics in gravitational units.
 
-To use this guider set parameter `HASPT.algo = "NotWorn"`. Further, we recommend combining the using of "NotWorn" with: `do.imp = FALSE`, `HASPT.ignore.invalid = NA`, and `ignorenonwear = FALSE`.
+To use this guider set parameter `HASPT.algo = "NotWorn"`. Further, we recommend combining the using of "NotWorn" with: `do.imp = FALSE` and `ignorenonwear = FALSE`. Internally `HASPT.ignore.invalid` is always set to `NA` when "NotWorn" is used.
 
 If this is used it will also define the resulting window as SIB period and ignore all other identified SIB window to ensure the entire window is treated as sleep. So, all SIB periods detected are ignored.
 


### PR DESCRIPTION
<!-- Describe your PR here -->

[Earlier this year](https://github.com/wadpac/GGIR/commit/e1b0b8ef111e80c1ee7098f6d7c6434e8f71237a) in PR #1137 I added the option to specify `HASPT.algo = c("NotWorn", "HDCZA")` or `HASPT.algo = c("NotWorn", "HorAngle")`. If the window has more than 25% nonwear it will use NotWorn algorithm, alternatively it will fall back on the second guider.

In this PR I am making a number of additional updates:

1. The guider as used, which can differ from night to night, now correctly logged in csv reports (see changes to g.part4).
2. Nights for which `NotWorn` is used are now skipped in the csv part4_nightsummary_sleep_full.csv report  (see changes to g.report.part4).
3. `HorAngle` threshold increased to 60 as that seems more suitable. Additional updates may follow later this autumn but for now this seems a safer choice than 45. As a result I also had to update `test_recordingEndSleepHour`.
4. `HASPT.ignore.invalid` is now automatically set to `NA` when `NotWorn` guider is used. In that way user has freedom control it in relation to HDCZA or HorAngle, while `sticking` to `NA` for `NotWorn`.
5. Fix to `g.part5.savetimeseries` that failed to log the guider used when it includes `+invalid` in the name.
6. The `selectdaysfile` functionality, that got deprecated several years ago, was still present in the unit test, now removed.

Closes #1156 

<!-- Please, make sure the following items are checked -->
### Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [x] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [x] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [ ] Documentation updated:
  - [x] Function documentation
  - [x] Chapter vignettes for GitHub IO
  - [ ] Vignettes for CRAN
- [x] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
- [ ] GGIR parameters were added/removed.
