### PR TITLE
Fix bug causing non-default csv sibreport to be saved with UTC timestamps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# CHANGES IN GGIR VERSION 3.2-?
+
+- Part 5: Fix bug that caused sibreport to be stored with timestamps in UTC timezone. #1332
+
 # CHANGES IN GGIR VERSION 3.2-8
 
 - Revise guidance on GGIR citation. #1303

--- a/R/g.part5.R
+++ b/R/g.part5.R
@@ -415,7 +415,8 @@ g.part5 = function(datadir = c(), metadatadir = c(), f0=c(), f1=c(),
               if (length(sibreport) > 0) {
                 data.table::fwrite(x = sibreport, file = sibreport_fname, row.names = FALSE,
                                    sep = params_output[["sep_reports"]],
-                                   dec = params_output[["dec_reports"]])
+                                   dec = params_output[["dec_reports"]],
+                                   dateTimeAs = "write.csv")
               }
               # nap/sib/nonwear overlap analysis
               if (length(params_sleep[["nap_model"]]) > 0 & length(sibreport) > 0) {


### PR DESCRIPTION
<!-- Describe your PR here -->
Fixes #1332 
It seems this only affected the sibreports themselves and not the rest of the GGIR output and be limited to the non-default approach of storing the data to .csv.

<!-- Please, make sure the following items are checked -->
### Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [ ] Documentation updated:
  - [ ] Function documentation
  - [ ] Chapter vignettes for GitHub IO
  - [ ] Vignettes for CRAN
- [x] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] If you think you made a significant contribution, add your name to the contributors lists in the `DESCRIPTION`, `zenodo.json`, and `inst/CITATION` files.
- [ ] GGIR parameters were added/removed. If yes, please also complete checklist below.
