### PR TITLE
Issue1318 activity log dates sortering

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# CHANGES IN GGIR VERSION 3.2-?
+
+- Part 2 + 5: Segmentation with activity log is now able to handle non-chronological order of segment definitions in the log. #1318
+
 # CHANGES IN GGIR VERSION 3.2-7
 
 - Part 5: Fix bug in reinitialisation of window numbers when using multiple timewindow definitions in GGIR part 5. #1311
@@ -16,7 +20,6 @@
 
 - Part 2: Fix minor bug that added an extra row (day) in "part2_daysummary" when recording duration was less than one day and did not overlap with midnight. #1313
 
-- Part 2 + 5: Segmentation with activity log is now able to handle non-chronological order of segment definitions in the log. #1318
 
 # CHANGES IN GGIR VERSION 3.2-6
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,7 +20,6 @@
 
 - Part 2: Fix minor bug that added an extra row (day) in "part2_daysummary" when recording duration was less than one day and did not overlap with midnight. #1313
 
-
 # CHANGES IN GGIR VERSION 3.2-6
 
 - Part 3 and 4:

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 
 - Part 2: Fix minor bug that added an extra row (day) in "part2_daysummary" when recording duration was less than one day and did not overlap with midnight. #1313
 
+- Improved segmentation with activity log to allow for non-chronological segment definitions per file. #1318
+
 # CHANGES IN GGIR VERSION 3.2-6
 
 - Part 3 and 4:

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,7 +16,7 @@
 
 - Part 2: Fix minor bug that added an extra row (day) in "part2_daysummary" when recording duration was less than one day and did not overlap with midnight. #1313
 
-- Improved segmentation with activity log to allow for non-chronological segment definitions per file. #1318
+- Part 2 + 5: Segmentation with activity log is now able to handle non-chronological order of segment definitions in the log. #1318
 
 # CHANGES IN GGIR VERSION 3.2-6
 

--- a/R/g.analyse.perday.R
+++ b/R/g.analyse.perday.R
@@ -88,6 +88,11 @@ g.analyse.perday = function(ndays, firstmidnighti, time, nfeatures,
       qwindow_times = as.character(params_247[["qwindow"]])
       qwindow_names = as.character(params_247[["qwindow"]])
     }
+    # order qwindow timestamps in current date
+    qwindow_order = order(params_247[["qwindow"]])
+    params_247[["qwindow"]] = qwindow_values_backup = params_247[["qwindow"]][qwindow_order]
+    qwindow_times = qwindow_times[qwindow_order]
+    qwindow_names = qwindow_names[qwindow_order]
     # extract day from matrix D and qcheck
     if (startatmidnight == 1 & endatmidnight == 1) {
       qqq1 = midnightsi[di] * (ws2/ws3)	#a day starts at 00:00

--- a/R/g.part5.definedays.R
+++ b/R/g.part5.definedays.R
@@ -75,6 +75,9 @@ g.part5.definedays = function(nightsi, wi, indjump, nightsi_bu,
         if (length(qdate) == 1) { # if ID/date matched with activity log
           qnames = unlist(qwindow$qwindow_names[qdate])
           qwindow = unlist(qwindow$qwindow_values[qdate])
+          qwindow_order = order(qwindow)
+          qwindow = qwindow[qwindow_order]
+          qnames = qnames[qwindow_order]
         } else { # if ID/date not correctly matched with activity log
           qwindow = c(0, 24)
         }

--- a/tests/testthat/test_part5_qwindow.R
+++ b/tests/testthat/test_part5_qwindow.R
@@ -102,6 +102,44 @@ test_that("g.part5.definedays considers qwindow to generate segments", {
   expect_true(file.exists(fn))
   if (file.exists(fn)) file.remove(fn)
   
+  
+  # With times in not chronological order
+  actlog = data.frame(id = c("1RAW"),
+                      date = c("2022-01-01"),
+                      travelhome = c("16:30:43"),
+                      work = c("08:09:59"),
+                      home = c("17:30:00"))
+  fn = "testactlog.csv"
+  write.csv(x = actlog, file = fn, row.names = FALSE)
+  LOG = g.conv.actlog(qwindow = fn, qwindow_dateformat = "%Y-%m-%d")
+  
+  # definedays
+  definedays = g.part5.definedays(nightsi = nightsi, wi = 1, indjump = 1, 
+                                  nightsi_bu = nightsi, epochSize = 60, 
+                                  qqq_backup=c(), 
+                                  ts = ts, timewindowi = "MM", Nwindows = 1, 
+                                  qwindow = LOG, ID = "1RAW")
+  
+  expect_false(is.null(definedays$segments))
+  expect_true(is.list(definedays$segments))
+  expect_equal(length(definedays$segments), 5)
+  expect_equal(names(definedays$segments)[1], "00:00:00-23:59:00")
+  expect_equal(definedays$segments[[1]], c(1, 1440))
+  expect_equal(names(definedays$segments)[2], "00:00:00-08:09:00")
+  expect_equal(definedays$segments[[2]], c(1, 490))
+  expect_equal(names(definedays$segments)[3], "08:10:00-16:30:00")
+  expect_equal(definedays$segments[[3]], c(491, 991))
+  expect_equal(names(definedays$segments)[4], "16:31:00-17:29:00")
+  expect_equal(definedays$segments[[4]], c(992, 1050))
+  expect_equal(names(definedays$segments)[5], "17:30:00-23:59:00")
+  expect_equal(definedays$segments[[5]], c(1051, 1440))
+  expect_equal(definedays$segments_names, c("MM", "daystart-work", 
+                                            "work-travelhome", 
+                                            "travelhome-home", "home-dayend"))
+  
+  expect_true(file.exists(fn))
+  if (file.exists(fn)) file.remove(fn)
+  
 })
 
 


### PR DESCRIPTION
<!-- Describe your PR here -->
Fixes #1318 => activity log can now contain non-chronologically sorted segments as GGIR would sort them within each file-date loop in both part 2 and part 5.

<!-- Please, make sure the following items are checked -->
### Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [x] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [x] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [ ] Documentation updated:
  - [ ] Function documentation
  - [ ] Chapter vignettes for GitHub IO
  - [ ] Vignettes for CRAN
- [x] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
- [ ] GGIR parameters were added/removed. If yes, please also complete checklist below.

**If NEW GGIR parameter(s) were added then these NEW parameter(s) are:**
- [ ] documented in `man/GGIR.Rd`
- [ ] included with a default in `R/load_params.R`
- [ ] included with value class check in `R/check_params.R`
- [ ] included in table of `vignettes/GGIRParameters.Rmd` with references to the GGIR parts the parameter is used in.
- [ ] mentioned in NEWS.Rd as NEW parameter

**If GGIR parameter(s) were deprecated these parameter(s) are:**
- [ ] documented as deprecated in `man/GGIR.Rd`
- [ ] removed from `R/load_params.R`
- [ ] removed from `R/check_params.R`
- [ ] removed from table in `vignettes/GGIRParameters.Rmd`
- [ ] mentioned as deprecated parameter in NEWS.Rd
- [ ] added to the list in `R/extract_params.R` with deprecated parameters such that these do not produce warnings when found in old config.csv files.