### PR TITLE
Issue1278 additional work

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# CHANGES IN GGIR VERSION 3.2-4
+
+- Part 1: Expand split recording functionality with parameter recording_split_ignore_edges. #1278
+
 # CHANGES IN GGIR VERSION 3.2-3
 
 - Part 1: Implemented functionality to read and process Parmay Matrix sensors data (bin or BIN files) #1253

--- a/R/check_params.R
+++ b/R/check_params.R
@@ -133,7 +133,8 @@ check_params = function(params_sleep = c(), params_metrics = c(),
     numeric_params = c("maxNcores", "windowsizes", "idloc", "dayborder",
                        "expand_tail_max_hours", "maxRecordingInterval",
                        "recording_split_overlap")
-    boolean_params = c("overwrite", "print.filename", "do.parallel", "part5_agg2_60seconds")
+    boolean_params = c("overwrite", "print.filename", "do.parallel", "part5_agg2_60seconds",
+                       "recording_split_ignore_edges")
     character_params = c("acc.metric", "desiredtz", "configtz", "sensor.location", 
                          "dataFormat", "extEpochData_timeformat", "recording_split_times",
                          "recording_split_timeformat")

--- a/R/load_params.R
+++ b/R/load_params.R
@@ -142,7 +142,8 @@ load_params = function(topic = c("sleep", "metrics", "rawdata",
                           extEpochData_timeformat = "%d-%m-%Y %H:%M:%S",
                           recording_split_times = NULL,
                           recording_split_timeformat = "%d/%m/%Y %H:%M",
-                          recording_split_overlap = 0)
+                          recording_split_overlap = 0,
+                          recording_split_ignore_edges = FALSE)
   }
   invisible(list(params_sleep = params_sleep,
                  params_metrics = params_metrics,

--- a/R/splitRecords.R
+++ b/R/splitRecords.R
@@ -75,7 +75,8 @@ splitRecords = function(metadatadir, params_general = NULL) {
           Mbu = M
           segment_names = segment_starts = segment_ends = NULL
           # Define segments
-          if (splitTime_tmp[1] > timestamp_short[1]) {
+          if (splitTime_tmp[1] > timestamp_short[1] &&
+              params_general[["recording_split_ignore_edges"]] == FALSE) {
             segment_starts = timestamp_short[1]
             segment_ends = splitTime_tmp[1]
             segment_names = paste0("startrecTO", split_names[1])
@@ -87,10 +88,12 @@ splitRecords = function(metadatadir, params_general = NULL) {
               segment_names = c(segment_names, paste0(split_names[segment_index], "TO",
                                                       split_names[segment_index + 1]))
             } else {
-              segment_starts = c(segment_starts, splitTime_tmp[segment_index])
-              segment_ends = c(segment_ends, timestamp_short[length(timestamp_short)])
-              segment_names = c(segment_names, paste0(split_names[segment_index],
-                                                      "TOendrec"))
+              if (params_general[["recording_split_ignore_edges"]] == FALSE) {
+                segment_starts = c(segment_starts, splitTime_tmp[segment_index])
+                segment_ends = c(segment_ends, timestamp_short[length(timestamp_short)])
+                segment_names = c(segment_names, paste0(split_names[segment_index],
+                                                        "TOendrec"))
+              }
             }
           }
           # Store each part separately

--- a/man/GGIR.Rd
+++ b/man/GGIR.Rd
@@ -298,6 +298,12 @@ GGIR(mode = 1:5,
         \code{recording_split_times}.
       }
       
+      \item{recording_split_ignore_edges}{
+        Boolean (default = FALSE)
+        To indicate whether the recording time before and after the time range defined by
+        \code{recording_split_times} should be considered as segments.
+      }
+      
       \item{recording_split_overlap}{
         Numeric (default = 0).
         Number of hours to use as buffer when splitting recording. A possitive number

--- a/tests/testthat/test_load_check_params.R
+++ b/tests/testthat/test_load_check_params.R
@@ -18,7 +18,7 @@ test_that("load_params can load parameters", {
   expect_equal(length(params$params_cleaning), 28)
   expect_equal(length(params$params_phyact), 14)
   expect_equal(length(params$params_output), 27)
-  expect_equal(length(params$params_general), 20)
+  expect_equal(length(params$params_general), 21)
 
   params_sleep = params$params_sleep
   params_metrics = params$params_metrics

--- a/tests/testthat/test_splitRecords.R
+++ b/tests/testthat/test_splitRecords.R
@@ -40,6 +40,7 @@ test_that("Recording can be split", {
   params_general[["recording_split_times"]] = "time_chunks_per_participant.csv"
   params_general[["recording_split_overlap"]] = 0
   params_general[["recording_split_timeformat"]] = "%Y-%m-%d %H:%M"
+  params_general[["recording_split_ignore_edges"]] == FALSE
   
   splitRecords(metadatadir = "./testfolder",
                params_general = params_general)
@@ -65,6 +66,70 @@ test_that("Recording can be split", {
   expect_equal(tail(M$metashort$timestamp, n = 1), "2013-11-15T13:44:50+0000")
   expect_equal(M$metalong$timestamp[1], "2013-11-14T23:00:00+0000")
   expect_equal(tail(M$metalong$timestamp, n = 1), "2013-11-15T13:15:00+0000")
+  
+  if (dir.exists("./testfolder"))  unlink("./testfolder", recursive = TRUE)
+  if (file.exists(csv_file)) unlink(csv_file, recursive = TRUE)
+})
+
+
+test_that("Recording can be split and ignore edges", {
+  skip_on_cran()
+  
+  #==========================================
+  # Create dummy file
+  data(data.getmeta)
+  data(data.calibrate)
+  data(data.inspectfile)
+  M = data.getmeta
+  
+  # change timestamp format to what it has been since 2017
+  M$metashort$timestamp = POSIXtime2iso8601(x = M$metashort$timestamp, tz = "Europe/London")
+  M$metalong$timestamp = POSIXtime2iso8601(x = M$metalong$timestamp, tz = "Europe/London")
+  I = data.inspectfile
+  I$filename = "1_1-1-1900.bin"
+  C = data.calibrate
+  
+  dn = "./testfolder/meta/basic"
+  if (!dir.exists(dn)) {
+    dir.create(dn, recursive = TRUE)
+  }
+  filefoldername = filename_dir = I$filename
+  tail_expansion_log = NULL
+  save(M, C, I,
+       filefoldername = filefoldername,
+       filename_dir = filename_dir,
+       tail_expansion_log = tail_expansion_log,
+       file = paste0(dn, "/meta_1_1-1-1900.bin.RData"))
+  
+  times_to_split = data.frame(ID = "1", time1 = "2013-11-15 00:05", time2 = "2013-11-16")
+  csv_file = "time_chunks_per_participant.csv"
+  write.csv(x = times_to_split, file = csv_file, row.names = FALSE)
+  
+  # Prepare params object
+  params_general = load_params()$params_general
+  params_general[["desiredtz"]] = "Europe/Amsterdam"
+  params_general[["idloc"]] = 2
+  params_general[["recording_split_times"]] = "time_chunks_per_participant.csv"
+  params_general[["recording_split_overlap"]] = 0
+  params_general[["recording_split_timeformat"]] = "%Y-%m-%d %H:%M"
+  params_general[["recording_split_ignore_edges"]] = TRUE
+  
+  splitRecords(metadatadir = "./testfolder",
+               params_general = params_general)
+  
+  # File created?
+  expect_true(dir.exists("./testfolder/meta/basic"))
+  expect_equal(length(dir("./testfolder/meta/basic")), 1)
+  expect_true(file.exists("./testfolder/meta/basic/meta_1_1-1-1900.bin.RData"))
+  
+  # File content correct?
+  load("./testfolder/meta/basic/meta_1_1-1-1900.bin.RData")
+  expect_equal(nrow(M$metashort), 18720)
+  expect_equal(nrow(M$metalong), 104)
+  expect_equal(M$metashort$timestamp[1], "2013-11-14T11:45:00+0000")
+  expect_equal(tail(M$metashort$timestamp, n = 1), "2013-11-15T13:44:55+0000")
+  expect_equal(M$metalong$timestamp[1],  "2013-11-14T11:45:00+0000")
+  expect_equal(tail(M$metalong$timestamp, n = 1), "2013-11-15T13:30:00+0000")
   
   if (dir.exists("./testfolder"))  unlink("./testfolder", recursive = TRUE)
   if (file.exists(csv_file)) unlink(csv_file, recursive = TRUE)

--- a/vignettes/GGIRParameters.Rmd
+++ b/vignettes/GGIRParameters.Rmd
@@ -119,6 +119,7 @@ find a description and default value for all the arguments.
 | maxRecordingInterval        | 1                 | params_general           |
 | recording_split_times       | 1                 | params_general           |
 | recording_split_overlap     | 1                 | params_general           |
+| recording_split_ignore_edges | 1                | params_general           |
 | recording_split_timeformat  | 1                 | params_general           |
 | nonwear_approach            | 1                 | params_general           |
 | dataFormat                  | 1                 | params_general           |


### PR DESCRIPTION
<!-- Describe your PR here -->

Enhancing previous work on #1278 (splitting recordings) with option to ignore time before and after the last time.

<!-- Please, make sure the following items are checked -->
### Checklist before merging:

- [ ] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [x] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [x] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [ ] Documentation updated:
  - [x] Function documentation
  - [ ] Chapter vignettes for GitHub IO
  - [ ] Vignettes for CRAN
- [x] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
- [x] GGIR parameters were added/removed. If yes, please also complete checklist below.

**If NEW GGIR parameter(s) were added then these NEW parameter(s) are:**
- [x] documented in `man/GGIR.Rd`
- [x] included with a default in `R/load_params.R`
- [x] included with value class check in `R/check_params.R`
- [x] included in table of `vignettes/GGIRParameters.Rmd` with references to the GGIR parts the parameter is used in.
- [x] mentioned in NEWS.Rd as NEW parameter

**If GGIR parameter(s) were deprecated these parameter(s) are:**
- [ ] documented as deprecated in `man/GGIR.Rd`
- [ ] removed from `R/load_params.R`
- [ ] removed from `R/check_params.R`
- [ ] removed from table in `vignettes/GGIRParameters.Rmd`
- [ ] mentioned as deprecated parameter in NEWS.Rd
- [ ] added to the list in `R/extract_params.R` with deprecated parameters such that these do not produce warnings when found in old config.csv files.