### PR TITLE
Small changes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@ no SIBs are detected from the beginning of the recording until the first detecte
 
 - Reports: The calendar_date and filename columns in reports have been standardized, as %Y-%m-%d and the input accelerometer file name, respectively. #1197
 
+- Part 1: Reverse default value for nonwear_range_threshold as changed in 3.1-3 back to 150 as more research needed to support the change. #1172
+
 # CHANGES IN GGIR VERSION 3.1-4
 
 - Part 3: Update threshold used for HorAngle to 60 degree, and auto-setting HASPT.ignore.invalid to NA when NotWorn guider is used. #1186

--- a/R/g.part5.R
+++ b/R/g.part5.R
@@ -4,6 +4,7 @@ g.part5 = function(datadir = c(), metadatadir = c(), f0=c(), f1=c(),
                    params_cleaning = c(), params_output = c(),
                    params_general = c(), verbose = TRUE, ...) {
   options(encoding = "UTF-8")
+  filename_dir = NULL
   # This function called by function GGIR
   # and aims to combine all the milestone output from the previous parts
   # in order to facilitate a varierty of analysis on time-use, interactions
@@ -170,7 +171,7 @@ g.part5 = function(datadir = c(), metadatadir = c(), f0=c(), f1=c(),
         # convert to character/numeric if stored as factor in metashort and metalong
         M$metashort = correctOlderMilestoneData(M$metashort)
         M$metalong = correctOlderMilestoneData(M$metalong)
-        filename = filename_dir
+        filename = filename_dir # object comes from load() call above
         # load output g.part3
         longitudinal_axis = NULL # initialise var that is part of ms3.out
         load(paste0(metadatadir, "/meta/ms3.out/", fnames.ms3[i]))

--- a/R/load_params.R
+++ b/R/load_params.R
@@ -61,7 +61,7 @@ load_params = function(topic = c("sleep", "metrics", "rawdata",
       rmc.desiredtz = NULL, rmc.configtz = NULL,  rmc.sf = c(),
       rmc.headername.sf = c(), rmc.headername.sn = c(),
       rmc.headername.recordingid = c(), rmc.header.structure = c(),
-      rmc.check4timegaps = FALSE,  rmc.noise = 13, nonwear_range_threshold = 50,
+      rmc.check4timegaps = FALSE,  rmc.noise = 13, nonwear_range_threshold = 150,
       rmc.col.wear = c(), rmc.doresample = FALSE,
       interpolationType = 1,
       imputeTimegaps = TRUE, frequency_tol = 0.1, rmc.scalefactor.acc = 1)

--- a/vignettes/readmyacccsv.Rmd
+++ b/vignettes/readmyacccsv.Rmd
@@ -37,7 +37,7 @@ Internally GGIR loads csv files with accelerometer data and standardises the out
 
 # The read.myacc.csv function
 
-As for the rest of GGIR functions, `read.myacc.csv` is intended to be used within function `GGIR`. All the arguments of the `read.myacc.csv` can be easily recognized as they all start by "rmc". The GGIR function checks whether the argument `rmc.firstrow.acc` is provided by the user; in such case, GGIR will attempt to read the data with `read.myacc.csv`. In other words you always need to specify `rmc.firstrow.acc` to use `read.myacc.csv`.
+As for the rest of GGIR functions, `read.myacc.csv` is intended to be used within function `GGIR`. All the arguments of the `read.myacc.csv` can be easily recognized as they all start by "rmc". GGIR checks whether argument `rmc.firstrow.acc` is provided by the user; in such case, GGIR will attempt to read the data with function `read.myacc.csv`. In other words you always need to specify `rmc.firstrow.acc` to use `read.myacc.csv`. Further, we recommend that you always first test the function argument settings by first trying to use function `read.myacc.csv` on its own. When that works copy the arguments to you GGIR call.
 
 ## Input arguments
 
@@ -53,8 +53,8 @@ Below we present a summary of the available input arguments. Please see the [par
 - `rmc.dec` - Decimal separator used for numbers, same as dec argument in \link[utils]{read.csv} and in data.table::\link[data.table]{fread}. If not "." (default) then usually ",".
 - `rmc.firstrow.acc` - First row (number) of the acceleration data.
 - `rmc.unit.acc` - Character with unit of acceleration values: "g", "mg", or "bit".
-- `rmc.desiredtz` - Timezone in which device was worn.
-- `rmc.confgitz` - Timezone in which device was configured.
+- `desiredtz` - Timezone in which device was worn.
+- `confgitz` - Timezone in which device was configured.
 - `rmc.sf` - Sample rate in Hertz, if this is stored in the file header then that will be used instead.
 
 ### Arguments for files containing a header {#header}
@@ -112,7 +112,7 @@ dateTime | acc_x | acc_y | acc_z | ambient_temp
 
 This file contains timestamps in the column 1 (formatted as "%d/%m/%Y %H:%M:%OS"), the acceleration signals (in _g_'s) for the x, y, and z axis in the columns 2, 3, and 4, respectively, and temperature information in Celsius in the column 5. Also, this file has no header.
 
-First, we test read this file using the `read.myacc.csv` function in GGIR as follows.
+Before we can use this with GGIR, we first test read this file using the `read.myacc.csv` function directly.
 
 ```{R,eval=FALSE}
 library(GGIR)
@@ -128,7 +128,7 @@ read.myacc.csv(rmc.file = "C:/mystudy/mydata/datafile.csv",
                rmc.unit.temp = "C",
                rmc.unit.time = "POSIX",
                rmc.format.time = "%d/%m/%Y %H:%M:%OS",
-               rmc.desiredtz = "Europe/London",
+               desiredtz = "Europe/London",
                rmc.sf = 100)
 ```
 
@@ -156,7 +156,7 @@ GGIR(
              rmc.unit.temp = "C", 
              rmc.unit.time = "POSIX",
              rmc.format.time = "%d/%m/%Y %H:%M:%OS",
-             rmc.desiredtz = "Europe/London",
+             desiredtz = "Europe/London",
              rmc.sf = 100,
              rmc.noise = 0.013
 )


### PR DESCRIPTION
<!-- Describe your PR here -->

1. Fixes #1208 by adding declaration of object.
2. Reverses threshold changes in 3.1-3 relating to #1172 
3. Update read.myacc.csv documentation:
    - No longer refer to the arguments rmc.desiredtz and rmc.configtz that will be deprecated.
    - Emphasize that user should always test their arguments with read.myacc.csv directly, following experience with #1178

<!-- Please, make sure the following items are checked -->
### Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [x] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [ ] Documentation updated:
  - [ ] Function documentation
  - [ ] Chapter vignettes for GitHub IO
  - [x] Vignettes for CRAN
- [x] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
- [ ] GGIR parameters were added/removed. If yes, please also complete checklist below.
