### PR TITLE
Allow for multiple cadence and acceleration thresholds in detectEventBouts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# CHANGES IN GGIR VERSION 3.3-5
+
+- Part 2: Walking bout detection expanded to allow for multiple cadence and acceleration thresholds. #1466
+
 # CHANGES IN GGIR VERSION 3.3-4
 
 - Part 2: Improved handling of corrupted RData files in part 1 or 2. #1447 and #1449

--- a/R/detectEventBouts.R
+++ b/R/detectEventBouts.R
@@ -10,57 +10,66 @@ detectEventBouts = function(myfun, varnum_event, varnum,
   # varnum = metashort[anwindices, mi]
   cadence = varnum_event * (60/ws3)
   # Event bouts
+  # Loop over bout durations
   for (boutdur in myfun$ebout.dur) {
     boutduration = boutdur * (60/ws3) # per minute
-    rr1 = matrix(0, length(varnum), 1)
-    if (myfun$ebout.condition == "AND") {
-      p = which(varnum * UnitReScale >= myfun$ebout.th.acc &
-                  cadence >= myfun$ebout.th.cad); rr1[p] = 1
-    } else if (myfun$ebout.condition == "OR") {
-      p = which(varnum * UnitReScale >= myfun$ebout.th.acc |
-                  cadence >= myfun$ebout.th.cad); rr1[p] = 1
-    }
-    getboutout = g.getbout(x = rr1, boutduration = boutduration,
-                           boutcriter = myfun$ebout.criter,
-                           ws3 = ws3)
-    # time spent in bouts in minutes
-    eventbout = length(which(getboutout == 1)) / (60/ws3)
-    eboutname = paste0("ExtFunEvent_totdur_B", boutdur,
-                       "M", (myfun$ebout.criter  * 100),
-                       "%_cad",myfun$ebout.th.cad, myfun$ebout.condition,
-                       "acc", myfun$ebout.th.acc)
-    ebout_varname = paste0(eboutname, "_", boutnameEnding)
-    # fi = correct_fi(di, ds_names, fi, varname = ebout_varname)
-    daysummary[di,fi] = eventbout # total time in ebouts
-    ds_names[fi] = ebout_varname;
-    fi = fi + 1
-    # number of bouts
-    rle_bout = rle(as.numeric(getboutout))
-    rle_bout1 = which(rle_bout$values == 1)
-    number_of_bouts = length(rle_bout1)
     
-    eboutname = paste0("ExtFunEvent_number_B", boutdur,
-                       "M", (myfun$ebout.criter  * 100),
-                       "%_cad",myfun$ebout.th.cad, myfun$ebout.condition,
-                       "acc", myfun$ebout.th.acc)
-    ebout_varname = paste0(eboutname, "_", boutnameEnding)
-    daysummary[di,fi] = number_of_bouts
-    ds_names[fi] = ebout_varname;
-    fi = fi + 1
-    # average bout duration in minutes
-    if (number_of_bouts > 0) {
-      mn_dur_bouts = mean(rle_bout$lengths[which(rle_bout$values == 1)]) / (60/ws3)
-    } else {
-      mn_dur_bouts = 0
+    # Loop over cadence thresholds
+    for (cad_th in myfun$ebout.th.cad) {
+      
+      # Loop over acceleration thresholds
+      for (acc_th in myfun$ebout.th.acc) {
+        rr1 = matrix(0, length(varnum), 1)
+        if (myfun$ebout.condition == "AND") {
+          p = which(varnum * UnitReScale >= acc_th &
+                      cadence >= cad_th); rr1[p] = 1
+        } else if (myfun$ebout.condition == "OR") {
+          p = which(varnum * UnitReScale >= acc_th |
+                      cadence >= cad_th); rr1[p] = 1
+        }
+        getboutout = g.getbout(x = rr1, boutduration = boutduration,
+                               boutcriter = myfun$ebout.criter,
+                               ws3 = ws3)
+        # time spent in bouts in minutes
+        eventbout = length(which(getboutout == 1)) / (60/ws3)
+        eboutname = paste0("ExtFunEvent_totdur_B", boutdur,
+                           "M", (myfun$ebout.criter  * 100),
+                           "%_cad",cad_th, myfun$ebout.condition,
+                           "acc", acc_th)
+        ebout_varname = paste0(eboutname, "_", boutnameEnding)
+        # fi = correct_fi(di, ds_names, fi, varname = ebout_varname)
+        daysummary[di,fi] = eventbout # total time in ebouts
+        ds_names[fi] = ebout_varname;
+        fi = fi + 1
+        # number of bouts
+        rle_bout = rle(as.numeric(getboutout))
+        rle_bout1 = which(rle_bout$values == 1)
+        number_of_bouts = length(rle_bout1)
+        
+        eboutname = paste0("ExtFunEvent_number_B", boutdur,
+                           "M", (myfun$ebout.criter  * 100),
+                           "%_cad",cad_th, myfun$ebout.condition,
+                           "acc", acc_th)
+        ebout_varname = paste0(eboutname, "_", boutnameEnding)
+        daysummary[di,fi] = number_of_bouts
+        ds_names[fi] = ebout_varname;
+        fi = fi + 1
+        # average bout duration in minutes
+        if (number_of_bouts > 0) {
+          mn_dur_bouts = mean(rle_bout$lengths[which(rle_bout$values == 1)]) / (60/ws3)
+        } else {
+          mn_dur_bouts = 0
+        }
+        eboutname = paste0("ExtFunEvent_meandur_B", boutdur,
+                           "M", (myfun$ebout.criter  * 100),
+                           "%_cad",cad_th, myfun$ebout.condition,
+                           "acc", acc_th)
+        ebout_varname = paste0(eboutname, "_", boutnameEnding)
+        daysummary[di,fi] = mn_dur_bouts
+        ds_names[fi] = ebout_varname;
+        fi = fi + 1
+      }
     }
-    eboutname = paste0("ExtFunEvent_meandur_B", boutdur,
-                       "M", (myfun$ebout.criter  * 100),
-                       "%_cad",myfun$ebout.th.cad, myfun$ebout.condition,
-                       "acc", myfun$ebout.th.acc)
-    ebout_varname = paste0(eboutname, "_", boutnameEnding)
-    daysummary[di,fi] = mn_dur_bouts
-    ds_names[fi] = ebout_varname;
-    fi = fi + 1
   }
   invisible(list(daysummary = daysummary, ds_names = ds_names,
                  fi = fi, di = di))

--- a/tests/testthat/test_detectEventBouts.R
+++ b/tests/testthat/test_detectEventBouts.R
@@ -14,7 +14,7 @@ test_that("Detect bouts in events", {
   varnum_event[which(metashort$ENMO[anwindices] > 0.05)] = 10
   ws3 = 5
   anwi_nameindices = "_1234hrs"
-  daysummary = matrix("", 1, 25)
+  daysummary = matrix("", 1, 50)
   fi = 1
   di = 1
   ds_names = ""
@@ -22,8 +22,8 @@ test_that("Detect bouts in events", {
                clevels = c(0, 30, 50),
                qlevels = c(0.25, 0.5, 0.75),
                ebout.dur = c(1, 5, 10),
-               ebout.th.cad = 30,
-               ebout.th.acc = 50,
+               ebout.th.cad = c(30, 100),
+               ebout.th.acc = c(50, 100),
                ebout.criter = 1,
                ebout.condition = "AND")
 
@@ -38,7 +38,16 @@ test_that("Detect bouts in events", {
                                 boutnameEnding = "_anyRandomText")
   
   
-  expect_equal(as.numeric(eventBouts$daysummary)[1:5], c(3.5, 1, 3.5, 0, 0))
-  expect_equal(eventBouts$ds_names[5], "ExtFunEvent_number_B5M100%_cad30ANDacc50__anyRandomText")
+  # all bouts of 1 minute have the same estimates as they all meet the cadence and acc criteria
+  expect_equal(as.numeric(eventBouts$daysummary)[1:12], c(rep(c(3.5, 1.0, 3.5), 4)))
+  
+  # expect different estimates are calculated
+  expect_true("ExtFunEvent_number_B5M100%_cad30ANDacc50__anyRandomText" %in% eventBouts$ds_names)
+  expect_true("ExtFunEvent_totdur_B1M100%_cad30ANDacc100__anyRandomText" %in% eventBouts$ds_names)
+  expect_true("ExtFunEvent_totdur_B1M100%_cad100ANDacc100__anyRandomText" %in% eventBouts$ds_names)
+  expect_true("ExtFunEvent_totdur_B1M100%_cad100ANDacc50__anyRandomText" %in% eventBouts$ds_names)
+  
+  # Bouts of 5 or 10 minutes are undetected with any cadence and acc criteria
+  expect_equal(sum(as.numeric(eventBouts$daysummary)[13:36]), 0)
   
 })

--- a/vignettes/StepCadenceAnalysis.Rmd
+++ b/vignettes/StepCadenceAnalysis.Rmd
@@ -138,8 +138,8 @@ The step bout detection functionality automatically uses all acceleration metric
 To control the criteria for bout detection, include in your `myfun` object the items:
 
 - `ebout.dur` a numeric vector of length 1 or larger with the minimum bout duration(s) of interest, e.g. `ebout.dur = c(1, 5, 10)`.
-- `ebout.th.cad` a single number being the minimum cadence value in steps per minute, e.g. `ebout.th.cad = 30`.
-- `ebout.th.acc` a single number being the minimum acceleration value in steps per minute, e.g. `ebout.th.acc = 50`.
+- `ebout.th.cad` a numeric vector of length 1 or larger being the minimum cadence value in steps per minute, e.g. `ebout.th.cad = 30`.
+- `ebout.th.acc` a numeric vector of length 1 or larger being the minimum acceleration value in steps per minute, e.g. `ebout.th.acc = 50`.
 - `ebout.criter` a single number as a fraction of 1 being the faction of a bout for which the inclusion criteria need to be met identical to `boutcriter` in the context of physical activity bouts, e.g. `ebout.criter = 0.8`.
 - `ebout.condition` whether cadence and acceleration condition are both required (`ebout.condition = "AND"`) or either of the conditions is required (`ebout.condition = "OR"`). If both cadence and acc need to meet a thresholds then fill in `"AND"`. If it also acceptable if only one of the thresholds is met then fill in `"OR"`. If you do not want cadence or acceleration to be used in the equation then simply set `ebout.th.cad = 0` or `ebout.th.acc = 0`.
 


### PR DESCRIPTION
<!-- Describe your PR here -->
Updates the `detectEventBouts` function to support vector inputs for `ebout.th.cad` (cadence threshold) and `ebout.th.acc` (acceleration threshold).

Previously, the function only accepted single values, limiting users to a single cadence and acceleration definition to detect walking bouts. With this change, the function now iterates through all provided durations, cadence thresholds, and acceleration thresholds, enabling multiple walking bout definitions within a single execution.

Fixes #1466 

<!-- Please, make sure the following items are checked -->
### Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [x] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [x] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [x] Documentation updated:
  - [ ] Function documentation
  - [x] Chapter vignettes for GitHub IO
  - [ ] Vignettes for CRAN
- [x] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] If you think you made a significant contribution, add your name to the contributors lists in the `DESCRIPTION`, `zenodo.json`, and `inst/CITATION` files.
- [ ] GGIR parameters were added/removed. If yes, please also complete checklist below.

**If NEW GGIR parameter(s) were added then these NEW parameter(s) are:**
- [ ] documented in `man/GGIR.Rd`
- [ ] included with a default in `R/load_params.R`
- [ ] included with value class check in `R/check_params.R`
- [ ] included in table of `vignettes/GGIRParameters.Rmd` with references to the GGIR parts the parameter is used in.
- [ ] mentioned in NEWS.Rd as NEW parameter

**If GGIR parameter(s) were deprecated these parameter(s) are:**
- [ ] documented as deprecated in `man/GGIR.Rd`
- [ ] removed from `R/load_params.R`
- [ ] removed from `R/check_params.R`
- [ ] removed from table in `vignettes/GGIRParameters.Rmd`
- [ ] mentioned as deprecated parameter in NEWS.Rd
- [ ] added to the list in `R/extract_params.R` with deprecated parameters such that these do not produce warnings when found in old config.csv files.