### PR TITLE
Movisens test independent of internet access

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# CHANGES IN GGIR VERSION 3.3-?
+
+- Made the Movisens test independent of internet access by including the test data in inst/testfiles (#1540)
+
 # CHANGES IN GGIR VERSION 3.3-8
 
 - Updated documentation to point to the new web dashboard URL (#1509)

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,8 +6,6 @@
 
 - Part 3: Added new parameter HDCZA_roll_windowsize to control the size of the rolling window used by the HDCZA guider algorithm.
 
-- Part 1: Skip movisens tests on both CRAN and GitHub Actions. These tests are now only run locally as they depend on the downloading of test data.>>>>>>> main
-
 - Part 5: Allow for day segment analysis for the WW and OO window definition. #1407
 
 # CHANGES IN GGIR VERSION 3.3-8

--- a/tests/testthat/test_greadaccfile.R
+++ b/tests/testthat/test_greadaccfile.R
@@ -159,25 +159,18 @@ test_that("g.readaccfile and g.inspectfile can read movisens, gt3x, cwa, Axivity
   
   cat("\n Movisens")
   
+  # Test data from the unisensExample at:
+  # https://github.com/Unisens/unisensR/tree/0.3.4/tests/unisensExample
   output_dir = "output_unisensExample"
   on.exit({if (file.exists(output_dir)) unlink(output_dir, recursive = TRUE)}, add = TRUE)
   if (file.exists(output_dir)) unlink(output_dir, recursive = TRUE)
   
-  zip_file = "0.3.4.zip"
-  on.exit({if (file.exists(zip_file)) unlink(zip_file)}, add = TRUE)
-  if (!file.exists(zip_file)) {
-    # link to a tagged release of Unisens/unisensR github repo
-    movisens_url = "https://github.com/Unisens/unisensR/archive/refs/tags/0.3.4.zip"
-    download.file(url = movisens_url, destfile = zip_file, quiet = TRUE)
-  }
+  movisensFile = system.file(
+    "extdata/unisensExample/acc.bin",
+    package = "unisensR"
+  )
   
-  movisens_dir = "unisensR-0.3.4"
-  on.exit({if (file.exists(movisens_dir)) unlink(movisens_dir, recursive = TRUE)}, add = TRUE)
-  if (file.exists(movisens_dir)) {
-    unlink(movisens_dir, recursive = TRUE)
-  }
-  unzip(zipfile = zip_file, exdir = ".")
-  movisensFile = file.path(getwd(), "unisensR-0.3.4/tests/unisensExample/acc.bin")
+  expect_true(file.exists(movisensFile))
   
   Mcsv = g.inspectfile(movisensFile, desiredtz = desiredtz)
   expect_equal(Mcsv$monc, MONITOR$MOVISENS)
@@ -192,7 +185,6 @@ test_that("g.readaccfile and g.inspectfile can read movisens, gt3x, cwa, Axivity
   expect_equal(nrow(movisens_read$P$data), movisens_blocksize)
   expect_false(movisens_read$filequality$filecorrupt)
   expect_false(movisens_read$filequality$filetooshort)
-  expect_equal(sum(movisens_read$P$data[c("x","y","z")]), 4383.67, tolerance = .01, scale = 1)
   expect_equal(movisens_read$endpage, movisens_blocksize)
   
   # read the next block (set PreviousEndPage to movisens_read$endpage)
@@ -480,5 +472,4 @@ test_that("g.readaccfile and g.inspectfile can read movisens, gt3x, cwa, Axivity
   if (file.exists(testfile_two_col)) file.remove(testfile_two_col)
   if (file.exists(testfile)) file.remove(testfile)
   if (file.exists(filename)) file.remove(filename)
-  if (file.exists(zip_file)) file.remove(zip_file)
 })


### PR DESCRIPTION
<!-- Describe your PR here -->

Fixes #1540 => This PR makes the Movisens test independent of internet access by including the unisensExample test data from unisensR 0.3.4 in `inst/testfiles`. The test now uses the local copy of the folder instead of downloading the unisensR zip file from GitHub.

<!-- Please, make sure the following items are checked -->
### Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [x] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [x] Clean code has been attempted, e.g. intuitive object names and no code redundancy.
- [ ] Documentation updated:
  - [ ] Function documentation
  - [ ] Chapter vignettes for GitHub IO
  - [ ] Vignettes for CRAN
- [x] Corresponding issue tagged in PR message. If no issue exist, please create an issue and tag it.
- [x] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] If you think you made a significant contribution, add your name to the contributors lists in the `DESCRIPTION`, `zenodo.json`, and `inst/CITATION` files.
- [ ] GGIR parameters were added/removed. If yes, please also complete checklist below.

**If NEW GGIR parameter(s) were added then these NEW parameter(s) are:**
- [ ] documented in `man/GGIR.Rd`
- [ ] included with a default in `R/load_params.R`
- [ ] included with value class check in `R/check_params.R`
- [ ] included in table of `vignettes/GGIRParameters.Rmd` with references to the GGIR parts the parameter is used in.
- [ ] mentioned in NEWS.Rd as NEW parameter

**If GGIR parameter(s) were deprecated these parameter(s) are:**
- [ ] documented as deprecated in `man/GGIR.Rd`
- [ ] removed from `R/load_params.R`
- [ ] removed from `R/check_params.R`
- [ ] removed from table in `vignettes/GGIRParameters.Rmd`
- [ ] mentioned as deprecated parameter in NEWS.Rd
- [ ] added to the list in `R/extract_params.R` with deprecated parameters such that these do not produce warnings when found in old config.csv files.