### PR TITLE
Issue1198 addfirstwake

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# CHANGES IN GGIR VERSION 3.1-5
+
+- Part 5: Fixed minor bug in g.part5.addfirstwake causing the first wake is not correctly added when
+no SIBs are detected from the beginning of the recording until the first detected night. #1198
+
 # CHANGES IN GGIR VERSION 3.1-4
 
 - Part 3: Update threshold used for HorAngle to 60 degree, and auto-setting HASPT.ignore.invalid to NA when NotWorn guider is used. #1186

--- a/R/g.part5.addfirstwake.R
+++ b/R/g.part5.addfirstwake.R
@@ -73,7 +73,9 @@ g.part5.addfirstwake = function(ts, summarysleep, nightsi, sleeplog, ID,
     if (is.na(wake_night1_index)) wake_night1_index = 0
     if (wake_night1_index < firstwake & wake_night1_index > 1 &
         (wake_night1_index - 1) > nightsi[1]) {
-      newWakeIndex = max(which(ts$sibdetection[1:(wake_night1_index - 1)] == 1))
+      newWakeIndex = c()
+      firstSIBs = which(ts$sibdetection[1:(wake_night1_index - 1)] == 1)
+      if (length(firstSIBs) > 0) newWakeIndex = max(firstSIBs)
       if (length(newWakeIndex) == 0) {
         newWakeIndex = wake_night1_index - 1
       }


### PR DESCRIPTION
<!-- Describe your PR here -->
Fixes #1198 => in those cases in which the first wake time needs to be detected in part 5 (with `g.part5.addfirstwake`) and no sustained inactivity bouts have been detected from the begining of the recording until the first detected night, then GGIR struggled to define the first wake up and triggered an error. 

This scenario is very rare, and most likely in those study protocols in which the recordings start early in the morning and participants do not wear the devices durint nighttime.

<!-- Please, make sure the following items are checked -->
### Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [x] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [ ] Documentation updated:
  - [ ] Function documentation
  - [ ] Chapter vignettes for GitHub IO
  - [ ] Vignettes for CRAN
- [ ] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
- [ ] GGIR parameters were added/removed. If yes, please also complete checklist below.

**If NEW GGIR parameter(s) were added then these NEW parameter(s) are:**
- [ ] documented in `man/GGIR.Rd`
- [ ] included with a default in `R/load_params.R`
- [ ] included with value class check in `R/check_params.R`
- [ ] included in table of `vignettes/GGIRParameters.Rmd` with references to the GGIR parts the parameter is used in.
- [ ] mentioned in NEWS.Rd as NEW parameter

**If GGIR parameter(s) were deprecated these parameter(s) are:**
- [ ] documented as deprecated in `man/GGIR.Rd`
- [ ] removed from `R/load_params.R`
- [ ] removed from `R/check_params.R`
- [ ] removed from table in `vignettes/GGIRParameters.Rmd`
- [ ] mentioned as deprecated parameter in NEWS.Rd
- [ ] added to the list in `R/extract_params.R` with deprecated parameters such that these do not produce warnings when found in old config.csv files.