### PR TITLE
Issue1260 part6 threshold combi

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# CHANGES IN GGIR VERSION 3.X-Y
+
+- Part 6 and visual report: Fix bug related to determining the combination of threhsolds to use for the 
+  visual report and for part 6 analyses when there are several options and 
+  part6_threshold_combi is NULL. #1260
+  
 # CHANGES IN GGIR VERSION 3.1-11
 
 - Part 2:

--- a/R/check_params.R
+++ b/R/check_params.R
@@ -364,9 +364,9 @@ check_params = function(params_sleep = c(), params_metrics = c(),
     if ((length(params_phyact[["threshold.lig"]]) == 1 &&
         length(params_phyact[["threshold.mod"]]) == 1 &&
         length(params_phyact[["threshold.vig"]]) == 1) | is.null(params_phyact[["part6_threshold_combi"]])) {
-      params_phyact[["part6_threshold_combi"]] = paste(params_phyact[["threshold.lig"]],
-                                                       params_phyact[["threshold.mod"]],
-                                                       params_phyact[["threshold.vig"]], sep = "_")
+      params_phyact[["part6_threshold_combi"]] = paste(params_phyact[["threshold.lig"]][1],
+                                                       params_phyact[["threshold.mod"]][1],
+                                                       params_phyact[["threshold.vig"]][1], sep = "_")
     }
   }
   # params output 


### PR DESCRIPTION
<!-- Describe your PR here -->
Fixes #1260 => revises the definition of `part6_threshold_combi` when there are more than one set of thresholds to pick from and `part6_threshold_combi` is set to `NULL`.

<!-- Please, make sure the following items are checked -->
### Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [ ] Documentation updated:
  - [ ] Function documentation
  - [ ] Chapter vignettes for GitHub IO
  - [ ] Vignettes for CRAN
- [x] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
- [ ] GGIR parameters were added/removed. If yes, please also complete checklist below.

**If NEW GGIR parameter(s) were added then these NEW parameter(s) are:**
- [ ] documented in `man/GGIR.Rd`
- [ ] included with a default in `R/load_params.R`
- [ ] included with value class check in `R/check_params.R`
- [ ] included in table of `vignettes/GGIRParameters.Rmd` with references to the GGIR parts the parameter is used in.
- [ ] mentioned in NEWS.Rd as NEW parameter

**If GGIR parameter(s) were deprecated these parameter(s) are:**
- [ ] documented as deprecated in `man/GGIR.Rd`
- [ ] removed from `R/load_params.R`
- [ ] removed from `R/check_params.R`
- [ ] removed from table in `vignettes/GGIRParameters.Rmd`
- [ ] mentioned as deprecated parameter in NEWS.Rd
- [ ] added to the list in `R/extract_params.R` with deprecated parameters such that these do not produce warnings when found in old config.csv files.