### PR TITLE
Enhance recently added require_complete_lastnight_part5 functionality

### DIFF
--- a/R/g.report.part5.R
+++ b/R/g.report.part5.R
@@ -47,32 +47,34 @@ g.report.part5 = function(metadatadir = c(), f0 = c(), f1 = c(), loglocation = c
       
       x$wear_min_day = (1 - (x$nonwear_perc_day / 100)) * x$dur_day_min #valid minute during waking hours
       x$wear_perc_day = 100 - x$nonwear_perc_day #wear percentage during waking hours
-      x$lasttimestamp = as.numeric(x$lasttimestamp)
-      
+      x$lastHour = as.numeric(x$lastHour)
+      x$calendar_date = as.Date(x$calendar_date)
       minimumValidMinutesMM = 0 # default
       if (length(params_cleaning[["includedaycrit"]]) == 2) {
         minimumValidMinutesMM = params_cleaning[["includedaycrit"]][2] * 60
       }
       if (params_output[["require_complete_lastnight_part5"]] == FALSE) {
-        x$lastnight = FALSE
+        x$lastWindow = FALSE
+        x$lastDate = x$calendar_date
       } else {
-        x$lastnight = x$window_number == max(x$window_number)
+        x$lastWindow = x$window_number == max(x$window_number)
+        x$lastDate = as.Date(x$lastDate)
       }
       if (window == "WW" | window == "OO") {
         indices = which(x$wear_perc_day >= includeday_wearPercentage &
                           x$wear_min_day >= includeday_absolute &
                           x$dur_spt_min > 0 & x$dur_day_min > 0 &
-                          ((x$lastnight == TRUE & x$lasttimestamp >= 15 & window == "WW") |
-                             (x$lastnight == TRUE & x$lasttimestamp >= 9 & window == "OO") |
-                             x$lastnight == FALSE) &
+                          ((x$lastWindow == TRUE & x$lastHour >= 15 & (x$lastDate - x$calendar_date) >= -1 & window == "WW") |
+                             (x$lastWindow == TRUE & x$lastHour >= 9 & (x$lastDate - x$calendar_date) >= -1 & window == "OO") |
+                             x$lastWindow == FALSE) &
                           include_window == TRUE &
                           x$wear_min_day_spt >= minimumValidMinutesMM)
       } else if (window == "MM") {
         indices = which(x$wear_perc_day >= includeday_wearPercentage &
                           x$wear_min_day >= includeday_absolute &
                           x$dur_spt_min > 0 & x$dur_day_min > 0 &
-                          ((x$lastnight == TRUE & x$lasttimestamp > 9) |
-                             x$lastnight == FALSE) &
+                          ((x$lastWindow == TRUE & x$lastHour > 9 & (x$lastDate - x$calendar_date) >= -1) |
+                             x$lastWindow == FALSE) &
                           x$dur_day_spt_min >= (params_cleaning[["minimum_MM_length.part5"]] * 60) &
                           include_window == TRUE &
                           x$wear_min_day_spt >= minimumValidMinutesMM)
@@ -136,9 +138,11 @@ g.report.part5 = function(metadatadir = c(), f0 = c(), f1 = c(), loglocation = c
         output = output[-cut, which(colnames(output) != "")]
       }
       if (exists("last_timestamp") == TRUE) {
-        output$lasttimestamp = as.numeric(format(last_timestamp, "%H"))
+        output$lastHour = as.numeric(format(last_timestamp, "%H"))
+        output$lastDate = as.Date(last_timestamp)
       } else {
-        output$lasttimestamp = Inf # use dummy value
+        output$lastHour = Inf # use dummy value
+        output$lastDate = Inf # use dummy value
       }
       out = as.matrix(output)
       if (length(expectedCols) > 0) {
@@ -163,9 +167,9 @@ g.report.part5 = function(metadatadir = c(), f0 = c(), f1 = c(), loglocation = c
                                        "daysleeper|sleeplog_used|_spt_sleep|_spt_wake"),
                       x = names(out), value = FALSE)
         window_number = as.numeric(out[,"window_number"])
-        lastwindow = which(window_number == max(window_number, na.rm = TRUE))
-        if (length(col2na) > 0 & length(lastwindow) > 0) {
-          out[lastwindow, col2na] = "" # set last row to NA for all sleep related variables
+        lastwindow_indices = which(window_number == max(window_number, na.rm = TRUE))
+        if (length(col2na) > 0 & length(lastwindow_indices) > 0) {
+          out[lastwindow_indices, col2na] = "" # set last row to NA for all sleep related variables
         }
       }
       return(out)
@@ -290,8 +294,8 @@ g.report.part5 = function(metadatadir = c(), f0 = c(), f1 = c(), loglocation = c
                 # store all summaries in csv files with cleaning criteria
                 validdaysi = getValidDayIndices(x = OF3_clean, window = uwi[j],
                                                 params_cleaning = params_cleaning)
-                if ("lasttimestamp" %in% colnames(OF3_clean)) {
-                  OF3_clean = OF3_clean[, -which(colnames(OF3_clean) == "lasttimestamp")]
+                if ("lastHour" %in% colnames(OF3_clean)) {
+                  OF3_clean = OF3_clean[, -which(colnames(OF3_clean) %in% c("lastHour", "lasteDate"))]
                 }
                 if (length(validdaysi) > 0) {
                   data.table::fwrite(

--- a/man/GGIR.Rd
+++ b/man/GGIR.Rd
@@ -1541,10 +1541,12 @@ GGIR(mode = 1:5,
           when viewingwindow = 1 or \code{includenightcrit} when viewingwindow = 2}
       \item{require_complete_lastnight_part5}{    
           Boolean (default = FALSE).
-          When set to TRUE: The last WW window is excluded if recording ends 
-          between midnight and 3pm; The last OO and MM window are excluded if 
-          recording ends between midnight and 9am. This to avoid risk that recording
-          end biases the sleep estimates for the last night.
+          When set to TRUE: The last WW window is excluded if the recording ends 
+          between midnight and 3pm, and starts on a date that is on or one day before the 
+          recording end date; The last OO and MM window are excluded if recording 
+          ends between midnight and 9am, and starts on a date that is on or one
+          day before the recording end date. This to avoid risk that recording end 
+          biases the sleep estimates for the last night.
       }
     }
   }


### PR DESCRIPTION
This PR makes sure our recent updates related to #1196 focuses only on the last window if it is related to the last night in the recording and in no circumstances considers deleting windows earlier in the recording. I do this to make the code more robust.

- Additionally I have tried to improve object names.
- Update to NEWS.Rd is not needed because recent update has not been released yet.
- Fixes #1196

<!-- Describe your PR here -->

<!-- Please, make sure the following items are checked -->
### Checklist before merging:

- [ ] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [x] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [ ] Documentation updated:
  - [x] Function documentation
  - [ ] Chapter vignettes for GitHub IO
  - [ ] Vignettes for CRAN
- [x] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
- [ ] GGIR parameters were added/removed. If yes, please also complete checklist below.
