### PR TITLE
Fix g.impute() NA/NaN error with study_dates_file and check_log() IDate handling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 - Part 1: Fixed an issue in g.calibrate() where large data chunks caused out-of-bounds errors (#1513)
 
+- Part 2: Fixed regression in g.impute() where using a study_dates_file raised "NA/NaN argument" for participants whose listed start or end date is not a midnight present in the recording (e.g. an evening start, or a device that stopped recording before the listed end date). #1508
+
+- Fixed check_log() to coerce study dates log columns to character, so that dates auto-parsed as IDate by data.table::fread() are handled correctly. #1521
+
 # CHANGES IN GGIR VERSION 3.3-7
 
 - Functionality added to save all key output to one parquet file per person. #1460

--- a/R/check_log.R
+++ b/R/check_log.R
@@ -1,6 +1,10 @@
 check_log = function(log, dateformat, colid = 1, datecols = c(), 
                      logPath, logtype) {
-  
+
+  # data.table::fread() may auto-parse date columns as IDate, which breaks the
+  # text-based date checks below; force all columns to character first
+  log[] = lapply(log, as.character)
+
   # at the moment this is used only for activity log and study dates log
   dateformat_param = ifelse(logtype == "activity log", "qwindow_dateformat", "study_dates_dateformat")
   

--- a/R/g.impute.R
+++ b/R/g.impute.R
@@ -150,19 +150,19 @@ g.impute = function(M, I, params_cleaning = c(), desiredtz = "",
         lastmidnighti = NULL
       }
       # trim start
-      if (length(firstmidnighti) > 0) {
+      if (length(firstmidnighti) > 0 && !is.na(firstmidnighti)) {
         r4[1:(firstmidnighti - 1)] = 1
         study_dates_log_used[1] = TRUE
       } else {
-        # if midnight timestamp for the date is not available, 
+        # if midnight timestamp for the date is not available,
         # do not trim the data and recover the firstmidnight value
-        list2env(dmidn[c("lastmidnighti", "lastmidnight")], envir = environment())
+        list2env(dmidn[c("firstmidnighti", "firstmidnight")], envir = environment())
         # warning(paste0("The start date provided in the study dates file for ID = ", 
         #                ID, "is not within the dates available in the recording. ",
         #                "The data was not trimmed at the beginning of the recording."), call. = FALSE)
       }
       # trim end
-      if (length(lastmidnighti) > 0) {
+      if (length(lastmidnighti) > 0 && !is.na(lastmidnighti)) {
         r4[lastmidnighti:nrow(r4)] = 1
         study_dates_log_used[2] = TRUE
       } else {

--- a/tests/testthat/test_StudyDatesFile.R
+++ b/tests/testthat/test_StudyDatesFile.R
@@ -179,36 +179,32 @@ test_that("chainof5parts", {
   expect_true(t0 == as.POSIXct("2016-06-25 05:00:00", tz = "Europe/London"))
   expect_true(t1 == as.POSIXct("2016-06-25 18:45:00", tz = "Europe/London"))
   
-  # start date out of recorded dates (warning and do not trim) -----
-  # studydates = data.frame(ID = "123A",
-  #                         start = "18/06/2016",
-  #                         end = "25/06/2016")
-  # write.csv(studydates, "study_dates_file.csv", row.names = FALSE)
-  # expect_warning(
-  #   GGIR(datadir = fn, outputdir = getwd(), studyname = "test", mode = 2, verbose = FALSE,
-  #        # study dates file
-  #        study_dates_file = "study_dates_file.csv", 
-  #        study_dates_dateformat = "%d/%m/%Y",
-  #        # strategy
-  #        data_masking_strategy = 1, ndayswindow = 7,
-  #        hrs.del.start = 0,hrs.del.end = 0),
-  #   regexp = "The start date")
-  
-  # end date out of recorded dates (warning and do not trim) -----
-  # studydates = data.frame(ID = "123A",
-  #                         start = "24/06/2016",
-  #                         end = "26/06/2016")
-  # write.csv(studydates, "study_dates_file.csv", row.names = FALSE)
-  # expect_warning(
-  #   GGIR(datadir = fn, outputdir = getwd(), studyname = "test", mode = 2, verbose = FALSE,
-  #        # study dates file
-  #        study_dates_file = "study_dates_file.csv", 
-  #        study_dates_dateformat = "%d/%m/%Y",
-  #        # strategy
-  #        data_masking_strategy = 1, ndayswindow = 7,
-  #        hrs.del.start = 0,hrs.del.end = 0),
-  #   regexp = "The end date")
-  
+  # start and/or end date outside the recorded dates: do not trim, do not error -----
+  # Regression test for issue #1508: a study date that is not a midnight present
+  # in the recording previously raised "NA/NaN argument" in g.impute().
+  studydates = data.frame(ID = "123A",
+                          start = "18/06/2016", # before the recording starts
+                          end = "30/06/2016")   # after the recording ends
+  write.csv(studydates, "study_dates_file.csv", row.names = FALSE)
+  expect_error(
+    GGIR(datadir = fn, outputdir = getwd(), studyname = "test", mode = 2, verbose = FALSE,
+         # study dates file
+         study_dates_file = "study_dates_file.csv",
+         study_dates_dateformat = "%d/%m/%Y",
+         # strategy
+         data_masking_strategy = 1, hrs.del.start = 0, hrs.del.end = 0),
+    regexp = NA)
+  # load data
+  load(dir("output_test/meta/basic/", full.names = TRUE)[1])
+  load(dir("output_test/meta/ms2.out/", full.names = TRUE)[1])
+  # both dates fall outside the recording, so nothing is trimmed
+  first_epoch_in_protocol = which(IMP$rout$r4 == 0)[1]
+  t0 = iso8601chartime2POSIX(M$metalong$timestamp[first_epoch_in_protocol], tz = "Europe/London")
+  last_epoch_in_protocol = max(which(IMP$rout$r4 == 0))
+  t1 = iso8601chartime2POSIX(M$metalong$timestamp[last_epoch_in_protocol], tz = "Europe/London")
+  expect_true(t0 == as.POSIXct("2016-06-23 09:00:00", tz = "Europe/London"))
+  expect_true(t1 == as.POSIXct("2016-06-26 08:45:00", tz = "Europe/London"))
+
   # ID not in study dates file (warning and do not trim) -----
   studydates = data.frame(ID = "dummyID",
                           start = "24/06/2016",

--- a/tests/testthat/test_check_log.R
+++ b/tests/testthat/test_check_log.R
@@ -1,0 +1,20 @@
+library(GGIR)
+context("check_log")
+
+test_that("check_log coerces fread IDate date columns to character", {
+  # data.table::fread() auto-parses ISO-format dates as IDate when reading a
+  # study dates file, which previously broke the text-based date checks.
+  log = data.frame(ID = "123A",
+                   start = data.table::as.IDate("2016-06-24"),
+                   end = data.table::as.IDate("2016-06-25"),
+                   stringsAsFactors = FALSE)
+  expect_s3_class(log$start, "IDate")
+
+  out = check_log(log, dateformat = "%Y-%m-%d", colid = 1, datecols = 2:3,
+                  logPath = "study_dates_file.csv", logtype = "study dates log")
+
+  expect_type(out$start, "character")
+  expect_type(out$end, "character")
+  expect_equal(out$start, "2016-06-24")
+  expect_equal(out$end, "2016-06-25")
+})


### PR DESCRIPTION
Fixes #1508 and #1521.

### g.impute()

Guards both study-date trim branches with `&& \!is.na(...)`, so a listed start or end date that is not a midnight present in the recording falls into the existing recovery branch instead of producing `r4[1:(NA - 1)] = 1` / `r4[NA:nrow(r4)] = 1` → `NA/NaN argument`.

This happens because `firstmidnighti = midnightsi[grep(firstmidnight, midnights)][1]` (and the matching `lastmidnighti` line) returns `NA_integer_` (length 1) when `grep()` finds no match, so the existing `length(...) > 0` check passes and execution reaches the subscript with `NA`. Two situations trigger it in practice:

- the recording starts in the evening of the listed start date, so the first midnight in the data is the next day (#1508);
- the device stopped recording before the listed end date, so that end date has no midnight in the data (discharged-device case, #1508 follow-up).

This PR also fixes a latent copy-paste in the first-midnight recovery `else` branch, which restored `lastmidnighti`/`lastmidnight` instead of `firstmidnighti`/`firstmidnight`.

### check_log()

Adds `log[] = lapply(log, as.character)` at the top of `check_log()`, so study dates that `data.table::fread()` auto-parses as `IDate` are handled by the text-based date checks. The activity-log path is unaffected (it is already read with `colClasses = "character"`). Per @jhmigueles' suggestion in #1508.

### Verification

- Reproduced on the original pediatric Axivity recordings from #1508 (both evening-start and discharged-device files); all process cleanly through Part 2 with the patch.
- Negative control: the same scenario on unpatched master errors with `NA/NaN argument`; patched runs clean.
- Added a regression test in `test_StudyDatesFile.R` (start/end date outside the recorded dates) and a new `test_check_log.R` for the IDate coercion. Both pass.
