### PR TITLE
Fixed bug related to processing pipelines that only require one acceleration metric

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
   visual report and for part 6 analyses when there are several options and 
   part6_threshold_combi is NULL. #1260
   
+- Part 2: Bug fixed in handling function calls that only require one acceleration metric #1265
+  
 # CHANGES IN GGIR VERSION 3.1-11
 
 - Part 2:

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
   visual report and for part 6 analyses when there are several options and 
   part6_threshold_combi is NULL. #1260
   
-- Part 2: Bug fixed in handling function calls that only require one acceleration metric #1265
+- Part 2: Bug fixed in handling part 1 output with the uncommon scenario of having only 1 metric (in object metashort) #1265
   
 # CHANGES IN GGIR VERSION 3.1-11
 

--- a/R/g.analyse.perday.R
+++ b/R/g.analyse.perday.R
@@ -207,7 +207,7 @@ g.analyse.perday = function(ndays, firstmidnighti, time, nfeatures,
     daysummary[di,(fi + 3)] = nhours
     ds_names[fi:(fi + 3)] = c("calendar_date","bodylocation","N valid hours","N hours")
     fi = fi + 4
-    vari = vari[,2:ncol(vari)] # remove timestamp now it is no longer needed
+    vari = vari[,2:ncol(vari), drop = FALSE] # remove timestamp now it is no longer needed, drop = FALSE ensures it is not coerced to numeric if only 1 metric is calculated
     colnames(averageday) = colnames(vari)
     
     if (length(params_247[["qwindow"]]) > 0) {


### PR DESCRIPTION
<!-- Describe your PR here -->
Fixes #1265 => when only one acceleration metric is calculated, now `g.analyse.perday` makes sure that subsetting `metashort` does not coerce the metric to a numeric vector, but keep the `data.frame` class instead.

<!-- Please, make sure the following items are checked -->
### Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [ ] Documentation updated:
  - [ ] Function documentation
  - [ ] Chapter vignettes for GitHub IO
  - [ ] Vignettes for CRAN
- [x] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
- [ ] GGIR parameters were added/removed. If yes, please also complete checklist below.

**If NEW GGIR parameter(s) were added then these NEW parameter(s) are:**
- [ ] documented in `man/GGIR.Rd`
- [ ] included with a default in `R/load_params.R`
- [ ] included with value class check in `R/check_params.R`
- [ ] included in table of `vignettes/GGIRParameters.Rmd` with references to the GGIR parts the parameter is used in.
- [ ] mentioned in NEWS.Rd as NEW parameter

**If GGIR parameter(s) were deprecated these parameter(s) are:**
- [ ] documented as deprecated in `man/GGIR.Rd`
- [ ] removed from `R/load_params.R`
- [ ] removed from `R/check_params.R`
- [ ] removed from table in `vignettes/GGIRParameters.Rmd`
- [ ] mentioned as deprecated parameter in NEWS.Rd
- [ ] added to the list in `R/extract_params.R` with deprecated parameters such that these do not produce warnings when found in old config.csv files.