### PR TITLE
Issue1211 MM window definition in part 5

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
   - Add parameters require_complete_lastnight_part5 to control whether last window is included if last night is incomplete. #1196
 
+  - Revise MM window definition in daylight saving time days, as it assumed fixed day duration of 24 hours #1211 
+
 - General: GGIR version look-up in .onattach() no longer crashes when computer is offline, fixes #1203.
 
 - Reports: The calendar_date and filename columns in reports have been standardized, as %Y-%m-%d and the input accelerometer file name, respectively. #1197

--- a/R/g.part5.definedays.R
+++ b/R/g.part5.definedays.R
@@ -41,7 +41,6 @@ g.part5.definedays = function(nightsi, wi, indjump, nightsi_bu,
   # Check that it is possible to find both windows (WW and MM)
   # in the data for this day.
   if (timewindowi == "MM") {
-    NepochPerDay = ((24*3600) / epochSize)
     # include first and last partial days in MM
     if (nightsi[1] > 1) nightsi = c(1, nightsi)
     if (nightsi[length(nightsi)] < nrow(ts)) nightsi = c(nightsi, nrow(ts))
@@ -78,9 +77,9 @@ g.part5.definedays = function(nightsi, wi, indjump, nightsi_bu,
       breaks = qwindow2timestamp(qwindow, epochSize)
       if (24 %in% qwindow) {
         # 24:00:00: probably does not exist, replace by last timestamp in a day
-        # here, NepochPerDay + 1 extra hour just in case we are deriving this in 
+        # here, we consider N epochs per day plus 1 hour just in case we are deriving this in 
         # a 25-hour daylight saving time day
-        NepochPerDayPlusOneHr = NepochPerDay + 60*60/epochSize
+        NepochPerDayPlusOneHr = ((25*3600) / epochSize)
         latest_time_in_day = max(format(ts$time[1:pmin(Nts, NepochPerDayPlusOneHr)], format = "%H:%M:%S"))
         breaks = gsub(pattern = "24:00:00", replacement = latest_time_in_day, x = breaks)
       }

--- a/R/g.part5.definedays.R
+++ b/R/g.part5.definedays.R
@@ -78,7 +78,10 @@ g.part5.definedays = function(nightsi, wi, indjump, nightsi_bu,
       breaks = qwindow2timestamp(qwindow, epochSize)
       if (24 %in% qwindow) {
         # 24:00:00: probably does not exist, replace by last timestamp in a day
-        latest_time_in_day = max(format(ts$time[1:pmin(Nts, NepochPerDay)], format = "%H:%M:%S"))
+        # here, NepochPerDay + 1 extra hour just in case we are deriving this in 
+        # a 25-hour daylight saving time day
+        NepochPerDayPlusOneHr = NepochPerDay + 60*60/epochSize
+        latest_time_in_day = max(format(ts$time[1:pmin(Nts, NepochPerDayPlusOneHr)], format = "%H:%M:%S"))
         breaks = gsub(pattern = "24:00:00", replacement = latest_time_in_day, x = breaks)
       }
       breaks_i = c()

--- a/R/g.part5.definedays.R
+++ b/R/g.part5.definedays.R
@@ -42,24 +42,14 @@ g.part5.definedays = function(nightsi, wi, indjump, nightsi_bu,
   # in the data for this day.
   if (timewindowi == "MM") {
     NepochPerDay = ((24*3600) / epochSize)
-    # offset from prev midnight
-    t0 = format(ts$time[1], "%H:%M:%S")
-    hms = as.numeric(unlist(strsplit(t0, ":")))
-    NepochFromPrevMidnight = (hms[1]*60*60 + hms[2]*60 + hms[3]) / epochSize
-    NepochFromDayborder2Midnight = (-dayborder*60*60) / epochSize
-    NepochFromPrevNight = NepochFromPrevMidnight + NepochFromDayborder2Midnight
-    if (NepochFromPrevNight < 0) {
-      NepochFromPrevNight = NepochPerDay + NepochFromPrevNight
-    }
-    if (wi == 1) {
-      qqq[1] = 1
-      qqq[2] = NepochPerDay - NepochFromPrevNight
-    } else {
-      qqq[1] = ((wi - 1) * NepochPerDay) - NepochFromPrevNight + 1
-      qqq[2] = (wi * NepochPerDay) - NepochFromPrevNight
-    }
+    # include first and last partial days in MM
+    if (nightsi[1] > 1) nightsi = c(1, nightsi)
+    if (nightsi[length(nightsi)] < nrow(ts)) nightsi = c(nightsi, nrow(ts))
+    # define window
+    qqq[1] = nightsi[wi]
+    qqq[2] = nightsi[wi + 1] - 1
     # is this the last day?
-    if (qqq[2] >= Nts) {
+    if (qqq[2] >= Nts - 1) {
       qqq[2] = Nts
       lastDay = TRUE
     }


### PR DESCRIPTION
<!-- Describe your PR here -->
Fixes #1211 => Fixes definition of MM windows in g.part5.definedays as it assumed fixed window duration of 24 hours which does not hold true in daylight saving time days.

<!-- Please, make sure the following items are checked -->
### Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [x] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [ ] Documentation updated:
  - [ ] Function documentation
  - [ ] Chapter vignettes for GitHub IO
  - [ ] Vignettes for CRAN
- [x] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
- [ ] GGIR parameters were added/removed. If yes, please also complete checklist below.

**If NEW GGIR parameter(s) were added then these NEW parameter(s) are:**
- [ ] documented in `man/GGIR.Rd`
- [ ] included with a default in `R/load_params.R`
- [ ] included with value class check in `R/check_params.R`
- [ ] included in table of `vignettes/GGIRParameters.Rmd` with references to the GGIR parts the parameter is used in.
- [ ] mentioned in NEWS.Rd as NEW parameter

**If GGIR parameter(s) were deprecated these parameter(s) are:**
- [ ] documented as deprecated in `man/GGIR.Rd`
- [ ] removed from `R/load_params.R`
- [ ] removed from `R/check_params.R`
- [ ] removed from table in `vignettes/GGIRParameters.Rmd`
- [ ] mentioned as deprecated parameter in NEWS.Rd
- [ ] added to the list in `R/extract_params.R` with deprecated parameters such that these do not produce warnings when found in old config.csv files.