### PR TITLE
Issue1513 features expansion calibrate

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 - Updated documentation to point to the new web dashboard URL (#1509)
 
+- Part 1: Fixed an issue in g.calibrate() where large data chunks caused out-of-bounds errors (#1513)
+
 # CHANGES IN GGIR VERSION 3.3-7
 
 - Functionality added to save all key output to one parquet file per person. #1460

--- a/R/g.calibrate.R
+++ b/R/g.calibrate.R
@@ -176,8 +176,13 @@ g.calibrate = function(datafile, params_rawdata = c(),
           }
           #=============================================
           #expand 'out' if it is expected to be too short
-          if (count > (nrow(features) - (2.5 * (3600/calibEpochSize) * 24))) {
-            extension = matrix(99999, ((3600/calibEpochSize) * 24), ncol(features))
+          expected_EN2_length = use / (sf * calibEpochSize)
+          expected_endCount = count + expected_EN2_length - 1
+          if (expected_endCount > nrow(features)) {
+            # Calculate the number of rows to add (+ 1 day for safety)
+            rows_needed = expected_endCount - nrow(features)
+            rows_to_add = rows_needed + (3600/calibEpochSize) * 24 
+            extension = matrix(99999, rows_to_add, ncol(features))
             features = rbind(features, extension)
           }
           # mean acceleration for EN, x, y, and z


### PR DESCRIPTION
<!-- Describe your PR here -->
Fixes #1513 => This PR fixes an issue in `g.calibrate()` where assigning `EN2` to the features matrix occasionally triggers an out-of-bounds error (`features[count:endCount, 1] = EN2`). The original expansion logic relied on a check that failed if the incoming `EN2` chunk was larger than the remaining empty rows. The fix pre-calculates the exact `expected_EN2_length` based on the data chunk (`use`) and dynamically expands the features matrix by the exact deficit plus a 24-hour buffer, ensuring the assignment never fails.

<!-- Please, make sure the following items are checked -->
### Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [x] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [ ] Documentation updated:
  - [ ] Function documentation
  - [ ] Chapter vignettes for GitHub IO
  - [ ] Vignettes for CRAN
- [x] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] If you think you made a significant contribution, add your name to the contributors lists in the `DESCRIPTION`, `zenodo.json`, and `inst/CITATION` files.
- [ ] GGIR parameters were added/removed. If yes, please also complete checklist below.

**If NEW GGIR parameter(s) were added then these NEW parameter(s) are:**
- [ ] documented in `man/GGIR.Rd`
- [ ] included with a default in `R/load_params.R`
- [ ] included with value class check in `R/check_params.R`
- [ ] included in table of `vignettes/GGIRParameters.Rmd` with references to the GGIR parts the parameter is used in.
- [ ] mentioned in NEWS.Rd as NEW parameter

**If GGIR parameter(s) were deprecated these parameter(s) are:**
- [ ] documented as deprecated in `man/GGIR.Rd`
- [ ] removed from `R/load_params.R`
- [ ] removed from `R/check_params.R`
- [ ] removed from table in `vignettes/GGIRParameters.Rmd`
- [ ] mentioned as deprecated parameter in NEWS.Rd
- [ ] added to the list in `R/extract_params.R` with deprecated parameters such that these do not produce warnings when found in old config.csv files.