### PR TITLE
Part 2: fix activity log (qwindow) segments assigned one day early (#1518)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - Part 1: Fixed an issue in g.calibrate() where large data chunks caused out-of-bounds errors (#1513)
 
+- Part 2: Fixed bug where activity log (qwindow) segments could be assigned to the day before, because g.analyse.perday() derived the recording-day dates with as.Date() defaulting to UTC instead of desiredtz (#1518)
+
 # CHANGES IN GGIR VERSION 3.3-7
 
 - Functionality added to save all key output to one parquet file per person. #1460

--- a/R/g.analyse.perday.R
+++ b/R/g.analyse.perday.R
@@ -59,7 +59,8 @@ g.analyse.perday = function(ndays, firstmidnighti, time, nfeatures,
   }
   unique_dates_recording = unique(as.Date(iso8601chartime2POSIX(time[c(seq(1, length(time),
                                                                            by = (3600/ws2) * 12),
-                                                                       length(time))], tz = params_general[["desiredtz"]])))
+                                                                       length(time))], tz = params_general[["desiredtz"]]),
+                                          tz = params_general[["desiredtz"]]))
   ExtFunColsi = ExtFunColsi - 1 # subtract 1 because code ignores timestamp
   ExtFunColsi_backup = ExtFunColsi
   for (di in 1:ndays) { #run through days


### PR DESCRIPTION
Closes #1518.

When part 2 is guided by an activity log (`qwindow = <file>`), `g.analyse.perday()`
derives two dates for each recording day in inconsistent timezones:

- the date used to match the activity log was computed with `as.Date(...)`, which
  defaults to `tz = "UTC"` (the inner `iso8601chartime2POSIX()` got `desiredtz`, but
  the outer `as.Date()` did not);
- `calendar_date` is taken from the local timestamp string (line ~232).

For recordings that start in the local evening at a negative UTC offset, the UTC date
rolls past midnight, so the first local date never appears in `unique_dates_recording`
and the qwindow match is shifted one day earlier for the whole recording.

This passes `desiredtz` to the outer `as.Date()` so the recording-day dates use the
same timezone as `calendar_date`.

Confirmed end-to-end on real Axivity AX3 data (devices started recording at 20:15
local EDT): with the unpatched code the activity-log segments were assigned to the
previous day, and with this change every day's `qwindow_names` matched the activity-log
row of the same date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
