### PR TITLE
Speed up POSIX calls in part 6 that were recently revised to facilitate backward compatibility with older R versions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,9 @@
 - Part 6 and new visual report: Fix bug related to determining the combination of thresholds to use for the 
   visual report and for part 6 analyses when there are several options and 
   part6_threshold_combi is NULL. #1260
-  
+
+- Part 6: Revise fix to #1181 and #1245 in 3.1-11 as it slowed down part 6 substantially. #1263
+
 # CHANGES IN GGIR VERSION 3.1-11
 
 - Part 2:
@@ -40,7 +42,7 @@ with only 1 valid day, these were previously skipped. #1246
   - Change extraction of imputation code from sleep diary, which is now assumed to 
   correspond to preceding night. #1251
   
-- Part 1, 5 and 6: Update code to be backward compatible with R 4.2.0
+- Part 1, 5 and 6: Update code to be backward compatible with R 4.2.0 #1181 and #1245
 
 - Part 5: Default values for parameters `do.sibreport` and `save_ms5rawlevels` changed
 to TRUE, for `save_ms5raw_format` changed to "RData" in order to ease generating visual 

--- a/R/g.part6.R
+++ b/R/g.part6.R
@@ -169,9 +169,8 @@ g.part6 = function(datadir = c(), metadatadir = c(), f0 = c(), f1 = c(),
           mdat$window[invalid] = 9999
           mdat$invalid_sleepperiod[invalid] = 100
           mdat$invalid_wakinghours[invalid] = 100
-          mdat$time = mdat$timestamp = as.POSIXct(mdat$timenum,
-                                                  tz =  params_general[["desiredtz"]],
-                                                  origin = "1970-01-01")
+          mdat$time = mdat$timestamp = .POSIXct(mdat$timenum,
+                                                tz =  params_general[["desiredtz"]])
           return(mdat)
         }
         mdat = imputeTimeGaps(mdat, epochSize)
@@ -240,8 +239,7 @@ g.part6 = function(datadir = c(), metadatadir = c(), f0 = c(), f1 = c(),
       summary[fi] = unlist(strsplit(fnames.ms5raw[i], "_"))[1]
       s_names[fi] = "ID"
       fi = fi + 1
-      starttime = as.POSIXlt(ts$time[1], tz = params_general[["desiredtz"]],
-                             origin = "1970-01-01")
+      starttime = .POSIXct(ts$time[1], tz = params_general[["desiredtz"]])
       summary[fi] = format(starttime)
       s_names[fi] = "starttime"
       fi = fi + 1
@@ -294,10 +292,10 @@ g.part6 = function(datadir = c(), metadatadir = c(), f0 = c(), f1 = c(),
         threshold = as.numeric(unlist(strsplit( params_phyact[["part6_threshold_combi"]], "_"))[1])
         
         # extract nightsi again
-        tempp = unclass(as.POSIXlt(acc4cos$time, tz = params_general[["desiredtz"]], origin = "1970-01-01"))
-        sec = tempp$sec
-        min = tempp$min
-        hour = tempp$hour
+        tempp = .POSIXct(acc4cos$time, tz = params_general[["desiredtz"]])
+        sec = data.table::second(tempp)
+        min = data.table::minute(tempp)
+        hour = data.table::hour(tempp)
         if (params_general[["dayborder"]] == 0) {
           nightsi = which(sec == 0 & min == 0 & hour == 0)
         } else {

--- a/tests/testthat/test_part6.R
+++ b/tests/testthat/test_part6.R
@@ -1,7 +1,7 @@
 library(GGIR)
 context("g.part6")
 
-test_that("Part 6 with household co-analysis", {
+test_that("Part 6 can run co-analysis and CR analysis", {
 
   # Create test files for household co-analysis
   metadatadir = "./output_testpart6"

--- a/tests/testthat/test_part6.R
+++ b/tests/testthat/test_part6.R
@@ -1,7 +1,7 @@
 library(GGIR)
 context("g.part6")
 
-test_that("Part 6 can run co-analysis and CR analysis", {
+test_that("Part 6 can run household co-analysis and Circadian Rhythm analysis", {
 
   # Create test files for household co-analysis
   metadatadir = "./output_testpart6"


### PR DESCRIPTION
<!-- Describe your PR here -->

Fixes #1263 by revising the previous edits that made the code backward compatible with R 4.2.0 but then slowed down part 6.

@forget999 would you mind testing that GGIR part 6 is of acceptable speed again in this update? (I am travelling and do not have time for elaborate testing in the upcoming 2 weeks).

You can do so by installing GGIR via:
`remotes::install_github("wadpac/GGIR", ref = "issue1263_POSIXct_speed")`

<!-- Please, make sure the following items are checked -->
### Checklist before merging:

- [ ] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [ ] Documentation updated:
  - [ ] Function documentation
  - [ ] Chapter vignettes for GitHub IO
  - [ ] Vignettes for CRAN
- [ ] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [ ] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
- [ ] GGIR parameters were added/removed. If yes, please also complete checklist below.

**If NEW GGIR parameter(s) were added then these NEW parameter(s) are:**
- [ ] documented in `man/GGIR.Rd`
- [ ] included with a default in `R/load_params.R`
- [ ] included with value class check in `R/check_params.R`
- [ ] included in table of `vignettes/GGIRParameters.Rmd` with references to the GGIR parts the parameter is used in.
- [ ] mentioned in NEWS.Rd as NEW parameter

**If GGIR parameter(s) were deprecated these parameter(s) are:**
- [ ] documented as deprecated in `man/GGIR.Rd`
- [ ] removed from `R/load_params.R`
- [ ] removed from `R/check_params.R`
- [ ] removed from table in `vignettes/GGIRParameters.Rmd`
- [ ] mentioned as deprecated parameter in NEWS.Rd
- [ ] added to the list in `R/extract_params.R` with deprecated parameters such that these do not produce warnings when found in old config.csv files.