### PR TITLE
Revised rounding seconds in g.part5.wakesleepwindows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,8 @@
 
   - Skip night in part 4 csv report if guider was NotWorn, #1156
   
-- Part 5: Revised rounding of seconds in timestamps to match epoch size used in part 5 when adding the sleep period time windows to the time series (g.part5.wakesleepwindows). #1192
+- Part 5: Fixed bug in g.part5.wakesleepwindows causing the first SPT window in a recording incorrectly to be  defined from the first timestamp in the recording. For details see: #1192
+
 
 # CHANGES IN GGIR VERSION 3.1-3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,8 @@
   - Improved logging of what guider was used when using NotWorn and optional backup guider, #1156
 
   - Skip night in part 4 csv report if guider was NotWorn, #1156
+  
+- Part 5: Revised rounding of seconds in timestamps to match epoch size used in part 5 when adding the sleep period time windows to the time series (g.part5.wakesleepwindows). #1192
 
 # CHANGES IN GGIR VERSION 3.1-3
 

--- a/R/g.part5.wakesleepwindows.R
+++ b/R/g.part5.wakesleepwindows.R
@@ -27,12 +27,18 @@ g.part5.wakesleepwindows = function(ts, part4_output, desiredtz, nightsi,
       if (temp[3] / epochSize != round(temp[3] / epochSize)) {
         temp[3] = round(temp[3] / epochSize)*epochSize
         if (temp[3] == 60) {
+          # if rounded seconds == 60, then add one minute
           temp[2] = temp[2] + 1
           temp[3] = 0
-        }
-        if (temp[2] == 60) {
-          temp[1] = temp[1] + 1
-          temp[2] = 0
+          if (temp[2] == 60) {
+            # if after adding one minute, minutes == 60, then add 1 hour
+            temp[1] = temp[1] + 1
+            temp[2] = 0
+            if (temp[1] == 24) {
+              # if after adding one hour, hours == 24, then turn to midnight
+              temp[1] = 0
+            }
+          }
         }
         x = paste(temp, collapse = ":")
       }

--- a/R/g.part5.wakesleepwindows.R
+++ b/R/g.part5.wakesleepwindows.R
@@ -25,7 +25,16 @@ g.part5.wakesleepwindows = function(ts, part4_output, desiredtz, nightsi,
     temp = as.numeric(unlist(strsplit(x,":")))
     if (length(temp) == 3) {
       if (temp[3] / epochSize != round(temp[3] / epochSize)) {
-        x = paste0(temp[1],":",temp[2],":",round(temp[3] / epochSize)*epochSize)
+        temp[3] = round(temp[3] / epochSize)*epochSize
+        if (temp[3] == 60) {
+          temp[2] = temp[2] + 1
+          temp[3] = 0
+        }
+        if (temp[2] == 60) {
+          temp[1] = temp[1] + 1
+          temp[2] = 0
+        }
+        x = paste(temp, collapse = ":")
       }
     } else {
       x = ""


### PR DESCRIPTION
<!-- Describe your PR here -->
fixes #1192 => takes care of minute and hour handling when rounding seconds end up in `seconds == 60`. This is important for identifying the index corresponding to a give timestamp when adding the sleep period time windows to the part 5 time series.

<!-- Please, make sure the following items are checked -->
### Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [x] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [ ] Documentation updated:
  - [ ] Function documentation
  - [ ] Chapter vignettes for GitHub IO
  - [ ] Vignettes for CRAN
- [ ] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [ ] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
- [ ] GGIR parameters were added/removed. If yes, please also complete checklist below.

**If NEW GGIR parameter(s) were added then these NEW parameter(s) are:**
- [ ] documented in `man/GGIR.Rd`
- [ ] included with a default in `R/load_params.R`
- [ ] included with value class check in `R/check_params.R`
- [ ] included in table of `vignettes/GGIRParameters.Rmd` with references to the GGIR parts the parameter is used in.
- [ ] mentioned in NEWS.Rd as NEW parameter

**If GGIR parameter(s) were deprecated these parameter(s) are:**
- [ ] documented as deprecated in `man/GGIR.Rd`
- [ ] removed from `R/load_params.R`
- [ ] removed from `R/check_params.R`
- [ ] removed from table in `vignettes/GGIRParameters.Rmd`
- [ ] mentioned as deprecated parameter in NEWS.Rd
- [ ] added to the list in `R/extract_params.R` with deprecated parameters such that these do not produce warnings when found in old config.csv files.