### PR TITLE
Generate error when unknown parameter provided

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# CHANGES IN GGIR VERSION 3.2-7
+
+- Now generates error message when user provides parameters with unknown names to GGIR function #1300.
+
 # CHANGES IN GGIR VERSION 3.2-6
 
 - Part 3 and 4:

--- a/R/GGIR.R
+++ b/R/GGIR.R
@@ -19,12 +19,27 @@ GGIR = function(mode = 1:5, datadir = c(), outputdir = c(),
       for (dupi in unique(argNames[dupArgNames])) {
         dupArgValues = input[which(argNames %in% dupi)]
         if (all(dupArgValues == dupArgValues[[1]])) { # duplicated arguments, but no confusion about what value should be
-          warning(paste0("\nArgument ", dupi, " has been provided more than once. Try to avoid this."))
+          warning(paste0("\nParameter ", dupi, " has been provided more than once. Try to avoid this."))
         } else {# duplicated arguments, and confusion about what value should be,
-          warning(paste0("\nArgument ", dupi, " has been provided more than once and with inconsistent values. Please fix."))
+          warning(paste0("\nParameter ", dupi, " has been provided more than once and with inconsistent values. Please fix."))
         }
       }
     }
+    default_params = load_params()
+    known_param_names =  unlist(lapply(names(default_params), function(n) names(default_params[[n]])))
+    if (any(argNames %in% known_param_names == FALSE)) {
+      unknown_param_names = argNames[argNames %in% known_param_names == FALSE]
+      if (length(unknown_param_names) == 1) {
+        stop(paste0("\nParameter ", unknown_param_names,
+                       " is unknown to GGIR and will not be used, ",
+                    "please check for typos or remove."), call. = FALSE)
+      } else {
+        stop(paste0("\nParameters ", paste0(unknown_param_names, collapse = " and "),
+                       " are unknown to GGIR and will not be used, ",
+                    "please check for typos or remove these."), call. = FALSE)
+      }
+    }
+    rm(unknown_param_names, default_params, known_param_names)
   }
   
   if (length(datadir) == 0) {

--- a/tests/testthat/test_chainof5parts.R
+++ b/tests/testthat/test_chainof5parts.R
@@ -258,6 +258,24 @@ test_that("chainof5parts", {
   expect_true(file.exists("output_test/results/part5_daysummary_OO_L40M100V400_T5A5.csv"))
   dn = "output_test"
   
+  # Expect warning when unknown parameters are provided
+  expect_error(GGIR(mode = NULL, datadir = fn, outputdir = getwd(),
+                    studyname = "test", f0 = 1, f1 = 1,
+                    do.report = NULL, overwrite = FALSE,
+                    verbose = FALSE,
+                    iamnewhere = 0),
+               paste0("\nParameter iamnewhere is unknown to GGIR and will not be",
+                      " used, please check for typos or remove."))
+  
+  expect_error(GGIR(mode = NULL, datadir = fn, outputdir = getwd(),
+                    studyname = "test", f0 = 1, f1 = 1,
+                    do.report = NULL, overwrite = FALSE,
+                    verbose = FALSE,
+                    iamnewhere = 0,
+                    iamnewtoo = 1),
+               paste0("\nParameters iamnewhere and iamnewtoo are unknown to GGIR and will not be used, please check for typos or remove these."))
+  
+
   #=======================
   # Different variations on part 4:
   #--------------------------------------------

--- a/tests/testthat/test_chainof5parts.R
+++ b/tests/testthat/test_chainof5parts.R
@@ -273,7 +273,9 @@ test_that("chainof5parts", {
                     verbose = FALSE,
                     iamnewhere = 0,
                     iamnewtoo = 1),
-               paste0("\nParameters iamnewhere and iamnewtoo are unknown to GGIR and will not be used, please check for typos or remove these."))
+               paste0("\nParameters iamnewhere and iamnewtoo are unknown",
+                      " to GGIR and will not be used, please check for ",
+                      "typos or remove these."))
   
 
   #=======================


### PR DESCRIPTION
<!-- Describe your PR here -->
Fixes #1300 by generating an error when user provides unknown parameters to GGIR function

<!-- Please, make sure the following items are checked -->
### Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [x] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [ ] Documentation updated:
  - [ ] Function documentation
  - [ ] Chapter vignettes for GitHub IO
  - [ ] Vignettes for CRAN
- [x] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
- [ ] GGIR parameters were added/removed. If yes, please also complete checklist below.
