### PR TITLE
Issue1298 ensure all parameters config

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # CHANGES IN GGIR VERSION 3.2-?
 
-- Config file: fix minor issue that made GGIR, GGIRread, and R version packages to overwrite other parameters in config file. #1298 
+- Config file: fix minor issue that caused GGIR, GGIRread, and R version to overwrite the last 3 parameters in the config file. #1298 
 
 # CHANGES IN GGIR VERSION 3.2-6
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# CHANGES IN GGIR VERSION 3.2-?
+
+- Config file: fix minor issue that made GGIR, GGIRread, and R version packages to overwrite other parameters in config file. #1298 
+
 # CHANGES IN GGIR VERSION 3.2-6
 
 - Part 3 and 4:

--- a/R/createConfigFile.R
+++ b/R/createConfigFile.R
@@ -85,15 +85,16 @@ createConfigFile = function(config.parameters = c(), GGIRversion = "") {
     GGIRread_version = as.character(utils::packageVersion("GGIRread"))
     if (length(GGIRread_version) != 1) GGIRread_version = sessionInfo()$otherPkgs$GGIRread$Version
   }
-
-  out[nrow(out) - 2,] = c("GGIRread_version", GGIRread_version, "not applicable")
-  out[nrow(out) - 1,] = c("GGIRversion", GGIRversion, "not applicable")
-  out[nrow(out),] = c("R_version", SI$R.version$version.string, "not applicable")
+  out = rbind(out, matrix(c("GGIRread_version", GGIRread_version, "not applicable"), nrow = 1))
+  out = rbind(out, matrix(c("GGIRversion", GGIRversion, "not applicable"), nrow = 1))
+  out = rbind(out, matrix(c("R_version", SI$R.version$version.string, "not applicable"), nrow = 1)) 
   out = out[which(!is.na(out[,1])),]
   out = as.data.frame(out, stringsAsFactors = TRUE)
   row.names(out) <- NULL
   colnames(out) = c("argument","value","context")
   out$value = as.character(out$value)
+  out$argument = as.character(out$argument)
+  out$context = factor(as.character(out$context))
   out = out[which(out$argument %in% c("", possible_params_objectnames) == FALSE),]
   out = out[order(out$context),]
   return(out)


### PR DESCRIPTION
<!-- Describe your PR here -->
Fixes #1298 => config file now appends GGIR, GGIRread and R versions as new rows in the config file instead of overwritting other parameters.

<!-- Please, make sure the following items are checked -->
### Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [ ] Documentation updated:
  - [ ] Function documentation
  - [ ] Chapter vignettes for GitHub IO
  - [ ] Vignettes for CRAN
- [x] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
- [ ] GGIR parameters were added/removed. If yes, please also complete checklist below.

**If NEW GGIR parameter(s) were added then these NEW parameter(s) are:**
- [ ] documented in `man/GGIR.Rd`
- [ ] included with a default in `R/load_params.R`
- [ ] included with value class check in `R/check_params.R`
- [ ] included in table of `vignettes/GGIRParameters.Rmd` with references to the GGIR parts the parameter is used in.
- [ ] mentioned in NEWS.Rd as NEW parameter

**If GGIR parameter(s) were deprecated these parameter(s) are:**
- [ ] documented as deprecated in `man/GGIR.Rd`
- [ ] removed from `R/load_params.R`
- [ ] removed from `R/check_params.R`
- [ ] removed from table in `vignettes/GGIRParameters.Rmd`
- [ ] mentioned as deprecated parameter in NEWS.Rd
- [ ] added to the list in `R/extract_params.R` with deprecated parameters such that these do not produce warnings when found in old config.csv files.