### PR TITLE
Update documentation of Chapter 13 (Circadian Rhythm Analyses)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 # CHANGES IN GGIR VERSION 3.3-?
 
-- Documentation: Remove suggestion that configfile can be used to store annotations inside the configuration file to keep focus on the main purpose of the configfile, which is to facilitate reproducing analysis. #1473
+- Documentation: 
+
+  - Remove suggestion that configfile can be used to store annotations inside the configuration file to keep focus on the main purpose of the configfile, which is to facilitate reproducing analysis. #1473
+
+  - Updated documentation in chapter 13 (Circadian Rhythm Analyses). #1494
 
 - Part 6: Enable extraction of participant ID from filename consistent with the other parts #1478
 

--- a/R/check_params.R
+++ b/R/check_params.R
@@ -98,7 +98,7 @@ check_params = function(params_sleep = c(), params_metrics = c(),
                        "IVIS.activity.metric", "IVIS_acc_threshold",
                        "qM5L5", "MX.ig.min.dur", "M5L5res", "winhr", "LUXthresholds", "LUX_cal_constant",
                        "LUX_cal_exponent", "LUX_day_segments", "L5M5window", "clevels", "SRI2_WASOmin")
-    boolean_params = c("cosinor", "part6CR", "part6HCA", "part6DFA")
+    boolean_params = c("cosinor", "part6CR", "part6HCA", "part6DFA", "part2CR")
     character_params = c("qwindow_dateformat", "part6Window")
     check_class("247", params = params_247, parnames = numeric_params, parclass = "numeric")
     check_class("247", params = params_247, parnames = boolean_params, parclass = "boolean")
@@ -438,6 +438,9 @@ check_params = function(params_sleep = c(), params_metrics = c(),
       if (params_247[["LUX_day_segments"]][length(params_247[["LUX_day_segments"]])] != 24) {
         params_247[["LUX_day_segments"]] = c(params_247[["LUX_day_segments"]], 24)
       }
+    }
+    if (params_247[["cosinor"]] == TRUE & params_247[["part2CR"]] == FALSE) {
+      params_247[["part2CR"]] = TRUE
     }
     # params 247 & params output
     if (length(params_output[["save_ms5raw_format"]]) == 1 && 

--- a/R/check_params.R
+++ b/R/check_params.R
@@ -439,7 +439,7 @@ check_params = function(params_sleep = c(), params_metrics = c(),
         params_247[["LUX_day_segments"]] = c(params_247[["LUX_day_segments"]], 24)
       }
     }
-    if (params_247[["cosinor"]] == TRUE & params_247[["part2CR"]] == FALSE) {
+    if (params_247[["cosinor"]] == TRUE && params_247[["part2CR"]] == FALSE) {
       params_247[["part2CR"]] = TRUE
     }
     # params 247 & params output

--- a/R/g.analyse.avday.R
+++ b/R/g.analyse.avday.R
@@ -115,7 +115,7 @@ g.analyse.avday = function(doquan, averageday, M, IMP, t_TWDI, quantiletype,
   #----------------------------------
   # Cosinor analysis, (Extended) Cosinor analysis, including IV, IS, and phi
   # based on time series where invalid data points are set to NA
-  if (params_247[["cosinor"]] == TRUE) {
+  if (params_247[["part2CR"]] == TRUE) {
     cosinor_coef = apply_cosinor_IS_IV_Analyses(ts = IMP$metashort[, c("timestamp", acc.metric)],
                                                 qcheck = qcheck,
                                                 midnightsi, epochsizes = c(ws3, ws2),

--- a/R/load_params.R
+++ b/R/load_params.R
@@ -99,7 +99,7 @@ load_params = function(topic = c("sleep", "metrics", "rawdata",
                       part6CR = FALSE, part6HCA = FALSE,
                       part6Window = c("start", "end"),
                       part6DFA = FALSE, clevels = c(30, 150),
-                      SRI2_WASOmin = 30)
+                      SRI2_WASOmin = 30, part2CR = FALSE)
 
   }
   if ("phyact" %in% topic) {

--- a/man/GGIR.Rd
+++ b/man/GGIR.Rd
@@ -1714,13 +1714,13 @@ GGIR(mode = 1:5,
         over which L5M5 needs to be calculated. Now this is done with parameter qwindow.}
 
       \item{cosinor}{
-        Boolean (default = FALSE). Whether to apply the cosinor analysis from the ActCR package in part 2.
-        In part 6 cosinor analysis is applied by default and cannot be turned off.
-        This parameter will be deprecated, for now its value overwrites part2CR in the 
-        case that \code{cosinor = TRUE} and \code{part2CR = FALSE}}
+        Boolean (default = FALSE). Whether to apply the circadian rhythm analysis in part 2.
+        This parameter will be superseded by new parameter \code{part2CR} to better reflect
+        that this controls all circadian rhythm parameters. If \code{part2CR} is specified then
+        that setting overwrites \code{cosinor}.}
       
       \item{part2CR}{
-        Boolean (default = FALSE). Whether to circadian rhythm analysis should be run in
+        Boolean (default = FALSE). Whether circadian rhythm analysis should be run in
         part 2, including: cosinor analysis, extended cosinor analysis, IS, IV, and phi.}
       
       \item{part6CR}{

--- a/man/GGIR.Rd
+++ b/man/GGIR.Rd
@@ -1715,8 +1715,14 @@ GGIR(mode = 1:5,
 
       \item{cosinor}{
         Boolean (default = FALSE). Whether to apply the cosinor analysis from the ActCR package in part 2.
-        In part 6 cosinor analysis is applied by default and cannot be turned off.}
-        
+        In part 6 cosinor analysis is applied by default and cannot be turned off.
+        This parameter will be deprecated, for now its value overwrites part2CR in the 
+        case that \code{cosinor = TRUE} and \code{part2CR = FALSE}}
+      
+      \item{part2CR}{
+        Boolean (default = FALSE). Whether to circadian rhythm analysis should be run in
+        part 2, including: cosinor analysis, extended cosinor analysis, IS, IV, and phi.}
+      
       \item{part6CR}{
         Boolean (default = FALSE) to indicate whether circadian rhythm analysis should
         be run by part 6, this includes: cosinor analysis, extended cosinor analysis,

--- a/tests/testthat/test_load_check_params.R
+++ b/tests/testthat/test_load_check_params.R
@@ -14,7 +14,7 @@ test_that("load_params can load parameters", {
   expect_equal(length(params$params_sleep), 43)
   expect_equal(length(params$params_metrics), 41)
   expect_equal(length(params$params_rawdata), 39)
-  expect_equal(length(params$params_247), 25)
+  expect_equal(length(params$params_247), 26)
   expect_equal(length(params$params_cleaning), 28)
   expect_equal(length(params$params_phyact), 14)
   expect_equal(length(params$params_output), 28)

--- a/tests/testthat/test_part6.R
+++ b/tests/testthat/test_part6.R
@@ -95,7 +95,7 @@ test_that("Part 6 with household co-analysis", {
   params_247[["part6HCA"]] = FALSE
   params_general[["do.parallel"]] = FALSE
   params_general[["overwrite"]] = TRUE
-  params_247[["cosinor"]] = TRUE
+  params_247[["part2CR"]] = TRUE
   params_247[["part6CR"]] = TRUE
   params_247[["part6Window"]] = c("start", "end")
   params_cleaning = load_params(topic = "cleaning")$params_cleaning

--- a/vignettes/GGIRParameters.Rmd
+++ b/vignettes/GGIRParameters.Rmd
@@ -165,6 +165,7 @@ find a description and default value for all the arguments.
 | qM5L5                       | 2                 | params_247               |
 | MX.ig.min.dur               | 2                 | params_247               |
 | qwindow_dateformat          | 2                 | params_247               |
+| part2CR                     | 2                 | params_247               |
 | anglethreshold              | 3                 | params_sleep             |
 | timethreshold               | 3                 | params_sleep             |
 | ignorenonwear               | 3                 | params_sleep             |

--- a/vignettes/GGIRoutput.Rmd
+++ b/vignettes/GGIRoutput.Rmd
@@ -111,10 +111,8 @@ The following variables in the GGIR output are derived by the ActCR package, the
 | Variable name | Description |
 |--------------------------|----------------------------------------------|
 | cosinor_mes |  MESOR which is short for midline statistics of rhythm, which is a rhythm adjusted mean. This represents mean activity level. |
-| cosinor_amp | amplitude, a measure of half the extend of predictable variation within a cycle.
-This represents the highest activity one can achieve |
-| cosinor_acrophase | acrophase, a measure of the time of the overall high values recurring in each
-cycle. Here it has a unit of radian. This represents time to reach the peak. |
+| cosinor_amp | amplitude, a measure of half the extend of predictable variation within a cycle. This represents the highest activity one can achieve |
+| cosinor_acrophase | acrophase, a measure of the time of the overall high values recurring in each cycle. Here it has a unit of radian. This represents time to reach the peak. |
 | cosinor_acrotime | acrotime represents time to reach the peak. |
 | cosinor_ndays | Number of days modeled |
 | cosinorExt_minimum | Minimum value of the of the function. |

--- a/vignettes/chapter13_CircadianRhythm.Rmd
+++ b/vignettes/chapter13_CircadianRhythm.Rmd
@@ -33,11 +33,11 @@ Within GGIR part 2 MXLX is calculated per calendar day and, if argument `qwindow
 
 The MX metric described here should not be confused by the MX metrics as proposed by [Rowlands et al.](https://doi.org/10.1186/s40798-019-0225-9) which looks at accumulated most active time which may not always be continuous in time. The MX metrics by Rowlands et al. are discussed [here](https://wadpac.github.io/GGIR/articles/chapter7_DescribingDataWithoutKnowingSleep.html#sets-of-quantiles-mx-metrics-by-rowlands-et-al-).
 
-## (Extended) Cosinor analysis {#extended-cosinor-analysis}
+## (Extended) Cosinor analysis
 
 The Cosinor analysis quantifies the circadian 24 hour cycle. Cosinor analysis refers to fitting a cosine function to a log transformed time series, while the extended cosinor analysis refers to fitting a non-linear transformation of the traditional cosinor curve to after Marler et al. Statist. Med. 2006 (doi: 10.1002/sim.2466).
 
-Cosinor analysis is applied in GGIR Part 2 and Part 6, yet it is not run by default. In part 2, the parameter `cosinor = TRUE` enables this analysis. In part 6, GGIR relies in parameter `part6CR = TRUE` for running the full circadian rhythm analyses, including the Cosinor and Extended Cosinor. The implementation is as follows:
+Cosinor analysis is applied in GGIR Part 2 and Part 6, yet it is not run by default. In part 2, the parameter `part2CR = TRUE` enables this analysis. In part 6, GGIR relies in parameter `part6CR = TRUE` for running the full circadian rhythm analyses, including the Cosinor and Extended Cosinor. The implementation is as follows:
 
 1.  The acceleration metric as specified with parameter `acc.metric` is used.
 2.  Acceleration metric values are averaged per minute and expressed in m*g* if the input is in *g*, and then log transformed as `log(acceleration + 1)`.
@@ -72,7 +72,7 @@ Phi indicates how correlated the multi-day acceleration time series is with itse
 
 ## Activating the calculation of IS, IV, and phi
 
-It is important to note that the calculation of the metrics IS, IV, and phi is tied to the performance of the (Extended) Cosinor analyses. Therefore, to get these metrics both in part 2 and part 6, you need to activate the Cosinor analyses with `cosinor = TRUE` in part 2 and with `part6CR = TRUE` in part 6, as described [here](#extended-cosinor-analysis).
+The parameter `part2CR = TRUE` enables the calculation of metrics IS, IV, and phi in part 2, and the parameter `part6CR = TRUE` in part 6.
 
 ## Detrended fluctuation analysis (DFA)
 

--- a/vignettes/chapter13_CircadianRhythm.Rmd
+++ b/vignettes/chapter13_CircadianRhythm.Rmd
@@ -64,6 +64,8 @@ The GGIR implementation of IV and IS since GGIR release 3.1-6 has been described
 
 The new implementation as documented by [Danilevicz et al. 2024](https://doi.org/10.1186/s12874-024-02255-w) is not compatible with the older experimental implementation. Parameters `IVIS.activity.metric`, `IVIS_windowsize_minutes`, `IVIS_epochsize_seconds`, and `IVIS_acc_threshold` that were used before is no longer needed and have been deprecated.
 
+IS is sometimes used as a measure of behavioural robustness when conducting Cosinor analysis. However, to work with the combination of the two outcomes it seems important that IS is calculated from the same time series. 
+
 ## phi
 
 Phi indicates how correlated the multi-day acceleration time series is with itself when there is an hour shift, also known as first-order auto-correlation from the first-order autoregressive model AR(1). A higher phi value indicates a higher autocorrelation, while a phi close to zero or even negative indicates more fragmented behavior. For a detailed discussion of phi see [Dickey and Fuller (1979)](https://doi.org/10.1080/01621459.1979.10482531) and [Danilevicz et al. 2024](https://doi.org/10.1186/s12874-024-02255-w). Phi is calculated by default in GGIR part 2 and in part 6 only when parameter `part6CR` is set to TRUE.

--- a/vignettes/chapter13_CircadianRhythm.Rmd
+++ b/vignettes/chapter13_CircadianRhythm.Rmd
@@ -25,6 +25,10 @@ As a result, when your intention is to compare physical activity or sleep estima
 
 Further, part 6 offers a few additional circadian rhythm estimates such as DFA (discussed below), and when fragmentation analysis is turned on (see parameter `frag.metrics` as discussed in the [next chapter](https://wadpac.github.io/GGIR/articles/chapter14_BehaviouralFragmentation.html)) activity and sleep fragmentation are also estimated.
 
+## Controlling which circadian rhythm estimates are derived
+
+Cosinor, IV, IS, and phi as discussed below are not derived by default. To activate them set parameters `part2CR = TRUE` and `part6CR = TRUE`, for part 2 and part 6 respectively. MXLX as discussed below is run by default in part 2 irrespective of how `part2CR` is set. However, in part 6 MXLX is only run when `part6CR = TRUE`.
+
 ## MXLX
 
 MXLX looks for the continuous least (LX) and most (MX) active X hour window in a day, where X is defined by parameter `winhr`. For both LX and MX, GGIR calculates the average acceleration, the start time, and if argument `iglevels` is specified also the intensity gradient. If parameter `winhr` is a vector then MX and LX are derived for each value in the vector.
@@ -37,7 +41,7 @@ The MX metric described here should not be confused by the MX metrics as propose
 
 The Cosinor analysis quantifies the circadian 24 hour cycle. Cosinor analysis refers to fitting a cosine function to a log transformed time series, while the extended cosinor analysis refers to fitting a non-linear transformation of the traditional cosinor curve to after Marler et al. Statist. Med. 2006 (doi: 10.1002/sim.2466).
 
-Cosinor analysis is applied in GGIR Part 2 and Part 6, yet it is not run by default. In part 2, the parameter `part2CR = TRUE` enables this analysis. In part 6, GGIR relies in parameter `part6CR = TRUE` for running the full circadian rhythm analyses, including the Cosinor and Extended Cosinor. The implementation is as follows:
+The implementation of Cosinor and Extended Cosinor in GGIR is as follows:
 
 1.  The acceleration metric as specified with parameter `acc.metric` is used.
 2.  Acceleration metric values are averaged per minute and expressed in m*g* if the input is in *g*, and then log transformed as `log(acceleration + 1)`.
@@ -64,15 +68,11 @@ The GGIR implementation of IV and IS since GGIR release 3.1-6 has been described
 
 The new implementation as documented by [Danilevicz et al. 2024](https://doi.org/10.1186/s12874-024-02255-w) is not compatible with the older experimental implementation. Parameters `IVIS.activity.metric`, `IVIS_windowsize_minutes`, `IVIS_epochsize_seconds`, and `IVIS_acc_threshold` that were used before is no longer needed and have been deprecated.
 
-IS is sometimes used as a measure of behavioural robustness when conducting Cosinor analysis. However, to work with the combination of the two outcomes it seems important that IS is calculated from the same time series. 
+IS is sometimes used as a measure of behavioural robustness when conducting Cosinor analysis. However, to work with the combination of the two outcomes it is important that IS is calculated from the same time series. 
 
 ## phi
 
 Phi indicates how correlated the multi-day acceleration time series is with itself when there is an hour shift, also known as first-order auto-correlation from the first-order autoregressive model AR(1). A higher phi value indicates a higher autocorrelation, while a phi close to zero or even negative indicates more fragmented behavior. For a detailed discussion of phi see [Dickey and Fuller (1979)](https://doi.org/10.1080/01621459.1979.10482531) and [Danilevicz et al. 2024](https://doi.org/10.1186/s12874-024-02255-w). Phi is calculated by default in GGIR part 2 and in part 6 only when parameter `part6CR` is set to TRUE.
-
-## Activating the calculation of IS, IV, and phi
-
-The parameter `part2CR = TRUE` enables the calculation of metrics IS, IV, and phi in part 2, and the parameter `part6CR = TRUE` in part 6.
 
 ## Detrended fluctuation analysis (DFA)
 

--- a/vignettes/chapter13_CircadianRhythm.Rmd
+++ b/vignettes/chapter13_CircadianRhythm.Rmd
@@ -18,8 +18,8 @@ Circadian rhythm are the physical, mental, and behavioral changes an organism ex
 
 Most of the techniques are applied in both GGIR part 2 and 6. The main differences between these implementations are:
 
-- In GGIR part 2 the circadian rhythm analysis tries to use every valid data point in the recording.
-- In GGIR part 6 the circadian rhythm analysis uses a specific time window as defined by the user, e.g. from first wake-up time till before last wake-up time, and omits entire days that are considered invalid or incomplete.
+-   In GGIR part 2 the circadian rhythm analysis tries to use every valid data point in the recording.
+-   In GGIR part 6 the circadian rhythm analysis uses a specific time window as defined by the user, e.g. from first wake-up time till before last wake-up time, and omits entire days that are considered invalid or incomplete.
 
 As a result, when your intention is to compare physical activity or sleep estimates derived in GGIR, part 6 estimates ensure that the same days and time points are used as in the other parts of GGIR. Whereas, part 2 does not attempt to do so.
 
@@ -33,11 +33,11 @@ Within GGIR part 2 MXLX is calculated per calendar day and, if argument `qwindow
 
 The MX metric described here should not be confused by the MX metrics as proposed by [Rowlands et al.](https://doi.org/10.1186/s40798-019-0225-9) which looks at accumulated most active time which may not always be continuous in time. The MX metrics by Rowlands et al. are discussed [here](https://wadpac.github.io/GGIR/articles/chapter7_DescribingDataWithoutKnowingSleep.html#sets-of-quantiles-mx-metrics-by-rowlands-et-al-).
 
-## (Extended) Cosinor analysis
+## (Extended) Cosinor analysis {#extended-cosinor-analysis}
 
 The Cosinor analysis quantifies the circadian 24 hour cycle. Cosinor analysis refers to fitting a cosine function to a log transformed time series, while the extended cosinor analysis refers to fitting a non-linear transformation of the traditional cosinor curve to after Marler et al. Statist. Med. 2006 (doi: 10.1002/sim.2466).
 
-Corinos analyssis are not run by default, to tell GGIR to perform these analyse specify parameter `cosinor = TRUE`. The implementation is as follows:
+Cosinor analysis is applied in GGIR Part 2 and Part 6, yet it is not run by default. In part 2, the parameter `cosinor = TRUE` enables this analysis. In part 6, GGIR relies in parameter `part6CR = TRUE` for running the full circadian rhythm analyses, including the Cosinor and Extended Cosinor. The implementation is as follows:
 
 1.  The acceleration metric as specified with parameter `acc.metric` is used.
 2.  Acceleration metric values are averaged per minute and expressed in m*g* if the input is in *g*, and then log transformed as `log(acceleration + 1)`.
@@ -55,39 +55,36 @@ IV and IS were first proposed by [Witting W et al. 1990](https://doi.org/10.1016
 
 -   IS measures how constant is the routine of activity over several days and ranges from 0 to 1, values close to 1 indicate more constant routine.
 
--   IV measures the variability in activity hour by hour throughout the days. It ranges from 0 to +$\infty$, value close to 2 indicates more fragmented rhythm, and \>2 indicates ultradian rhythm (very uncommon).
+-   IV measures the variability in activity hour by hour throughout the days. It ranges from 0 to +$\infty$, value close to 2 indicates more fragmented rhythm, and \>2 indicates ultradian rhythm (cycles occurring more frequently than once a day, very uncommon).
 
 The GGIR implementation of IV and IS since GGIR release 3.1-6 has been described in [Danilevicz et al. 2024](https://doi.org/10.1186/s12874-024-02255-w). This implementation replaces the experimental implementation of IS and IV that was present in GGIR since release 1.5-1. In the experimental implementation we were not sure how to go from raw acceleration signal to an indicator of being active as this aspect was not documented in the original publications. Similarly, we were not sure how to deal with missing data. However, these issues were both resolved in release 3.1-6:
 
--   Being active is now defined as a mean acceleration metric value above the light physical activity threshold as specified with parameter `threshold.lig`.
+-   Being active is now defined as a mean acceleration metric value above the light physical activity threshold as specified with parameter `threshold.lig`. In the case that more than a `threshold.lig` is defined (e.g., `threshold.lig = c(40, 60)`), GGIR will use the first value provided in Part 2, and the specific threshold indicated by parameter `part6_threshold_combi` in Part 6.
 -   Missing values are left missing and not imputed, the algorithm now accounts for this.
 
 The new implementation as documented by [Danilevicz et al. 2024](https://doi.org/10.1186/s12874-024-02255-w) is not compatible with the older experimental implementation. Parameters `IVIS.activity.metric`, `IVIS_windowsize_minutes`, `IVIS_epochsize_seconds`, and `IVIS_acc_threshold` that were used before is no longer needed and have been deprecated.
-
-**Cosinor analysis compatible IV and IS**
-
-IS is sometimes used as a measure of behavioural robustness when conducting Cosinor analysis. However, to work with the combination of the two outcomes it seems important that IS is calculated from the same time series. Therefore, when `cosinor = TRUE,` IV and IS are calculated twice: Once as part of the default IV and IS analysis as discussed above, and once as part of the Cosinor analysis using the same log transformed time series.
-
-The Cosinor-compatible IV and IS estimates are stored as output variables `cosinorIV` and `cosinorIS`.
 
 ## phi
 
 Phi indicates how correlated the multi-day acceleration time series is with itself when there is an hour shift, also known as first-order auto-correlation from the first-order autoregressive model AR(1). A higher phi value indicates a higher autocorrelation, while a phi close to zero or even negative indicates more fragmented behavior. For a detailed discussion of phi see [Dickey and Fuller (1979)](https://doi.org/10.1080/01621459.1979.10482531) and [Danilevicz et al. 2024](https://doi.org/10.1186/s12874-024-02255-w). Phi is calculated by default in GGIR part 2 and in part 6 only when parameter `part6CR` is set to TRUE.
 
-## Detrended fluctionation analysis (DFA)
+## Activating the calculation of IS, IV, and phi
 
-### Self-similarity paramerter (SSP)
+It is important to note that the calculation of the metrics IS, IV, and phi is tied to the performance of the (Extended) Cosinor analyses. Therefore, to get these metrics both in part 2 and part 6, you need to activate the Cosinor analyses with `cosinor = TRUE` in part 2 and with `part6CR = TRUE` in part 6, as described [here](#extended-cosinor-analysis).
 
-The self-similarity paramter (SSP) is also known as scaling exponent or alpha. SSP is a real number between zero and two. Values in the range (0, 1) indicate stationary motion behaviour. Values int he range (1, 2 indicate nonstationary motion behaviour. For details see [Mesquita et al 2020](https://doi.org/10.1093/bioinformatics/btaa955) and [Danilevicz et al. 2024](https://doi.org/10.1186/s12874-024-02255-w).
+## Detrended fluctuation analysis (DFA)
+
+### Self-Similarity Parameter (SSP)
+
+The self-similarity parameter (SSP) is also known as scaling exponent or alpha. SSP is a real number between zero and two. Values in the range (0, 1) indicate stationary motion behaviour. Values in the range (1, 2) indicate non-stationary motion behaviour. For details see [Mesquita et al 2020](https://doi.org/10.1093/bioinformatics/btaa955) and [Danilevicz et al. 2024](https://doi.org/10.1186/s12874-024-02255-w).
 
 ### Activity Balance Index (ABI)
 
-The Activity Balance Index (ABI) was introduced by [Danilevicz et al. 2024](https://doi.org/10.1186/s12874-024-02255-w) and is a transformation of SSP. ABI measures how the activity over the observed period is balanced, higher values reflect a more balanced pattern of activity. ABI is a real number between zero and one and calculated from the acceleration metric time series directly without the need for cut-points.
+The Activity Balance Index (ABI) was introduced by [Danilevicz et al. 2024](https://doi.org/10.1186/s12874-024-02255-w) and is a transformation of SSP. ABI measures how the activity over the observed period is balanced, higher values reflect a more balanced pattern of activity. ABI is a real number between zero and one and calculated from the acceleration metric time series directly without the need for cut-points. A higher ABI reflects a more balanced pattern of activity.
 
 ### Sleep Regularity Index (SRI)
 
-A discussion of the Sleep Regularity Index can be found in
-<https://wadpac.github.io/GGIR/articles/SleepRegularityIndex.html>
+A discussion of the Sleep Regularity Index can be found in <https://wadpac.github.io/GGIR/articles/SleepRegularityIndex.html>
 
 ## Related output
 


### PR DESCRIPTION
<!-- Describe your PR here -->
Fixes #1494 => This PR updates the documentation and parameter handling for circadian analyses in chapter 13. 

- Removed `cosinorIS` and `cosinorIV` as they are no longer provided since **version 3.1.6**. 
- Revised configuration of parameters for running cosinor and IS/IV/phi analyses in part 2 and part 6.
- Revised usage of threshold.lig in the IS/IV/phi analyses when more than one `threshold.lig` is defined.
- Clarified that IS/IV/phi analyses are tied to the cosinor analyses.

<!-- Please, make sure the following items are checked -->
### Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [x] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [x] Documentation updated:
  - [ ] Function documentation
  - [x] Chapter vignettes for GitHub IO
  - [x] Vignettes for CRAN
- [x] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] If you think you made a significant contribution, add your name to the contributors lists in the `DESCRIPTION`, `zenodo.json`, and `inst/CITATION` files.
- [ ] GGIR parameters were added/removed. If yes, please also complete checklist below.

**If NEW GGIR parameter(s) were added then these NEW parameter(s) are:**
- [x] documented in `man/GGIR.Rd`
- [x] included with a default in `R/load_params.R`
- [x] included with value class check in `R/check_params.R`
- [x] included in table of `vignettes/GGIRParameters.Rmd` with references to the GGIR parts the parameter is used in.
- [x] mentioned in NEWS.Rd as NEW parameter

**If GGIR parameter(s) were deprecated these parameter(s) are:**
- [ ] documented as deprecated in `man/GGIR.Rd`
- [ ] removed from `R/load_params.R`
- [ ] removed from `R/check_params.R`
- [ ] removed from table in `vignettes/GGIRParameters.Rmd`
- [ ] mentioned as deprecated parameter in NEWS.Rd
- [ ] added to the list in `R/extract_params.R` with deprecated parameters such that these do not produce warnings when found in old config.csv files.