### PR TITLE
Issue1197 date and filename

### DIFF
--- a/R/g.analyse.perday.R
+++ b/R/g.analyse.perday.R
@@ -5,7 +5,7 @@ g.analyse.perday = function(ndays, firstmidnighti, time, nfeatures,
                             doquan, quantiletype, doilevels, domvpa,
                             mvpanames, wdaycode, ID,
                             deviceSerialNumber, ExtFunColsi, myfun, desiredtz = "",
-                            params_247 = c(), params_phyact = c(), params_general = c(),
+                            params_247 = c(), params_phyact = c(),
                             ...) {
   #get input variables
   input = list(...)
@@ -18,12 +18,10 @@ g.analyse.perday = function(ndays, firstmidnighti, time, nfeatures,
     # as if it was still the old g.analyse function
     params = extract_params(params_247 = params_247,
                             params_phyact = params_phyact,
-                            params_general = params_general,
                             input = input,
-                            params2check = c("247", "phyact", "general")) # load default parameters
+                            params2check = c("247", "phyact")) # load default parameters
     params_247 = params$params_247
     params_phyact = params$params_phyact
-    params_general = params$params_general
     rm(params)
   }
   
@@ -199,9 +197,8 @@ g.analyse.perday = function(ndays, firstmidnighti, time, nfeatures,
     ds_names[fi] = "ID";      fi = fi + 1
     daysummary[di,fi] = fname
     ds_names[fi] = "filename";  fi = fi + 1
-    # calendardate = unlist(strsplit(as.character(vari[1,1])," "))[1]
-    calendardate = as.Date(vari[1,1], tz = params_general[["desiredtz"]])
-    daysummary[di,fi] = as.character(calendardate)
+    calendardate = unlist(strsplit(as.character(vari[1,1])," "))[1]
+    daysummary[di,fi] = calendardate
     daysummary[di,(fi + 1)] = sensor.location
     daysummary[di,(fi + 2)] = nvalidhours
     daysummary[di,(fi + 3)] = nhours

--- a/R/g.analyse.perday.R
+++ b/R/g.analyse.perday.R
@@ -5,7 +5,7 @@ g.analyse.perday = function(ndays, firstmidnighti, time, nfeatures,
                             doquan, quantiletype, doilevels, domvpa,
                             mvpanames, wdaycode, ID,
                             deviceSerialNumber, ExtFunColsi, myfun, desiredtz = "",
-                            params_247 = c(), params_phyact = c(),
+                            params_247 = c(), params_phyact = c(), params_general = c(),
                             ...) {
   #get input variables
   input = list(...)
@@ -18,10 +18,12 @@ g.analyse.perday = function(ndays, firstmidnighti, time, nfeatures,
     # as if it was still the old g.analyse function
     params = extract_params(params_247 = params_247,
                             params_phyact = params_phyact,
+                            params_general = params_general,
                             input = input,
-                            params2check = c("247", "phyact")) # load default parameters
+                            params2check = c("247", "phyact", "general")) # load default parameters
     params_247 = params$params_247
     params_phyact = params$params_phyact
+    params_general = params$params_general
     rm(params)
   }
   
@@ -197,8 +199,9 @@ g.analyse.perday = function(ndays, firstmidnighti, time, nfeatures,
     ds_names[fi] = "ID";      fi = fi + 1
     daysummary[di,fi] = fname
     ds_names[fi] = "filename";  fi = fi + 1
-    calendardate = unlist(strsplit(as.character(vari[1,1])," "))[1]
-    daysummary[di,fi] = calendardate
+    # calendardate = unlist(strsplit(as.character(vari[1,1])," "))[1]
+    calendardate = as.Date(vari[1,1], tz = params_general[["desiredtz"]])
+    daysummary[di,fi] = as.character(calendardate)
     daysummary[di,(fi + 1)] = sensor.location
     daysummary[di,(fi + 2)] = nvalidhours
     daysummary[di,(fi + 3)] = nhours

--- a/R/g.report.part2.R
+++ b/R/g.report.part2.R
@@ -239,7 +239,8 @@ g.report.part2 = function(metadatadir = c(), f0 = c(), f1 = c(), maxdur = 0,
       # tidy up data.frames
       SUMMARY_clean = tidyup_df(SUMMARY)
       daySUMMARY_clean = tidyup_df(daySUMMARY)
-      
+      # format calendar dates (dates are stored as iso8601, so date is in the first 10 characters )
+      daySUMMARY_clean$calendar_date = substr(daySUMMARY_clean$calendar_date, 1, 10)
       #===============================================================================
       # store final matrices again
       data.table::fwrite(x = SUMMARY_clean, file = paste0(metadatadir, "/results/part2_summary.csv"),

--- a/R/g.report.part4.R
+++ b/R/g.report.part4.R
@@ -76,6 +76,9 @@ g.report.part4 = function(datadir = c(), metadatadir = c(), loglocation = c(),
     }
     nightsummary2 = as.data.frame(do.call(rbind, lapply(fnames.ms4, myfun)), stringsAsFactors = FALSE)
     nightsummary2$night = as.numeric(gsub(" ", "", nightsummary2$night))
+    nightsummary2$calendar_date = as.Date(nightsummary2$calendar_date, format = "%d/%m/%Y")
+    nightsummary2$calendar_date = as.character(nightsummary2$calendar_date)
+    nightsummary2$filename = gsub(".RData$", "", nightsummary2$filename)
     # ====================================== Add non-wearing during SPT from part 5, if it is availabe:
     ms5.out = "/meta/ms5.out"
     if (file.exists(paste(metadatadir, ms5.out, sep = ""))) {

--- a/R/g.report.part5.R
+++ b/R/g.report.part5.R
@@ -184,6 +184,9 @@ g.report.part5 = function(metadatadir = c(), f0 = c(), f1 = c(), loglocation = c
       outputfinal = outputfinal[,-cut]
     }
     
+    # revise filename
+    outputfinal$filename = gsub(".RData$", "", outputfinal$filename)
+
     # order data.frame
     outputfinal$window_number = as.numeric(gsub(" ", "", outputfinal$window_number))
     outputfinal = outputfinal[order(outputfinal$filename, outputfinal$window_number, outputfinal$window), ]


### PR DESCRIPTION
<!-- Describe your PR here -->
Closes #1197 

- For part 2, 4, and 5 reports, the filename and date columns are now standardised in the `g.report.partX` functions. 
- In part 6, there was only need to standardise the `filename` (`calendar_date` is not a column in part6_summary). Here, it was easier to handle that directly in `g.part6` because it required access to the part 5 meta data to extract the original filename (it was using the filename from the part 5 time series, which is not the original one as used in the other reports).

`filename` is provided as the original filename of the raw data file path without the .RData extension corresponding to the meta data generated in GGIR (e.g., id001.gt3x instead of id001.gt3x.RData).
`calendar_date` is provided as "%Y-%m-%d" in all reports.

<!-- Please, make sure the following items are checked -->
### Checklist before merging:

- [ ] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [ ] Documentation updated:
  - [ ] Function documentation
  - [ ] Chapter vignettes for GitHub IO
  - [ ] Vignettes for CRAN
- [ ] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [ ] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
- [ ] GGIR parameters were added/removed. If yes, please also complete checklist below.

**If NEW GGIR parameter(s) were added then these NEW parameter(s) are:**
- [ ] documented in `man/GGIR.Rd`
- [ ] included with a default in `R/load_params.R`
- [ ] included with value class check in `R/check_params.R`
- [ ] included in table of `vignettes/GGIRParameters.Rmd` with references to the GGIR parts the parameter is used in.
- [ ] mentioned in NEWS.Rd as NEW parameter

**If GGIR parameter(s) were deprecated these parameter(s) are:**
- [ ] documented as deprecated in `man/GGIR.Rd`
- [ ] removed from `R/load_params.R`
- [ ] removed from `R/check_params.R`
- [ ] removed from table in `vignettes/GGIRParameters.Rmd`
- [ ] mentioned as deprecated parameter in NEWS.Rd
- [ ] added to the list in `R/extract_params.R` with deprecated parameters such that these do not produce warnings when found in old config.csv files.