### PR TITLE
Fix to several smaller issues relating to visualreport, diary handling, and simplifying usage of MVPA parameters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,24 @@
 # CHANGES IN GGIR VERSION 3.1-??
 
-- Part 2: Fix bug in determining the number of files to be included in the part 2 report.
+- Part 2:
 
-- Part 4: Further improvements to handling dates in sleeplog as a follow-up to work on #1243
+  - Fix bug in determining the number of files to be included in the part 2 report.
+
+  - Speed up activity diary extraction.
+
+  - Make sure event diary is saved to csv with intended sep and dec arguments rather than default.
 
 - Part 2 and 4: Both activity diary and sleep diary are now always reloaded if the derived copy of it (in .RData) is older than the diary itself.
 
-- Part 2: Make sure event diary is saved to csv with intended sep and dec arguments rather than default.
+- Visual report: Recently added visual report is now also able to handle recordings with only 1 valid data, these were previously skipped.
+
+- Part 4:
+
+  - Improvements to handling dates in sleeplog as a follow-up to work on #1243
+  
+  - Added warning when there are two accelerometer recordings with the same ID.
+
+  - Change extraction of imputation code from sleep diary, which is now assumed to correspond to preceding night. This is now also documented.
 
 # CHANGES IN GGIR VERSION 3.1-10
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,15 +2,15 @@
 
 - Part 2:
 
-  - Fix bug in determining the number of files to be included in the part 2 report.
+  - Fix bug in determining the number of files to be included in the part 2 report. This does not affect subsequent GGIR parts but does affect the part 2 report which may have had less recordings than expected. #1252
 
-  - Speed up activity diary extraction.
+  - Speed up activity diary extraction. #1250
 
   - Make sure event diary is saved to csv with intended sep and dec arguments rather than default.
 
-- Part 2 and 4: Both activity diary and sleep diary are now always reloaded if the derived copy of it (in .RData) is older than the diary itself.
+- Part 2 and 4: Both activity diary and sleep diary are now always reloaded if the derived copy of it (in .RData) is older than the diary itself. #1250
 
-- Visual report: Recently added visual report is now also able to handle recordings with only 1 valid data, these were previously skipped.
+- Visual report: Recently added visual report is now also able to handle recordings with only 1 valid data, these were previously skipped. #1246
 
 - Part 4:
 
@@ -18,7 +18,7 @@
   
   - Added warning when there are two accelerometer recordings with the same ID.
 
-  - Change extraction of imputation code from sleep diary, which is now assumed to correspond to preceding night. This is now also documented.
+  - Change extraction of imputation code from sleep diary, which is now assumed to correspond to preceding night. This is now also documented. #1251
 
 # CHANGES IN GGIR VERSION 3.1-10
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
   - Speed up activity diary extraction. #1250
 
   - Make sure event diary is saved to csv with intended sep and dec arguments rather than default.
+  
+  - Simplify MVPA parameter specification in part 2 (mvpathreshold, boutcriter) by copying values from corresponding parameters in part 5 (threshold.mod and boutcriter.mvpa) if not specified. #1247
 
 - Part 2 and 4: Both activity diary and sleep diary are now always reloaded if the derived copy of it (in .RData) is older than the diary itself. #1250
 

--- a/R/check_params.R
+++ b/R/check_params.R
@@ -10,17 +10,17 @@ check_params = function(params_sleep = c(), params_metrics = c(),
           x = params[[parname]]
           if (parclass == "numeric") {
             if (!is.numeric(x)) {
-              stop(paste0("\n", category, " argument ", parname, " is not ", parclass))
+              stop(paste0("\n", category, " parameter ", parname, " is not ", parclass))
             }
           }
           if (parclass == "boolean") {
             if (!is.logical(x)) {
-              stop(paste0("\n", category, " argument ", parname, " is not ", parclass))
+              stop(paste0("\n", category, " parameter ", parname, " is not ", parclass))
             }
           }
           if (parclass == "character") {
             if (!is.character(x)) {
-              stop(paste0("\n", category, " argument ", parname, " is not ", parclass))
+              stop(paste0("\n", category, " parameter ", parname, " is not ", parclass))
             }
           }
         }
@@ -168,14 +168,14 @@ check_params = function(params_sleep = c(), params_metrics = c(),
     if (params_metrics[["do.brondcounts"]] == TRUE) {
       stop(paste0("\nThe brondcounts option has been deprecated following issues with the ",
                   "activityCounts package. We will reinsert brondcounts ",
-                  "once the issues are resolved. Consider using argument do.neishabouricounts, ",
+                  "once the issues are resolved. Consider using parameter do.neishabouricounts, ",
                   "for more information see package documentation."), call. = FALSE)
     }
   }
   
   if (length(params_rawdata) > 0) {
     if (params_rawdata[["frequency_tol"]] < 0 | params_rawdata[["frequency_tol"]] > 1) {
-      stop(paste0("\nArgument frequency_tol is ", params_rawdata[["frequency_tol"]],
+      stop(paste0("\nParameter frequency_tol is ", params_rawdata[["frequency_tol"]],
                   " , please adjust such that it is a number between 0 and 1"))
     }
   }
@@ -218,7 +218,7 @@ check_params = function(params_sleep = c(), params_metrics = c(),
     
     if (params_sleep[["HASIB.algo"]] %in% c("Sadeh1994", "Galland2012", "ColeKripke1992") == TRUE) {
       if (params_sleep[["Sadeh_axis"]] %in% c("X","Y","Z") == FALSE) {
-        warning("Argument Sadeh_axis does not have meaningful value, it needs to be X, Y or Z (capital)", call. = FALSE)
+        warning("Parameter Sadeh_axis does not have meaningful value, it needs to be X, Y or Z (capital)", call. = FALSE)
       }
       if (params_sleep[["Sadeh_axis"]] == "X" & params_metrics[["do.zcx"]] == FALSE) params_metrics[["do.zcx"]] =  TRUE
       if (params_sleep[["Sadeh_axis"]] == "Y" & params_metrics[["do.zcy"]] == FALSE) params_metrics[["do.zcy"]] =  TRUE
@@ -233,7 +233,7 @@ check_params = function(params_sleep = c(), params_metrics = c(),
         params_sleep[["HASPT.algo"]][1] %in% c("notused", "NotWorn") == FALSE) {
       if (params_metrics[["do.anglex"]] == FALSE | params_metrics[["do.angley"]] == FALSE | params_metrics[["do.anglez"]] == FALSE) {
         warning(paste0("\nWhen working with hip data all three angle metrics are needed,",
-                       "so GGIR now auto-sets arguments do.anglex, do.angley, and do.anglez to TRUE."), call. = FALSE)
+                       "so GGIR now auto-sets parameters do.anglex, do.angley, and do.anglez to TRUE."), call. = FALSE)
         params_metrics[["do.anglex"]] = params_metrics[["do.angley"]] = params_metrics[["do.anglez"]] = TRUE
       }
       if (length(params_sleep[["HASPT.algo"]]) == 1 && params_sleep[["HASPT.algo"]][1] != "HorAngle") {
@@ -256,7 +256,7 @@ check_params = function(params_sleep = c(), params_metrics = c(),
     if (length(params_sleep[["loglocation"]]) > 0 & length(params_sleep[["def.noc.sleep"]]) != 1) {
       warning(paste0("\nloglocation was specified and def.noc.sleep does not have length of 1, this is not compatible. ",
                      " We assume you want to use the sleeplog and misunderstood",
-                     " argument def.noc.sleep. Therefore, we will reset def.noc.sleep to its default value of 1"), call. = FALSE)
+                     " parameter def.noc.sleep. Therefore, we will reset def.noc.sleep to its default value of 1"), call. = FALSE)
       params_sleep[["def.noc.sleep"]] = 1
     }
     
@@ -281,21 +281,21 @@ check_params = function(params_sleep = c(), params_metrics = c(),
       params_cleaning[["data_masking_strategy"]] = params_cleaning[["strategy"]]
     }
     if (params_cleaning[["data_masking_strategy"]] %in% c(2, 4) & params_cleaning[["hrs.del.start"]] != 0) {
-      warning(paste0("\nSetting argument hrs.del.start in combination with data_masking_strategy = ",
+      warning(paste0("\nSetting parameter hrs.del.start in combination with data_masking_strategy = ",
                      params_cleaning[["data_masking_strategy"]]," is not meaningful, because this is only used when straytegy = 1"), call. = FALSE)
     }
     if (params_cleaning[["data_masking_strategy"]] %in% c(2, 4) & params_cleaning[["hrs.del.end"]] != 0) {
-      warning(paste0("\nSetting argument hrs.del.end in combination with data_masking_strategy = ",
+      warning(paste0("\nSetting parameter hrs.del.end in combination with data_masking_strategy = ",
                      params_cleaning[["data_masking_strategy"]]," is not meaningful, because this is only used when straytegy = 1"), call. = FALSE)
     }
     if (!(params_cleaning[["data_masking_strategy"]] %in% c(3, 5)) & params_cleaning[["ndayswindow"]] != 7) {
-      warning(paste0("\nSetting argument ndayswindow in combination with data_masking_strategy = ",
+      warning(paste0("\nSetting parameter ndayswindow in combination with data_masking_strategy = ",
                      params_cleaning[["data_masking_strategy"]]," is not meaningful, because this is only used when data_masking_strategy = 3 or data_masking_strategy = 5"), call. = FALSE)
     }
     if (params_cleaning[["data_masking_strategy"]] == 5 &
         params_cleaning[["ndayswindow"]] != round(params_cleaning[["ndayswindow"]])) {
       newValue = round(params_cleaning[["ndayswindow"]])
-      warning(paste0("\nArgument ndayswindow has been rounded from ",
+      warning(paste0("\nParameter ndayswindow has been rounded from ",
                      params_cleaning[["ndayswindow"]], " to ", newValue, " days",
                      "because when data_masking_strategy == 5 we expect an integer value", call. = FALSE))
       params_cleaning[["ndayswindow"]] = newValue
@@ -347,13 +347,19 @@ check_params = function(params_sleep = c(), params_metrics = c(),
   if (length(params_phyact) > 0) {
     if (length(params_phyact[["bout.metric"]]) > 0 |
         length(params_phyact[["closedbout"]]) > 0) {
-      warning(paste0("\nArguments bout.metric and closedbout are no longer used",
-                     " by GGIR, we now use one piece of code stored in",
+      warning(paste0("\nParameters bout.metric and closedbout are no longer used",
+                     " by GGIR and ignored, we now use one piece of code stored in",
                      " function g.getbout."), call. = FALSE)
     }
     if (length(params_phyact[["mvpadur"]]) != 3) {
       params_phyact[["mvpadur"]] = c(1,5,10)
       warning("\nmvpadur needs to be a vector with length three, value now reset to default c(1, 5, 10)", call. = FALSE)
+    }
+    if (is.null(params_phyact[["mvpathreshold"]]) == TRUE) {
+      params_phyact[["mvpathreshold"]] = params_phyact[["threshold.mod"]]
+    }
+    if (is.null(params_phyact[["boutcriter"]]) == TRUE) {
+      params_phyact[["boutcriter"]] = params_phyact[["boutcriter.mvpa"]]
     }
     if ((length(params_phyact[["threshold.lig"]]) == 1 &&
         length(params_phyact[["threshold.mod"]]) == 1 &&
@@ -423,7 +429,7 @@ check_params = function(params_sleep = c(), params_metrics = c(),
     if (is.null(params_general[["recordingEndSleepHour"]]) & params_general[["expand_tail_max_hours"]] != 0) {
       params_general[["recordingEndSleepHour"]] = 24 - params_general[["expand_tail_max_hours"]] # redefine the argument
       params_general[["expand_tail_max_hours"]] = NULL # set to null so that it keeps this configuration in the config file for the next run of the script.
-      stop("\nThe argument expand_tail_max_hours has been replaced by",
+      stop("\nThe parameter expand_tail_max_hours has been replaced by",
            " recordingEndSleepHour which has a different definition. Please",
            " see the documentation for further details and replace",
            " expand_tail_max_hour in your function call and config.csv file.", call. = FALSE)
@@ -475,7 +481,7 @@ check_params = function(params_sleep = c(), params_metrics = c(),
         }
         warning(paste0("\nWhen dataFormat is set to ", params_general[["dataFormat"]],
                        " we assume that only metric ZCY is extracted and",
-                       " GGIR ignores all other metric requests. So, you should set arguments ",
+                       " GGIR ignores all other metric requests. So, you should set parameters ",
                        paste0(metricsNotFalse, collapse = " & "), " to FALSE"), call. = FALSE)
         # Turn all commonly used metrics to FALSE
         params_metrics[["do.anglex"]] = params_metrics[["do.angley"]] = FALSE
@@ -515,7 +521,7 @@ check_params = function(params_sleep = c(), params_metrics = c(),
         }
         warning(paste0("\nWhen dataFormat is set to ukbiobank",
                        " we assume that only metric LFENMO is extracted and",
-                       " GGIR ignores all other metric requests. So, you should set arguments ",
+                       " GGIR ignores all other metric requests. So, you should set parameters ",
                        paste0(metricsNotFalse, collapse = " & "), " to FALSE"), call. = FALSE)
         # Turn all commonly used metrics to FALSE
         params_metrics[["do.anglex"]] = params_metrics[["do.angley"]] = FALSE
@@ -573,7 +579,7 @@ check_params = function(params_sleep = c(), params_metrics = c(),
            call. = FALSE)
     }
     if (length(params_cleaning[["segmentDAYSPTcrit.part5"]]) != 2) {
-      stop("\nArgument segmentDAYSPTcrit.part5 is expected to be a numeric vector of length 2", call. = FALSE)
+      stop("\nParameter segmentDAYSPTcrit.part5 is expected to be a numeric vector of length 2", call. = FALSE)
     }
     if (any(params_cleaning[["segmentDAYSPTcrit.part5"]] < 0) | 
         any(params_cleaning[["segmentDAYSPTcrit.part5"]] > 1)) {

--- a/R/g.conv.actlog.R
+++ b/R/g.conv.actlog.R
@@ -1,4 +1,4 @@
-g.conv.actlog = function(qwindow, qwindow_dateformat="%d-%m-%Y", epochSize = 5) {
+g.conv.actlog = function(qwindow, qwindow_dateformat = "%d-%m-%Y", epochSize = 5) {
   # Function to read activity log and convert it into data.frame
   # that has for each ID and date a different qwindow vector
   # local functions:
@@ -32,74 +32,78 @@ g.conv.actlog = function(qwindow, qwindow_dateformat="%d-%m-%Y", epochSize = 5) 
   
   # find dates
   actlog_vec = unlist(actlog) # turn into vector
-  actlog_vec = sapply(actlog_vec, function(x) !all(is.na(as.Date(as.character(x),format=qwindow_dateformat))))
+  actlog_vec = sapply(actlog_vec, FUN = function(x) !all(is.na(as.Date(as.character(x),
+                                                                 format = qwindow_dateformat))))
   exampledates = unlist(actlog)[which(actlog_vec == TRUE)]
   Ndates = length(which(actlog_vec == TRUE))
-  dim(actlog_vec) = c(nrow(actlog),ncol(actlog))
+  dim(actlog_vec) = c(nrow(actlog), ncol(actlog))
   # create new qwindow object to archive all extracted information
-  qwindow = data.frame(ID = rep(0,Ndates), date =  rep("",Ndates))
+  qwindow = data.frame(ID = rep(0, Ndates), date =  rep("", Ndates))
   qwindow$qwindow_times = qwindow$qwindow_values = qwindow$qwindow_names = c()
   cnt = 1
-  for (i in 1:nrow(actlog)) { # loop over rows in activity log = recordings
-    datei = which(actlog_vec[i,] == TRUE)
+  processLogRow = function(actlog, qwindow_dateformat = qwindow_dateformat) {
+    actlog_vec = unlist(actlog) # turn into vector
+    actlog_vec = sapply(actlog_vec, FUN = function(x) !all(is.na(as.Date(as.character(x),
+                                                                         format = qwindow_dateformat))))
+    datei = which(actlog_vec == TRUE)
     Ndays = length(datei)
+    out = data.frame(ID = character(Ndays), date = character(Ndays))
+    out$qwindow_times = out$qwindow_values = qwindow$qwindow_names = NULL
     if (Ndays > 0) {
-      qwindow$ID[cnt:(cnt+Ndays-1)]  = rep(actlog[i,1],Ndays)
-      qwindow$date[cnt:(cnt+Ndays-1)]  = as.character(as.Date(as.character(actlog[i,datei]),format=qwindow_dateformat))
+      out$ID[1:Ndays]  = rep(actlog[1], Ndays)
+      out$date[1:Ndays]  = as.character(as.Date(as.character(actlog[datei]), format = qwindow_dateformat))
       # datei are the indices of the date columns
       # add number to be able to identify last class after last date
-      datei = c(datei,max(which(actlog[i,] != "")) + 1)
-      for (j in 1:(length(datei)-1)) { # loop over days within the recording
+      datei = c(datei, max(which(actlog != "")) + 1)
+      for (j in 1:(length(datei) - 1)) { # loop over days within the recording
         # Note: qindow is a data.frame and the timestamps for each day will be stored
         # as a list object in a single cell of qwindow. The same applies ot the corresponding
         # labels.
         k = cnt + j - 1
         if ((datei[j + 1] - datei[j]) >= 2) {
-          actlog_tmp = actlog[i,(datei[j] + 1):(datei[j + 1] - 1)]
+          actlog_tmp = actlog[(datei[j] + 1):(datei[j + 1] - 1)]
           actlog_tmp = actlog_tmp[which(is.na(actlog_tmp) == FALSE & actlog_tmp != "")]
-          qwindow$qwindow_times[k] = list(actlog_tmp) # list of times for that day
+          out$qwindow_times[k] = list(actlog_tmp) # list of times for that day
           # make sure that seconds are multiple of epochSize
-          seconds = data.table::second(strptime(qwindow$qwindow_times[[k]], format = "%H:%M:%S"))
+          seconds = data.table::second(strptime(out$qwindow_times[[k]], format = "%H:%M:%S"))
           to_next_epoch = which(seconds %% epochSize != 0)
           if (length(to_next_epoch) > 0) {
-            timechar = qwindow$qwindow_times[[k]][to_next_epoch]
+            timechar = out$qwindow_times[[k]][to_next_epoch]
             time = strptime(timechar, format = "%H:%M:%S")
             seconds2sum = epochSize - seconds[to_next_epoch] %% epochSize
             time = time + seconds2sum
             timechar_new = as.character(time)
             time_new = unlist(lapply(timechar_new, FUN = function(x) strsplit(x, " ", fixed = T)[[1]][2]))
-            qwindow$qwindow_times[[k]][to_next_epoch] = time_new
+            out$qwindow_times[[k]][to_next_epoch] = time_new
           }
-          qwindow$qwindow_values[k] = list(time2numeric(qwindow$qwindow_times[k]))
-          qwindow$qwindow_names[k] = list(extract_names(qwindow$qwindow_times[k]))
-          unlisted_qv = unlist(qwindow$qwindow_values[k])
-          unlisted_qt = unlist(qwindow$qwindow_times[k])
-          unlisted_qn = unlist(qwindow$qwindow_names[k])
-          
+          out$qwindow_values[k] = list(time2numeric(out$qwindow_times[k]))
+          out$qwindow_names[k] = list(extract_names(out$qwindow_times[k]))
+          unlisted_qv = unlist(out$qwindow_values[k])
           if (length(which(is.na(unlisted_qv) == FALSE)) > 0) {
+            unlisted_qn = unlist(out$qwindow_names[k])
+            unlisted_qt = unlist(out$qwindow_times[k])
             if (min(unlisted_qv, na.rm = TRUE) > 0) {
-              qwindow$qwindow_values[k] = list(c(0, unlisted_qv))
-              qwindow$qwindow_times[k] = list(c("00:00", unlisted_qt))
-              qwindow$qwindow_names[k] = list(c("daystart", unlisted_qn))
+              out$qwindow_values[k] = list(c(0, unlisted_qv))
+              out$qwindow_times[k] = list(c("00:00", unlisted_qt))
+              out$qwindow_names[k] = list(c("daystart", unlisted_qn))
             }
             if (max(unlisted_qv, na.rm = TRUE) < 24) {
-              qwindow$qwindow_values[k] = list(c(unlist(qwindow$qwindow_values[k]), 24))
-              qwindow$qwindow_times[k] = list(c(unlist(qwindow$qwindow_times[k]), "24:00:00"))
-              qwindow$qwindow_names[k] = list(c(unlist(qwindow$qwindow_names[k]),"dayend"))
+              out$qwindow_values[k] = list(c(unlist(out$qwindow_values[k]), 24))
+              out$qwindow_times[k] = list(c(unlist(out$qwindow_times[k]), "24:00:00"))
+              out$qwindow_names[k] = list(c(unlist(out$qwindow_names[k]),"dayend"))
             }
           }
         } else {
-          qwindow$qwindow_values[k] = list("")
-          qwindow$qwindow_names[k] = list("")
-          qwindow$qwindow_times[k] = list("")
+          out$qwindow_values[k] = out$qwindow_names[k] = out$qwindow_times[k] = list("")
         }
       }
-      cnt = cnt + Ndays
     }
+    return(out)
   }
-  
+  test = apply(X = actlog, MARGIN = 1, FUN = processLogRow, qwindow_dateformat)
+  qwindow = do.call(what = rbind, args = test)
   # When testing the code it seemed sometimes not to recognise the date.
-  # The following lines should hopefully help to catch any errors people may encounter.
+  # The following lines should help to catch any errors people may encounter.
   if (is.na(as.Date(qwindow$date[1], format = "%y-%m-%d")) == FALSE) {
     qwindow$date =  as.Date(qwindow$date, format = "%y-%m-%d")
   } else {

--- a/R/g.part2.R
+++ b/R/g.part2.R
@@ -31,7 +31,7 @@ g.part2 = function(datadir = c(), metadatadir = c(), f0 = c(), f1 = c(),
     tmp_activityDiary_file = paste0(metadatadir, "/activityDiary.RData")
     
     if (!file.exists(tmp_activityDiary_file) || (file.exists(tmp_activityDiary_file) && 
-        file.info(params_247[["qwindow"]])$ctime >= file.info(tmp_activityDiary_file)$ctime)) {
+        file.info(params_247[["qwindow"]])$mtime >= file.info(tmp_activityDiary_file)$mtime)) {
       if (verbose == TRUE) cat("\nConverting activity diary...")
       # This will be an object with numeric qwindow values for all individuals and days
       params_247[["qwindow"]] = g.conv.actlog(params_247[["qwindow"]],

--- a/R/g.part2.R
+++ b/R/g.part2.R
@@ -28,7 +28,7 @@ g.part2 = function(datadir = c(), metadatadir = c(), f0 = c(), f1 = c(),
       # note that this filtering is only use if parameter nonwearFiltermaxHours is specified.
       use_qwindow_as_diary = FALSE 
     }
-    tmp_activityDiary_file = paste0(metadatadir, "/activityDiary.RData")
+    tmp_activityDiary_file = paste0(metadatadir, "/meta/activityDiary.RData")
     
     if (!file.exists(tmp_activityDiary_file) || (file.exists(tmp_activityDiary_file) && 
         file.info(params_247[["qwindow"]])$mtime >= file.info(tmp_activityDiary_file)$mtime)) {

--- a/R/g.part4.R
+++ b/R/g.part4.R
@@ -36,7 +36,7 @@ g.part4 = function(datadir = c(), metadatadir = c(), f0 = f0, f1 = f1,
     # only re-process sleeplog if sleeplog.RData does not exist or if sleeplog
     # is from a date equal to or after sleeplog.RData
     if (!file.exists(sleeplogRDataFile) || 
-        file.info(params_sleep[["loglocation"]])$ctime >= file.info(sleeplogRDataFile)$ctime) {
+        file.info(params_sleep[["loglocation"]])$mtime >= file.info(sleeplogRDataFile)$mtime) {
       logs_diaries = g.loadlog(params_sleep[["loglocation"]], 
                                coln1 = params_sleep[["coln1"]],
                                colid = params_sleep[["colid"]],

--- a/R/g.sibreport.R
+++ b/R/g.sibreport.R
@@ -40,7 +40,7 @@ g.sibreport = function(ts, ID, epochlength, logs_diaries=c(), desiredtz="") {
     imputecodelog = logs_diaries$imputecodelog
     dateformat = logs_diaries$dateformat
 
-    firstDate = as.Date(ts$time[1])
+    firstDate = as.Date(ts$time[1], tz = desiredtz)
     extract_logs = function(log, ID, logname, firstDate = NULL) {
       logreport = c()
       if (length(log) > 0) {
@@ -60,7 +60,7 @@ g.sibreport = function(ts, ID, epochlength, logs_diaries=c(), desiredtz="") {
             if (ncol(tmp) <= 2) next
             nonempty = which(tmp[3:ncol(tmp)] != "" & tmp[3:ncol(tmp)] != "NA")
             if (length(nonempty) > 1) {
-              date = as.Date(tmp[1,2], format = dateformat)
+              date = as.Date(tmp[1,2], format = dateformat, tz = desiredtz)
               times = as.character(unlist(tmp[1,3:ncol(tmp)]))
               times = grep(pattern = "NA", value = TRUE, invert = TRUE, x = times)
               times = gsub(pattern = " ", replacement = "", x = times)
@@ -130,11 +130,11 @@ g.sibreport = function(ts, ID, epochlength, logs_diaries=c(), desiredtz="") {
     bedlogreport = extract_logs(bedlog, ID, logname = "bedlog", firstDate = firstDate)
     # add imputecodelog
     if (length(imputecodelog) > 0) {
-      addDate = function(x) {
-        start_time = as.POSIXct(x$start, "")
-        x$date = as.Date(start_time)
+      addDate = function(x, tz = desiredtz) {
+        start_time = as.POSIXct(x$start, tz = tz)
+        x$date = as.Date(start_time, tz = tz)
         start_hour = as.numeric(format(start_time, "%H"))
-        start_am = which(x$date < 12)
+        start_am = which(start_hour < 12)
         if (length(start_am) > 0) {
           x$date[start_am] = x$date[start_am] - 1
         }

--- a/R/load_params.R
+++ b/R/load_params.R
@@ -83,7 +83,7 @@ load_params = function(topic = c("sleep", "metrics", "rawdata",
 
   }
   if ("phyact" %in% topic) {
-    params_phyact = list(mvpathreshold = 100, boutcriter = 0.8,
+    params_phyact = list(mvpathreshold = NULL, boutcriter = NULL,
                          mvpadur = c(1,5,10),
                          boutcriter.in = 0.9, boutcriter.lig = 0.8,
                          boutcriter.mvpa = 0.8, threshold.lig = 40,

--- a/R/visualReport.R
+++ b/R/visualReport.R
@@ -563,8 +563,11 @@ visualReport = function(metadatadir = c(),
               subploti[si, ] = -1
             }
           }
-          subploti = subploti[which(subploti[,1] > 0), ]
-          if (length(subploti) == 0 || inherits(x = subploti, what = "matrix") == FALSE || nrow(subploti) == 0) {
+          valid_rows = which(subploti[,1] > 0)
+          if (length(valid_rows) > 0) {
+            subploti = subploti[valid_rows, , drop = FALSE]
+          }
+          if (length(valid_rows) == 0 || inherits(x = subploti, what = "matrix") == FALSE || nrow(subploti) == 0) {
             message(paste0("Recording ", simple_filename, " skipped from visual",
                            " report generation because valid",
                            " data criteria (visualreport_validcrit) not met."))

--- a/man/GGIR.Rd
+++ b/man/GGIR.Rd
@@ -1017,7 +1017,9 @@ GGIR(mode = 1:5,
     \describe{
 
       \item{mvpathreshold}{
-        Numeric (default = 100).
+        Numeric (default = NULL).
+        Legacy parameter, if not provided GGIR uses the value of \code{threshold.mod} 
+        for this.
         Acceleration threshold for MVPA estimation in GGIR \link{g.part2}.
         This can be a single number or an vector of numbers,
         e.g., \code{mvpathreshold = c(100, 120)}.
@@ -1026,11 +1028,13 @@ GGIR(mode = 1:5,
         MVPA is not estimated.}
 
       \item{mvpadur}{
-        Numeric (default = 10).
+        Numeric (default = c(1, 5, 10)).
         The bout duration(s) for which MVPA will be calculated. Only used in GGIR \link{g.part2}.}
 
       \item{boutcriter}{
-        Numeric (default = 0.8).
+        Numeric (default = NULL).
+        Legacy parameter, if not provided GGIR uses the value of \code{boutcriter.mvpa} 
+        for this.
         A number between 0 and 1, it defines what fraction of a bout needs to be above the
         mvpathreshold, only used in GGIR \link{g.part2}.}
 
@@ -1118,6 +1122,11 @@ GGIR(mode = 1:5,
         part 5 to be used for part 6. For example, "40_100_120". If left in default value
         GGIR will use the first threshold value from parameters \code{threshold.lig},
         \code{threshold.mod}, and \code{threshold.vig}.
+      }
+      \item{bout.metric}{
+        Deprecated parameter that was previously used to choose which
+        bout detection metric (algorithm) GGIR should use. GGIR now uses only one 
+        algorithm.
       }
     }
   }

--- a/vignettes/chapter9_SleepFundamentalsGuiders.Rmd
+++ b/vignettes/chapter9_SleepFundamentalsGuiders.Rmd
@@ -110,6 +110,8 @@ Relative to the basic sleeplog format the advanced sleep log format comes with t
 
 - GGIR guesses the data format by looping over common date formats. If the date falls within 30 days of the start date of the accelerometer recording then the date format is assumed to be found. It starts with attempting “Y-m-d” (as in 2015-06-25).
 
+- If a column name includes the word "impute" then this column is treated as a log of the diary imputation for outside GGIR for the preceding night. The value will be shown in the visualreport and is stored in the time series by GGIR part 5. The imputation codes we used for testing have the format C0000 to indicate no imputation for inbed, sleeponset, wakeup and outbed, respectively. If one of the numbers would be 1 then that would reflect imputation.
+
 ### Guider: HDCZA
 
 The HDCZA algorithm is designed for studies with wrist-worn accelerometer (raw) data where no sleep log is available. The algorithm was first described in a [2018 article](https://dx.doi.org/10.1038/s41598-018-31266-z), and has been modified slightly: Step 6 in Figure 1 has been replaced by a single threshold (0.2 by default).\


### PR DESCRIPTION
<!-- Describe your PR here -->

In this PR several smaller fixes:

- Speeds up loading of activity diary, mainly relevant for large datasets, fixes #1250
- Skips loading of activity or sleeplog diary when input diary has not changed, fixes #1250
- Corrects determining how many recordings should be in part 2 csv report, fixes #1252 
- Improves handling of optional diary imputation code as stored in advanced format sleeplog and adds documentation for this #1251 
- Visualreport is now able to handle recordings with only 1 valid day. #1246
- Simplifies MVPA parameter specification for part 2 by using the part 5 values when not specified, fixes #1247

<!-- Please, make sure the following items are checked -->
### Checklist before merging:

- [ ] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [ ] Documentation updated:
  - [ ] Function documentation
  - [ ] Chapter vignettes for GitHub IO
  - [ ] Vignettes for CRAN
- [ ] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [ ] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
- [ ] GGIR parameters were added/removed. If yes, please also complete checklist below.